### PR TITLE
Improve ineffecient module detector method

### DIFF
--- a/detector/aws_db_instance_default_parameter_group.go
+++ b/detector/aws_db_instance_default_parameter_group.go
@@ -7,7 +7,15 @@ import (
 	"github.com/wata727/tflint/issue"
 )
 
-func (d *Detector) DetectAwsDbInstanceDefaultParameterGroup(issues *[]*issue.Issue) {
+type AwsDBInstanceDefaultParameterGroupDetector struct {
+	*Detector
+}
+
+func (d *Detector) CreateAwsDBInstanceDefaultParameterGroupDetector() *AwsDBInstanceDefaultParameterGroupDetector {
+	return &AwsDBInstanceDefaultParameterGroupDetector{d}
+}
+
+func (d *AwsDBInstanceDefaultParameterGroupDetector) Detect(issues *[]*issue.Issue) {
 	for filename, list := range d.ListMap {
 		for _, item := range list.Filter("resource", "aws_db_instance").Items {
 			parameterGroupToken, err := hclLiteralToken(item, "parameter_group_name")
@@ -21,7 +29,7 @@ func (d *Detector) DetectAwsDbInstanceDefaultParameterGroup(issues *[]*issue.Iss
 				continue
 			}
 
-			if isDefaultDbParameterGroup(parameterGroup) {
+			if d.isDefaultDbParameterGroup(parameterGroup) {
 				issue := &issue.Issue{
 					Type:    "NOTICE",
 					Message: fmt.Sprintf("\"%s\" is default parameter group. You cannot edit it.", parameterGroup),
@@ -34,6 +42,6 @@ func (d *Detector) DetectAwsDbInstanceDefaultParameterGroup(issues *[]*issue.Iss
 	}
 }
 
-func isDefaultDbParameterGroup(s string) bool {
+func (d *AwsDBInstanceDefaultParameterGroupDetector) isDefaultDbParameterGroup(s string) bool {
 	return regexp.MustCompile("^default").Match([]byte(s))
 }

--- a/detector/aws_db_instance_default_parameter_group_test.go
+++ b/detector/aws_db_instance_default_parameter_group_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/wata727/tflint/issue"
 )
 
-func TestDetectAwsDbInstanceDefaultParameterGroup(t *testing.T) {
+func TestDetectAwsDBInstanceDefaultParameterGroup(t *testing.T) {
 	cases := []struct {
 		Name   string
 		Src    string
@@ -49,13 +49,15 @@ resource "aws_db_instance" "db" {
 		listMap["test.tf"] = list
 
 		evalConfig, _ := evaluator.NewEvaluator(listMap, config.Init())
-		d := &Detector{
-			ListMap:    listMap,
-			EvalConfig: evalConfig,
+		d := &AwsDBInstanceDefaultParameterGroupDetector{
+			&Detector{
+				ListMap:    listMap,
+				EvalConfig: evalConfig,
+			},
 		}
 
 		var issues = []*issue.Issue{}
-		d.DetectAwsDbInstanceDefaultParameterGroup(&issues)
+		d.Detect(&issues)
 
 		if !reflect.DeepEqual(issues, tc.Issues) {
 			t.Fatalf("Bad: %s\nExpected: %s\n\ntestcase: %s", issues, tc.Issues, tc.Name)

--- a/detector/aws_db_instance_default_parameter_group_test.go
+++ b/detector/aws_db_instance_default_parameter_group_test.go
@@ -4,10 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/hcl/hcl/ast"
-	"github.com/hashicorp/hcl/hcl/parser"
 	"github.com/wata727/tflint/config"
-	"github.com/wata727/tflint/evaluator"
 	"github.com/wata727/tflint/issue"
 )
 
@@ -43,21 +40,14 @@ resource "aws_db_instance" "db" {
 	}
 
 	for _, tc := range cases {
-		listMap := make(map[string]*ast.ObjectList)
-		root, _ := parser.Parse([]byte(tc.Src))
-		list, _ := root.Node.(*ast.ObjectList)
-		listMap["test.tf"] = list
-
-		evalConfig, _ := evaluator.NewEvaluator(listMap, config.Init())
-		d := &AwsDBInstanceDefaultParameterGroupDetector{
-			&Detector{
-				ListMap:    listMap,
-				EvalConfig: evalConfig,
-			},
-		}
-
 		var issues = []*issue.Issue{}
-		d.Detect(&issues)
+		TestDetectByCreatorName(
+			"CreateAwsDBInstanceDefaultParameterGroupDetector",
+			tc.Src,
+			config.Init(),
+			config.Init().NewAwsClient(),
+			&issues,
+		)
 
 		if !reflect.DeepEqual(issues, tc.Issues) {
 			t.Fatalf("Bad: %s\nExpected: %s\n\ntestcase: %s", issues, tc.Issues, tc.Name)

--- a/detector/aws_elasticache_cluster_default_parameter_group.go
+++ b/detector/aws_elasticache_cluster_default_parameter_group.go
@@ -7,7 +7,15 @@ import (
 	"github.com/wata727/tflint/issue"
 )
 
-func (d *Detector) DetectAwsElasticacheClusterDefaultParameterGroup(issues *[]*issue.Issue) {
+type AwsElastiCacheClusterDefaultParameterGroupDetector struct {
+	*Detector
+}
+
+func (d *Detector) CreateAwsElastiCacheClusterDefaultParameterGroupDetector() *AwsElastiCacheClusterDefaultParameterGroupDetector {
+	return &AwsElastiCacheClusterDefaultParameterGroupDetector{d}
+}
+
+func (d *AwsElastiCacheClusterDefaultParameterGroupDetector) Detect(issues *[]*issue.Issue) {
 	for filename, list := range d.ListMap {
 		for _, item := range list.Filter("resource", "aws_elasticache_cluster").Items {
 			parameterGroupToken, err := hclLiteralToken(item, "parameter_group_name")
@@ -21,7 +29,7 @@ func (d *Detector) DetectAwsElasticacheClusterDefaultParameterGroup(issues *[]*i
 				continue
 			}
 
-			if isDefaultCacheParameterGroup(parameterGroup) {
+			if d.isDefaultCacheParameterGroup(parameterGroup) {
 				issue := &issue.Issue{
 					Type:    "NOTICE",
 					Message: fmt.Sprintf("\"%s\" is default parameter group. You cannot edit it.", parameterGroup),
@@ -34,6 +42,6 @@ func (d *Detector) DetectAwsElasticacheClusterDefaultParameterGroup(issues *[]*i
 	}
 }
 
-func isDefaultCacheParameterGroup(s string) bool {
+func (d *AwsElastiCacheClusterDefaultParameterGroupDetector) isDefaultCacheParameterGroup(s string) bool {
 	return regexp.MustCompile("^default").Match([]byte(s))
 }

--- a/detector/aws_elasticache_cluster_default_parameter_group_test.go
+++ b/detector/aws_elasticache_cluster_default_parameter_group_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/wata727/tflint/issue"
 )
 
-func TestDetectAwsElasticacheClusterDefaultParameterGroup(t *testing.T) {
+func TestDetectAwsElastiCacheClusterDefaultParameterGroup(t *testing.T) {
 	cases := []struct {
 		Name   string
 		Src    string
@@ -49,13 +49,15 @@ resource "aws_elasticache_cluster" "cache" {
 		listMap["test.tf"] = list
 
 		evalConfig, _ := evaluator.NewEvaluator(listMap, config.Init())
-		d := &Detector{
-			ListMap:    listMap,
-			EvalConfig: evalConfig,
+		d := &AwsElastiCacheClusterDefaultParameterGroupDetector{
+			&Detector{
+				ListMap:    listMap,
+				EvalConfig: evalConfig,
+			},
 		}
 
 		var issues = []*issue.Issue{}
-		d.DetectAwsElasticacheClusterDefaultParameterGroup(&issues)
+		d.Detect(&issues)
 
 		if !reflect.DeepEqual(issues, tc.Issues) {
 			t.Fatalf("Bad: %s\nExpected: %s\n\ntestcase: %s", issues, tc.Issues, tc.Name)

--- a/detector/aws_elasticache_cluster_default_parameter_group_test.go
+++ b/detector/aws_elasticache_cluster_default_parameter_group_test.go
@@ -4,10 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/hcl/hcl/ast"
-	"github.com/hashicorp/hcl/hcl/parser"
 	"github.com/wata727/tflint/config"
-	"github.com/wata727/tflint/evaluator"
 	"github.com/wata727/tflint/issue"
 )
 
@@ -43,21 +40,14 @@ resource "aws_elasticache_cluster" "cache" {
 	}
 
 	for _, tc := range cases {
-		listMap := make(map[string]*ast.ObjectList)
-		root, _ := parser.Parse([]byte(tc.Src))
-		list, _ := root.Node.(*ast.ObjectList)
-		listMap["test.tf"] = list
-
-		evalConfig, _ := evaluator.NewEvaluator(listMap, config.Init())
-		d := &AwsElastiCacheClusterDefaultParameterGroupDetector{
-			&Detector{
-				ListMap:    listMap,
-				EvalConfig: evalConfig,
-			},
-		}
-
 		var issues = []*issue.Issue{}
-		d.Detect(&issues)
+		TestDetectByCreatorName(
+			"CreateAwsElastiCacheClusterDefaultParameterGroupDetector",
+			tc.Src,
+			config.Init(),
+			config.Init().NewAwsClient(),
+			&issues,
+		)
 
 		if !reflect.DeepEqual(issues, tc.Issues) {
 			t.Fatalf("Bad: %s\nExpected: %s\n\ntestcase: %s", issues, tc.Issues, tc.Name)

--- a/detector/aws_instance_default_standard_volume.go
+++ b/detector/aws_instance_default_standard_volume.go
@@ -5,7 +5,15 @@ import (
 	"github.com/wata727/tflint/issue"
 )
 
-func (d *Detector) DetectAwsInstanceDefaultStandardVolume(issues *[]*issue.Issue) {
+type AwsInstanceDefaultStandardVolumeDetector struct {
+	*Detector
+}
+
+func (d *Detector) CreateAwsInstanceDefaultStandardVolumeDetector() *AwsInstanceDefaultStandardVolumeDetector {
+	return &AwsInstanceDefaultStandardVolumeDetector{d}
+}
+
+func (d *AwsInstanceDefaultStandardVolumeDetector) Detect(issues *[]*issue.Issue) {
 	for filename, list := range d.ListMap {
 		for _, item := range list.Filter("resource", "aws_instance").Items {
 			d.detectForBlockDevices(issues, item, filename, "root_block_device")
@@ -14,7 +22,7 @@ func (d *Detector) DetectAwsInstanceDefaultStandardVolume(issues *[]*issue.Issue
 	}
 }
 
-func (d *Detector) detectForBlockDevices(issues *[]*issue.Issue, item *ast.ObjectItem, filename string, device string) {
+func (d *AwsInstanceDefaultStandardVolumeDetector) detectForBlockDevices(issues *[]*issue.Issue, item *ast.ObjectItem, filename string, device string) {
 	if !IsKeyNotFound(item, device) {
 		deviceItems, err := hclObjectItems(item, device)
 		if err != nil {

--- a/detector/aws_instance_default_standard_volume_test.go
+++ b/detector/aws_instance_default_standard_volume_test.go
@@ -116,13 +116,15 @@ resource "aws_instance" "web" {
 		listMap["test.tf"] = list
 
 		evalConfig, _ := evaluator.NewEvaluator(listMap, config.Init())
-		d := &Detector{
-			ListMap:    listMap,
-			EvalConfig: evalConfig,
+		d := &AwsInstanceDefaultStandardVolumeDetector{
+			&Detector{
+				ListMap:    listMap,
+				EvalConfig: evalConfig,
+			},
 		}
 
 		var issues = []*issue.Issue{}
-		d.DetectAwsInstanceDefaultStandardVolume(&issues)
+		d.Detect(&issues)
 
 		if !reflect.DeepEqual(issues, tc.Issues) {
 			t.Fatalf("Bad: %s\nExpected: %s\n\ntestcase: %s", issues, tc.Issues, tc.Name)

--- a/detector/aws_instance_default_standard_volume_test.go
+++ b/detector/aws_instance_default_standard_volume_test.go
@@ -4,10 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/hcl/hcl/ast"
-	"github.com/hashicorp/hcl/hcl/parser"
 	"github.com/wata727/tflint/config"
-	"github.com/wata727/tflint/evaluator"
 	"github.com/wata727/tflint/issue"
 )
 
@@ -110,21 +107,14 @@ resource "aws_instance" "web" {
 	}
 
 	for _, tc := range cases {
-		listMap := make(map[string]*ast.ObjectList)
-		root, _ := parser.Parse([]byte(tc.Src))
-		list, _ := root.Node.(*ast.ObjectList)
-		listMap["test.tf"] = list
-
-		evalConfig, _ := evaluator.NewEvaluator(listMap, config.Init())
-		d := &AwsInstanceDefaultStandardVolumeDetector{
-			&Detector{
-				ListMap:    listMap,
-				EvalConfig: evalConfig,
-			},
-		}
-
 		var issues = []*issue.Issue{}
-		d.Detect(&issues)
+		TestDetectByCreatorName(
+			"CreateAwsInstanceDefaultStandardVolumeDetector",
+			tc.Src,
+			config.Init(),
+			config.Init().NewAwsClient(),
+			&issues,
+		)
 
 		if !reflect.DeepEqual(issues, tc.Issues) {
 			t.Fatalf("Bad: %s\nExpected: %s\n\ntestcase: %s", issues, tc.Issues, tc.Name)

--- a/detector/aws_instance_invalid_ami.go
+++ b/detector/aws_instance_invalid_ami.go
@@ -7,7 +7,15 @@ import (
 	"github.com/wata727/tflint/issue"
 )
 
-func (d *Detector) DetectAwsInstanceInvalidAmi(issues *[]*issue.Issue) {
+type AwsInstanceInvalidAMIDetector struct {
+	*Detector
+}
+
+func (d *Detector) CreateAwsInstanceInvalidAMIDetector() *AwsInstanceInvalidAMIDetector {
+	return &AwsInstanceInvalidAMIDetector{d}
+}
+
+func (d *AwsInstanceInvalidAMIDetector) Detect(issues *[]*issue.Issue) {
 	if !d.Config.DeepCheck {
 		d.Logger.Info("skip this rule.")
 		return

--- a/detector/aws_instance_invalid_ami.go
+++ b/detector/aws_instance_invalid_ami.go
@@ -22,12 +22,15 @@ func (d *AwsInstanceInvalidAMIDetector) Detect(issues *[]*issue.Issue) {
 	}
 
 	validAmi := map[string]bool{}
-	resp, err := d.AwsClient.Ec2.DescribeImages(&ec2.DescribeImagesInput{})
-	if err != nil {
-		d.Logger.Error(err)
-		d.Error = true
+	if d.ResponseCache.DescribeImagesOutput == nil {
+		resp, err := d.AwsClient.Ec2.DescribeImages(&ec2.DescribeImagesInput{})
+		if err != nil {
+			d.Logger.Error(err)
+			d.Error = true
+		}
+		d.ResponseCache.DescribeImagesOutput = resp
 	}
-	for _, image := range resp.Images {
+	for _, image := range d.ResponseCache.DescribeImagesOutput.Images {
 		validAmi[*image.ImageId] = true
 	}
 

--- a/detector/aws_instance_invalid_ami_test.go
+++ b/detector/aws_instance_invalid_ami_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/wata727/tflint/issue"
 )
 
-func TestDetectAwsInstanceInvalidAmi(t *testing.T) {
+func TestDetectAwsInstanceInvalidAMI(t *testing.T) {
 	cases := []struct {
 		Name     string
 		Src      string
@@ -72,11 +72,13 @@ resource "aws_instance" "web" {
 		c := config.Init()
 		c.DeepCheck = true
 		evalConfig, _ := evaluator.NewEvaluator(listMap, config.Init())
-		d := &Detector{
-			ListMap:    listMap,
-			EvalConfig: evalConfig,
-			Config:     c,
-			AwsClient:  c.NewAwsClient(),
+		d := &AwsInstanceInvalidAMIDetector{
+			&Detector{
+				ListMap:    listMap,
+				EvalConfig: evalConfig,
+				Config:     c,
+				AwsClient:  c.NewAwsClient(),
+			},
 		}
 
 		ctrl := gomock.NewController(t)
@@ -88,7 +90,7 @@ resource "aws_instance" "web" {
 		d.AwsClient.Ec2 = iammock
 
 		var issues = []*issue.Issue{}
-		d.DetectAwsInstanceInvalidAmi(&issues)
+		d.Detect(&issues)
 
 		if !reflect.DeepEqual(issues, tc.Issues) {
 			t.Fatalf("Bad: %s\nExpected: %s\n\ntestcase: %s", issues, tc.Issues, tc.Name)

--- a/detector/aws_instance_invalid_ami_test.go
+++ b/detector/aws_instance_invalid_ami_test.go
@@ -7,11 +7,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
-	"github.com/hashicorp/hcl/hcl/ast"
-	"github.com/hashicorp/hcl/hcl/parser"
 	"github.com/wata727/tflint/awsmock"
 	"github.com/wata727/tflint/config"
-	"github.com/wata727/tflint/evaluator"
 	"github.com/wata727/tflint/issue"
 )
 
@@ -64,33 +61,26 @@ resource "aws_instance" "web" {
 	}
 
 	for _, tc := range cases {
-		listMap := make(map[string]*ast.ObjectList)
-		root, _ := parser.Parse([]byte(tc.Src))
-		list, _ := root.Node.(*ast.ObjectList)
-		listMap["test.tf"] = list
-
 		c := config.Init()
 		c.DeepCheck = true
-		evalConfig, _ := evaluator.NewEvaluator(listMap, config.Init())
-		d := &AwsInstanceInvalidAMIDetector{
-			&Detector{
-				ListMap:    listMap,
-				EvalConfig: evalConfig,
-				Config:     c,
-				AwsClient:  c.NewAwsClient(),
-			},
-		}
 
+		awsClient := c.NewAwsClient()
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		iammock := awsmock.NewMockEC2API(ctrl)
-		iammock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{}).Return(&ec2.DescribeImagesOutput{
+		ec2mock := awsmock.NewMockEC2API(ctrl)
+		ec2mock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{}).Return(&ec2.DescribeImagesOutput{
 			Images: tc.Response,
 		}, nil)
-		d.AwsClient.Ec2 = iammock
+		awsClient.Ec2 = ec2mock
 
 		var issues = []*issue.Issue{}
-		d.Detect(&issues)
+		TestDetectByCreatorName(
+			"CreateAwsInstanceInvalidAMIDetector",
+			tc.Src,
+			c,
+			awsClient,
+			&issues,
+		)
 
 		if !reflect.DeepEqual(issues, tc.Issues) {
 			t.Fatalf("Bad: %s\nExpected: %s\n\ntestcase: %s", issues, tc.Issues, tc.Name)

--- a/detector/aws_instance_invalid_iam_profile.go
+++ b/detector/aws_instance_invalid_iam_profile.go
@@ -22,12 +22,15 @@ func (d *AwsInstanceInvalidIAMProfileDetector) Detect(issues *[]*issue.Issue) {
 	}
 
 	validIamProfiles := map[string]bool{}
-	resp, err := d.AwsClient.Iam.ListInstanceProfiles(&iam.ListInstanceProfilesInput{})
-	if err != nil {
-		d.Logger.Error(err)
-		d.Error = true
+	if d.ResponseCache.ListInstanceProfilesOutput == nil {
+		resp, err := d.AwsClient.Iam.ListInstanceProfiles(&iam.ListInstanceProfilesInput{})
+		if err != nil {
+			d.Logger.Error(err)
+			d.Error = true
+		}
+		d.ResponseCache.ListInstanceProfilesOutput = resp
 	}
-	for _, iamProfile := range resp.InstanceProfiles {
+	for _, iamProfile := range d.ResponseCache.ListInstanceProfilesOutput.InstanceProfiles {
 		validIamProfiles[*iamProfile.InstanceProfileName] = true
 	}
 

--- a/detector/aws_instance_invalid_iam_profile.go
+++ b/detector/aws_instance_invalid_iam_profile.go
@@ -7,7 +7,15 @@ import (
 	"github.com/wata727/tflint/issue"
 )
 
-func (d *Detector) DetectAwsInstanceInvalidIamProfile(issues *[]*issue.Issue) {
+type AwsInstanceInvalidIAMProfileDetector struct {
+	*Detector
+}
+
+func (d *Detector) CreateAwsInstanceInvalidIAMProfileDetector() *AwsInstanceInvalidIAMProfileDetector {
+	return &AwsInstanceInvalidIAMProfileDetector{d}
+}
+
+func (d *AwsInstanceInvalidIAMProfileDetector) Detect(issues *[]*issue.Issue) {
 	if !d.Config.DeepCheck {
 		d.Logger.Info("skip this rule.")
 		return

--- a/detector/aws_instance_invalid_iam_profile_test.go
+++ b/detector/aws_instance_invalid_iam_profile_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/wata727/tflint/issue"
 )
 
-func TestDetectAwsInstanceInvalidIamProfile(t *testing.T) {
+func TestDetectAwsInstanceInvalidIAMProfile(t *testing.T) {
 	cases := []struct {
 		Name     string
 		Src      string
@@ -75,11 +75,13 @@ resource "aws_instance" "web" {
 		c := config.Init()
 		c.DeepCheck = true
 		evalConfig, _ := evaluator.NewEvaluator(listMap, config.Init())
-		d := &Detector{
-			ListMap:    listMap,
-			EvalConfig: evalConfig,
-			Config:     c,
-			AwsClient:  c.NewAwsClient(),
+		d := &AwsInstanceInvalidIAMProfileDetector{
+			&Detector{
+				ListMap:    listMap,
+				EvalConfig: evalConfig,
+				Config:     c,
+				AwsClient:  c.NewAwsClient(),
+			},
 		}
 
 		ctrl := gomock.NewController(t)
@@ -91,7 +93,7 @@ resource "aws_instance" "web" {
 		d.AwsClient.Iam = iammock
 
 		var issues = []*issue.Issue{}
-		d.DetectAwsInstanceInvalidIamProfile(&issues)
+		d.Detect(&issues)
 
 		if !reflect.DeepEqual(issues, tc.Issues) {
 			t.Fatalf("Bad: %s\nExpected: %s\n\ntestcase: %s", issues, tc.Issues, tc.Name)

--- a/detector/aws_instance_invalid_type.go
+++ b/detector/aws_instance_invalid_type.go
@@ -6,7 +6,15 @@ import (
 	"github.com/wata727/tflint/issue"
 )
 
-func (d *Detector) DetectAwsInstanceInvalidType(issues *[]*issue.Issue) {
+type AwsInstanceInvalidTypeDetector struct {
+	*Detector
+}
+
+func (d *Detector) CreateAwsInstanceInvalidTypeDetector() *AwsInstanceInvalidTypeDetector {
+	return &AwsInstanceInvalidTypeDetector{d}
+}
+
+func (d *AwsInstanceInvalidTypeDetector) Detect(issues *[]*issue.Issue) {
 	var validInstanceType = map[string]bool{
 		"t2.nano":     true,
 		"t2.micro":    true,

--- a/detector/aws_instance_invalid_type_test.go
+++ b/detector/aws_instance_invalid_type_test.go
@@ -4,10 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/hcl/hcl/ast"
-	"github.com/hashicorp/hcl/hcl/parser"
 	"github.com/wata727/tflint/config"
-	"github.com/wata727/tflint/evaluator"
 	"github.com/wata727/tflint/issue"
 )
 
@@ -43,21 +40,14 @@ resource "aws_instance" "web" {
 	}
 
 	for _, tc := range cases {
-		listMap := make(map[string]*ast.ObjectList)
-		root, _ := parser.Parse([]byte(tc.Src))
-		list, _ := root.Node.(*ast.ObjectList)
-		listMap["test.tf"] = list
-
-		evalConfig, _ := evaluator.NewEvaluator(listMap, config.Init())
-		d := &AwsInstanceInvalidTypeDetector{
-			&Detector{
-				ListMap:    listMap,
-				EvalConfig: evalConfig,
-			},
-		}
-
 		var issues = []*issue.Issue{}
-		d.Detect(&issues)
+		TestDetectByCreatorName(
+			"CreateAwsInstanceInvalidTypeDetector",
+			tc.Src,
+			config.Init(),
+			config.Init().NewAwsClient(),
+			&issues,
+		)
 
 		if !reflect.DeepEqual(issues, tc.Issues) {
 			t.Fatalf("Bad: %s\nExpected: %s\n\ntestcase: %s", issues, tc.Issues, tc.Name)

--- a/detector/aws_instance_invalid_type_test.go
+++ b/detector/aws_instance_invalid_type_test.go
@@ -49,13 +49,15 @@ resource "aws_instance" "web" {
 		listMap["test.tf"] = list
 
 		evalConfig, _ := evaluator.NewEvaluator(listMap, config.Init())
-		d := &Detector{
-			ListMap:    listMap,
-			EvalConfig: evalConfig,
+		d := &AwsInstanceInvalidTypeDetector{
+			&Detector{
+				ListMap:    listMap,
+				EvalConfig: evalConfig,
+			},
 		}
 
 		var issues = []*issue.Issue{}
-		d.DetectAwsInstanceInvalidType(&issues)
+		d.Detect(&issues)
 
 		if !reflect.DeepEqual(issues, tc.Issues) {
 			t.Fatalf("Bad: %s\nExpected: %s\n\ntestcase: %s", issues, tc.Issues, tc.Name)

--- a/detector/aws_instance_not_specified_iam_profile.go
+++ b/detector/aws_instance_not_specified_iam_profile.go
@@ -25,3 +25,7 @@ func (d *AwsInstanceNotSpecifiedIAMProfileDetector) Detect(issues *[]*issue.Issu
 		}
 	}
 }
+
+func (d *AwsInstanceNotSpecifiedIAMProfileDetector) Inherit(original *AwsInstanceNotSpecifiedIAMProfileDetector) *AwsInstanceNotSpecifiedIAMProfileDetector {
+	return original
+}

--- a/detector/aws_instance_not_specified_iam_profile.go
+++ b/detector/aws_instance_not_specified_iam_profile.go
@@ -2,7 +2,15 @@ package detector
 
 import "github.com/wata727/tflint/issue"
 
-func (d *Detector) DetectAwsInstanceNotSpecifiedIamProfile(issues *[]*issue.Issue) {
+type AwsInstanceNotSpecifiedIAMProfileDetector struct {
+	*Detector
+}
+
+func (d *Detector) CreateAwsInstanceNotSpecifiedIAMProfileDetector() *AwsInstanceNotSpecifiedIAMProfileDetector {
+	return &AwsInstanceNotSpecifiedIAMProfileDetector{d}
+}
+
+func (d *AwsInstanceNotSpecifiedIAMProfileDetector) Detect(issues *[]*issue.Issue) {
 	for filename, list := range d.ListMap {
 		for _, item := range list.Filter("resource", "aws_instance").Items {
 			if IsKeyNotFound(item, "iam_instance_profile") {

--- a/detector/aws_instance_not_specified_iam_profile_test.go
+++ b/detector/aws_instance_not_specified_iam_profile_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/wata727/tflint/issue"
 )
 
-func TestDetectAwsInstanceNotSpecifiedIamProfile(t *testing.T) {
+func TestDetectAwsInstanceNotSpecifiedIAMProfile(t *testing.T) {
 	cases := []struct {
 		Name   string
 		Src    string
@@ -50,13 +50,15 @@ resource "aws_instance" "web" {
 		listMap["test.tf"] = list
 
 		evalConfig, _ := evaluator.NewEvaluator(listMap, config.Init())
-		d := &Detector{
-			ListMap:    listMap,
-			EvalConfig: evalConfig,
+		d := &AwsInstanceNotSpecifiedIAMProfileDetector{
+			&Detector{
+				ListMap:    listMap,
+				EvalConfig: evalConfig,
+			},
 		}
 
 		var issues = []*issue.Issue{}
-		d.DetectAwsInstanceNotSpecifiedIamProfile(&issues)
+		d.Detect(&issues)
 
 		if !reflect.DeepEqual(issues, tc.Issues) {
 			t.Fatalf("Bad: %s\nExpected: %s\n\ntestcase: %s", issues, tc.Issues, tc.Name)

--- a/detector/aws_instance_not_specified_iam_profile_test.go
+++ b/detector/aws_instance_not_specified_iam_profile_test.go
@@ -4,10 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/hcl/hcl/ast"
-	"github.com/hashicorp/hcl/hcl/parser"
 	"github.com/wata727/tflint/config"
-	"github.com/wata727/tflint/evaluator"
 	"github.com/wata727/tflint/issue"
 )
 
@@ -44,21 +41,14 @@ resource "aws_instance" "web" {
 	}
 
 	for _, tc := range cases {
-		listMap := make(map[string]*ast.ObjectList)
-		root, _ := parser.Parse([]byte(tc.Src))
-		list, _ := root.Node.(*ast.ObjectList)
-		listMap["test.tf"] = list
-
-		evalConfig, _ := evaluator.NewEvaluator(listMap, config.Init())
-		d := &AwsInstanceNotSpecifiedIAMProfileDetector{
-			&Detector{
-				ListMap:    listMap,
-				EvalConfig: evalConfig,
-			},
-		}
-
 		var issues = []*issue.Issue{}
-		d.Detect(&issues)
+		TestDetectByCreatorName(
+			"CreateAwsInstanceNotSpecifiedIAMProfileDetector",
+			tc.Src,
+			config.Init(),
+			config.Init().NewAwsClient(),
+			&issues,
+		)
 
 		if !reflect.DeepEqual(issues, tc.Issues) {
 			t.Fatalf("Bad: %s\nExpected: %s\n\ntestcase: %s", issues, tc.Issues, tc.Name)

--- a/detector/aws_instance_previous_type.go
+++ b/detector/aws_instance_previous_type.go
@@ -6,7 +6,15 @@ import (
 	"github.com/wata727/tflint/issue"
 )
 
-func (d *Detector) DetectAwsInstancePreviousType(issues *[]*issue.Issue) {
+type AwsInstancePreviousTypeDetector struct {
+	*Detector
+}
+
+func (d *Detector) CreateAwsInstancePreviousTypeDetector() *AwsInstancePreviousTypeDetector {
+	return &AwsInstancePreviousTypeDetector{d}
+}
+
+func (d *AwsInstancePreviousTypeDetector) Detect(issues *[]*issue.Issue) {
 	var previousInstanceType = map[string]bool{
 		"t1.micro":    true,
 		"m1.small":    true,

--- a/detector/aws_instance_previous_type_test.go
+++ b/detector/aws_instance_previous_type_test.go
@@ -49,13 +49,15 @@ resource "aws_instance" "web" {
 		listMap["test.tf"] = list
 
 		evalConfig, _ := evaluator.NewEvaluator(listMap, config.Init())
-		d := &Detector{
-			ListMap:    listMap,
-			EvalConfig: evalConfig,
+		d := &AwsInstancePreviousTypeDetector{
+			&Detector{
+				ListMap:    listMap,
+				EvalConfig: evalConfig,
+			},
 		}
 
 		var issues = []*issue.Issue{}
-		d.DetectAwsInstancePreviousType(&issues)
+		d.Detect(&issues)
 
 		if !reflect.DeepEqual(issues, tc.Issues) {
 			t.Fatalf("Bad: %s\nExpected: %s\n\ntestcase: %s", issues, tc.Issues, tc.Name)

--- a/detector/aws_instance_previous_type_test.go
+++ b/detector/aws_instance_previous_type_test.go
@@ -4,10 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/hcl/hcl/ast"
-	"github.com/hashicorp/hcl/hcl/parser"
 	"github.com/wata727/tflint/config"
-	"github.com/wata727/tflint/evaluator"
 	"github.com/wata727/tflint/issue"
 )
 
@@ -43,21 +40,14 @@ resource "aws_instance" "web" {
 	}
 
 	for _, tc := range cases {
-		listMap := make(map[string]*ast.ObjectList)
-		root, _ := parser.Parse([]byte(tc.Src))
-		list, _ := root.Node.(*ast.ObjectList)
-		listMap["test.tf"] = list
-
-		evalConfig, _ := evaluator.NewEvaluator(listMap, config.Init())
-		d := &AwsInstancePreviousTypeDetector{
-			&Detector{
-				ListMap:    listMap,
-				EvalConfig: evalConfig,
-			},
-		}
-
 		var issues = []*issue.Issue{}
-		d.Detect(&issues)
+		TestDetectByCreatorName(
+			"CreateAwsInstancePreviousTypeDetector",
+			tc.Src,
+			config.Init(),
+			config.Init().NewAwsClient(),
+			&issues,
+		)
 
 		if !reflect.DeepEqual(issues, tc.Issues) {
 			t.Fatalf("Bad: %s\nExpected: %s\n\ntestcase: %s", issues, tc.Issues, tc.Name)

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -77,13 +77,13 @@ func IsKeyNotFound(item *ast.ObjectItem, k string) bool {
 func (d *Detector) Detect() []*issue.Issue {
 	var issues = []*issue.Issue{}
 
-	for ruleName, detectorMethod := range detectors {
+	for ruleName, creatorMethod := range detectors {
 		if d.Config.IgnoreRule[ruleName] {
 			d.Logger.Info(fmt.Sprintf("ignore rule `%s`", ruleName))
 			continue
 		}
 		d.Logger.Info(fmt.Sprintf("detect by `%s`", ruleName))
-		creator := reflect.ValueOf(d).MethodByName(detectorMethod)
+		creator := reflect.ValueOf(d).MethodByName(creatorMethod)
 		detector := creator.Call([]reflect.Value{})[0]
 
 		method := detector.MethodByName("Detect")

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -14,12 +14,13 @@ import (
 )
 
 type Detector struct {
-	ListMap    map[string]*ast.ObjectList
-	Config     *config.Config
-	AwsClient  *config.AwsClient
-	EvalConfig *evaluator.Evaluator
-	Logger     *logger.Logger
-	Error      bool
+	ListMap       map[string]*ast.ObjectList
+	Config        *config.Config
+	AwsClient     *config.AwsClient
+	EvalConfig    *evaluator.Evaluator
+	Logger        *logger.Logger
+	ResponseCache *ResponseCache
+	Error         bool
 }
 
 var detectors = map[string]string{
@@ -40,12 +41,13 @@ func NewDetector(listMap map[string]*ast.ObjectList, c *config.Config) (*Detecto
 	}
 
 	return &Detector{
-		ListMap:    listMap,
-		Config:     c,
-		AwsClient:  c.NewAwsClient(),
-		EvalConfig: evalConfig,
-		Logger:     logger.Init(c.Debug),
-		Error:      false,
+		ListMap:       listMap,
+		Config:        c,
+		AwsClient:     c.NewAwsClient(),
+		EvalConfig:    evalConfig,
+		Logger:        logger.Init(c.Debug),
+		ResponseCache: &ResponseCache{},
+		Error:         false,
 	}, nil
 }
 
@@ -103,6 +105,7 @@ func (d *Detector) Detect() []*issue.Issue {
 			moduleDetector.EvalConfig = &evaluator.Evaluator{
 				Config: m.Config,
 			}
+			moduleDetector.ResponseCache = d.ResponseCache
 			moduleDetector.Error = d.Error
 			creator := reflect.ValueOf(moduleDetector).MethodByName(creatorMethod)
 			detector := creator.Call([]reflect.Value{})[0]

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -23,14 +23,14 @@ type Detector struct {
 }
 
 var detectors = map[string]string{
-	"aws_instance_invalid_type":                       "DetectAwsInstanceInvalidType",
-	"aws_instance_previous_type":                      "DetectAwsInstancePreviousType",
-	"aws_instance_not_specified_iam_profile":          "DetectAwsInstanceNotSpecifiedIamProfile",
-	"aws_instance_default_standard_volume":            "DetectAwsInstanceDefaultStandardVolume",
-	"aws_db_instance_default_parameter_group":         "DetectAwsDbInstanceDefaultParameterGroup",
-	"aws_elasticache_cluster_default_parameter_group": "DetectAwsElasticacheClusterDefaultParameterGroup",
-	"aws_instance_invalid_iam_profile":                "DetectAwsInstanceInvalidIamProfile",
-	"aws_instance_invalid_ami":                        "DetectAwsInstanceInvalidAmi",
+	"aws_instance_invalid_type":                       "CreateAwsInstanceInvalidTypeDetector",
+	"aws_instance_previous_type":                      "CreateAwsInstancePreviousTypeDetector",
+	"aws_instance_not_specified_iam_profile":          "CreateAwsInstanceNotSpecifiedIAMProfileDetector",
+	"aws_instance_default_standard_volume":            "CreateAwsInstanceDefaultStandardVolumeDetector",
+	"aws_db_instance_default_parameter_group":         "CreateAwsDBInstanceDefaultParameterGroupDetector",
+	"aws_elasticache_cluster_default_parameter_group": "CreateAwsElastiCacheClusterDefaultParameterGroupDetector",
+	"aws_instance_invalid_iam_profile":                "CreateAwsInstanceInvalidIAMProfileDetector",
+	"aws_instance_invalid_ami":                        "CreateAwsInstanceInvalidAMIDetector",
 }
 
 func NewDetector(listMap map[string]*ast.ObjectList, c *config.Config) (*Detector, error) {
@@ -83,7 +83,10 @@ func (d *Detector) Detect() []*issue.Issue {
 			continue
 		}
 		d.Logger.Info(fmt.Sprintf("detect by `%s`", ruleName))
-		method := reflect.ValueOf(d).MethodByName(detectorMethod)
+		creator := reflect.ValueOf(d).MethodByName(detectorMethod)
+		detector := creator.Call([]reflect.Value{})[0]
+
+		method := detector.MethodByName("Detect")
 		method.Call([]reflect.Value{reflect.ValueOf(&issues)})
 
 		for name, m := range d.EvalConfig.ModuleConfig {
@@ -92,17 +95,11 @@ func (d *Detector) Detect() []*issue.Issue {
 				continue
 			}
 			d.Logger.Info(fmt.Sprintf("detect module `%s`", name))
-			moduleDetector := &Detector{
-				ListMap:   m.ListMap,
-				Config:    d.Config,
-				AwsClient: d.AwsClient,
-				EvalConfig: &evaluator.Evaluator{
-					Config: m.Config,
-				},
-				Logger: d.Logger,
-				Error:  false,
-			}
-			method := reflect.ValueOf(moduleDetector).MethodByName(detectorMethod)
+			detector.Elem().FieldByName("ListMap").Set(reflect.ValueOf(m.ListMap))
+			detector.Elem().FieldByName("EvalConfig").Set(reflect.ValueOf(&evaluator.Evaluator{
+				Config: m.Config,
+			}))
+			method := detector.MethodByName("Detect")
 			method.Call([]reflect.Value{reflect.ValueOf(&issues)})
 		}
 	}

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/wata727/tflint/config"
 	"github.com/wata727/tflint/evaluator"
-	"github.com/wata727/tflint/issue"
 	"github.com/wata727/tflint/logger"
 )
 
@@ -89,23 +88,6 @@ module "ec2_instance" {
 			t.Fatalf("Bad: %s\nExpected: %s\n\ntestcase: %s", len(issues), tc.Result, tc.Name)
 		}
 	}
-}
-
-type TestDetector struct {
-	*Detector
-}
-
-func (d *Detector) CreateTestDetector() *TestDetector {
-	return &TestDetector{d}
-}
-
-func (d *TestDetector) Detect(issues *[]*issue.Issue) {
-	*issues = append(*issues, &issue.Issue{
-		Type:    "TEST",
-		Message: "this is test method",
-		Line:    1,
-		File:    "",
-	})
 }
 
 func TestHclLiteralToken(t *testing.T) {

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -53,7 +53,7 @@ func TestDetect(t *testing.T) {
 	}
 
 	detectors = map[string]string{
-		"test_rule": "DetectMethodForTest",
+		"test_rule": "CreateTestDetector",
 	}
 
 	for _, tc := range cases {
@@ -91,7 +91,15 @@ module "ec2_instance" {
 	}
 }
 
-func (d *Detector) DetectMethodForTest(issues *[]*issue.Issue) {
+type TestDetector struct {
+	*Detector
+}
+
+func (d *Detector) CreateTestDetector() *TestDetector {
+	return &TestDetector{d}
+}
+
+func (d *TestDetector) Detect(issues *[]*issue.Issue) {
 	*issues = append(*issues, &issue.Issue{
 		Type:    "TEST",
 		Message: "this is test method",

--- a/detector/response_cache.go
+++ b/detector/response_cache.go
@@ -1,0 +1,11 @@
+package detector
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/iam"
+)
+
+type ResponseCache struct {
+	DescribeImagesOutput       *ec2.DescribeImagesOutput
+	ListInstanceProfilesOutput *iam.ListInstanceProfilesOutput
+}

--- a/detector/test_helper.go
+++ b/detector/test_helper.go
@@ -35,10 +35,11 @@ func TestDetectByCreatorName(creatorMethod string, src string, c *config.Config,
 
 	evalConfig, _ := evaluator.NewEvaluator(listMap, c)
 	creator := reflect.ValueOf(&Detector{
-		ListMap:    listMap,
-		EvalConfig: evalConfig,
-		Config:     c,
-		AwsClient:  awsClient,
+		ListMap:       listMap,
+		EvalConfig:    evalConfig,
+		Config:        c,
+		AwsClient:     awsClient,
+		ResponseCache: &ResponseCache{},
 	}).MethodByName(creatorMethod)
 	detector := creator.Call([]reflect.Value{})[0]
 

--- a/detector/test_helper.go
+++ b/detector/test_helper.go
@@ -1,0 +1,47 @@
+package detector
+
+import (
+	"reflect"
+
+	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/hashicorp/hcl/hcl/parser"
+	"github.com/wata727/tflint/config"
+	"github.com/wata727/tflint/evaluator"
+	"github.com/wata727/tflint/issue"
+)
+
+type TestDetector struct {
+	*Detector
+}
+
+func (d *Detector) CreateTestDetector() *TestDetector {
+	return &TestDetector{d}
+}
+
+func (d *TestDetector) Detect(issues *[]*issue.Issue) {
+	*issues = append(*issues, &issue.Issue{
+		Type:    "TEST",
+		Message: "this is test method",
+		Line:    1,
+		File:    "",
+	})
+}
+
+func TestDetectByCreatorName(creatorMethod string, src string, c *config.Config, awsClient *config.AwsClient, issues *[]*issue.Issue) {
+	listMap := make(map[string]*ast.ObjectList)
+	root, _ := parser.Parse([]byte(src))
+	list, _ := root.Node.(*ast.ObjectList)
+	listMap["test.tf"] = list
+
+	evalConfig, _ := evaluator.NewEvaluator(listMap, c)
+	creator := reflect.ValueOf(&Detector{
+		ListMap:    listMap,
+		EvalConfig: evalConfig,
+		Config:     c,
+		AwsClient:  awsClient,
+	}).MethodByName(creatorMethod)
+	detector := creator.Call([]reflect.Value{})[0]
+
+	method := detector.MethodByName("Detect")
+	method.Call([]reflect.Value{reflect.ValueOf(issues)})
+}


### PR DESCRIPTION
Fix #9 

Add cache mechanism for core detector. The following is an example of a deep check detecting that contains single module.

## Before
```
tflint -c .tflint.hcl.config  29.35s user 1.08s system 79% cpu 38.119 total
```

## After
```
tflint -c .tflint.hcl.config  13.53s user 0.47s system 77% cpu 18.154 total
```