### PR TITLE
support list type variables evaluation

### DIFF
--- a/detector/test_helper.go
+++ b/detector/test_helper.go
@@ -8,6 +8,7 @@ import (
 	"github.com/wata727/tflint/config"
 	"github.com/wata727/tflint/evaluator"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/logger"
 )
 
 type TestDetector struct {
@@ -38,6 +39,7 @@ func TestDetectByCreatorName(creatorMethod string, src string, c *config.Config,
 		ListMap:       listMap,
 		EvalConfig:    evalConfig,
 		Config:        c,
+		Logger:        logger.Init(false),
 		AwsClient:     awsClient,
 		ResponseCache: &ResponseCache{},
 	}).MethodByName(creatorMethod)


### PR DESCRIPTION
This PR made support list type variables evaluation. Previously, false negatives occurred in the following cases:

```
variable "security_groups" {
  type = "list"
  default = [
    "sg-12345678", # This security group does not found
    "sg-1234abcd",
  ]
}

resource "aws_instance" {
  vpc_security_group_ids = "${var.security_groups}"
}
```