### PR TITLE
Fix panic deep detecting with module

### DIFF
--- a/detector/detector.go
+++ b/detector/detector.go
@@ -92,12 +92,14 @@ func (d *Detector) Detect() []*issue.Issue {
 			}
 			d.Logger.Info(fmt.Sprintf("detect module `%s`", name))
 			moduleDetector := &Detector{
-				ListMap: m.ListMap,
-				Config:  d.Config,
+				ListMap:   m.ListMap,
+				Config:    d.Config,
+				AwsClient: d.AwsClient,
 				EvalConfig: &evaluator.Evaluator{
 					Config: m.Config,
 				},
 				Logger: d.Logger,
+				Error:  false,
 			}
 			method := reflect.ValueOf(moduleDetector).MethodByName(detectorMethod)
 			method.Call([]reflect.Value{reflect.ValueOf(&issues)})


### PR DESCRIPTION
The following panic occurred in deep detecting with module.

```
$ tflint --deep -c .tflint.hcl.config --debug
DEBUG:/loader.go:84 [INFO] load `.tflint.hcl.config`
DEBUG:/loader.go:84 [INFO] load `module.tf`
DEBUG:/loader.go:38 [INFO] load module `./tf_aws_ec2_instance`
DEBUG:/loader.go:84 [INFO] load `.terraform/modules/960d94c2f60d34845dc3051edfad76e1/main.tf`
DEBUG:/loader.go:84 [INFO] load `.terraform/modules/960d94c2f60d34845dc3051edfad76e1/outputs.tf`
DEBUG:/loader.go:84 [INFO] load `.terraform/modules/960d94c2f60d34845dc3051edfad76e1/variables.tf`
DEBUG:/aws.go:30 [INFO] set AWS region
DEBUG:/detector.go:84 [INFO] detect by `aws_instance_default_standard_volume`
DEBUG:/detector.go:93 [INFO] detect module `960d94c2f60d34845dc3051edfad76e1`
DEBUG:/detector.go:84 [INFO] detect by `aws_db_instance_default_parameter_group`
DEBUG:/detector.go:93 [INFO] detect module `960d94c2f60d34845dc3051edfad76e1`
DEBUG:/detector.go:84 [INFO] detect by `aws_elasticache_cluster_default_parameter_group`
DEBUG:/detector.go:93 [INFO] detect module `960d94c2f60d34845dc3051edfad76e1`
DEBUG:/detector.go:84 [INFO] detect by `aws_instance_invalid_iam_profile`
DEBUG:/detector.go:93 [INFO] detect module `960d94c2f60d34845dc3051edfad76e1`
Panic: runtime error: invalid memory address or nil pointer dereference
 -> 0: main.main.func1: /main.go(17)
 -> 1: runtime.call32: /asm_amd64.s(479)
 -> 2: runtime.gopanic: /panic.go(458)
 -> 3: runtime.panicmem: /panic.go(62)
 -> 4: runtime.sigpanic: /sigpanic_unix.go(24)
 -> 5: github.com/wata727/tflint/detector.(*Detector).DetectAwsInstanceInvalidIamProfile: /aws_instance_invalid_iam_profile.go(17)
 -> 6: runtime.call32: /asm_amd64.s(479)
 -> 7: reflect.Value.call: /value.go(434)
 -> 8: reflect.Value.Call: /value.go(302)
 -> 9: github.com/wata727/tflint/detector.(*Detector).Detect: /detector.go(103)
 -> 10: main.(*CLI).Run: /cli.go(143)
 -> 11: main.main: /main.go(30)
 -> 12: runtime.main: /proc.go(183)
 -> 13: runtime.goexit: /asm_amd64.s(2086)

TFLint crached... :(
Please attach an output log, describe the situation and version that occurred and post an issue to https://github.com/wata727/tflint/issues
```

In order to fix this problem I added an AWS client to module detectors. Perhaps, this is not an essential solution. However, since this architecture is inefficient, it will be improved later. (For example, we need to call the AWS API for each modules.)