### PR TITLE
do not call API when target resources are not found

### DIFF
--- a/detector/aws_instance_invalid_ami.go
+++ b/detector/aws_instance_invalid_ami.go
@@ -16,8 +16,7 @@ func (d *Detector) CreateAwsInstanceInvalidAMIDetector() *AwsInstanceInvalidAMID
 }
 
 func (d *AwsInstanceInvalidAMIDetector) Detect(issues *[]*issue.Issue) {
-	if !d.Config.DeepCheck {
-		d.Logger.Info("skip this rule.")
+	if !d.isDeepCheck("resource", "aws_instance") {
 		return
 	}
 

--- a/detector/aws_instance_invalid_iam_profile.go
+++ b/detector/aws_instance_invalid_iam_profile.go
@@ -16,8 +16,7 @@ func (d *Detector) CreateAwsInstanceInvalidIAMProfileDetector() *AwsInstanceInva
 }
 
 func (d *AwsInstanceInvalidIAMProfileDetector) Detect(issues *[]*issue.Issue) {
-	if !d.Config.DeepCheck {
-		d.Logger.Info("skip this rule.")
+	if !d.isDeepCheck("resource", "aws_instance") {
 		return
 	}
 

--- a/detector/aws_instance_invalid_key_name.go
+++ b/detector/aws_instance_invalid_key_name.go
@@ -16,8 +16,7 @@ func (d *Detector) CreateAwsInstanceInvalidKeyNameDetector() *AwsInstanceInvalid
 }
 
 func (d *AwsInstanceInvalidKeyNameDetector) Detect(issues *[]*issue.Issue) {
-	if !d.Config.DeepCheck {
-		d.Logger.Info("skip this rule.")
+	if !d.isDeepCheck("resource", "aws_instance") {
 		return
 	}
 

--- a/detector/aws_instance_invalid_subnet.go
+++ b/detector/aws_instance_invalid_subnet.go
@@ -16,8 +16,7 @@ func (d *Detector) CreateAwsInstanceInvalidSubnetDetector() *AwsInstanceInvalidS
 }
 
 func (d *AwsInstanceInvalidSubnetDetector) Detect(issues *[]*issue.Issue) {
-	if !d.Config.DeepCheck {
-		d.Logger.Info("skip this rule.")
+	if !d.isDeepCheck("resource", "aws_instance") {
 		return
 	}
 

--- a/detector/aws_instance_invalid_vpc_security_group.go
+++ b/detector/aws_instance_invalid_vpc_security_group.go
@@ -16,8 +16,7 @@ func (d *Detector) CreateAwsInstanceInvalidVPCSecurityGroupDetector() *AwsInstan
 }
 
 func (d *AwsInstanceInvalidVPCSecurityGroupDetector) Detect(issues *[]*issue.Issue) {
-	if !d.Config.DeepCheck {
-		d.Logger.Info("skip this rule.")
+	if !d.isDeepCheck("resource", "aws_instance") {
 		return
 	}
 

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -153,3 +153,19 @@ func (d *Detector) evalToString(v string) (string, error) {
 
 	return ev.(string), nil
 }
+
+func (d *Detector) isDeepCheck(resources ...string) bool {
+	if !d.Config.DeepCheck {
+		d.Logger.Info("skip this rule.")
+		return false
+	}
+	target_resources := 0
+	for _, list := range d.ListMap {
+		target_resources += len(list.Filter(resources...).Items)
+	}
+	if target_resources == 0 {
+		d.Logger.Info("target resources are not found.")
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Fix #14 
Following example is detecting simple template (only "provider")

### Before
```
tflint --deep --aws-region us-east-1  22.29s user 1.30s system 47% cpu 49.193 total
```

### After
```
tflint --deep --aws-region us-east-1  0.00s user 0.01s system 79% cpu 0.015 total
```