### PR TITLE
Return error code when issue exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Please show `tflint --help`
 --aws-secret-key                        set AWS secret key used in deep check mode.
 --aws-region                            set AWS region used in deep check mode.
 -d, --debug                             enable debug mode.
+--error-with-issues                     return exit status code when issue exists.
 ```
 
 ## Configuration

--- a/cli.go
+++ b/cli.go
@@ -16,6 +16,7 @@ import (
 const (
 	ExitCodeOK    int = 0
 	ExitCodeError int = 1 + iota
+	ExitCodeIssuesFound
 )
 
 // CLI is the command line object
@@ -37,17 +38,18 @@ type TestCLIOptions struct {
 // Run invokes the CLI with the given arguments.
 func (cli *CLI) Run(args []string) int {
 	var (
-		version      bool
-		help         bool
-		debug        bool
-		format       string
-		ignoreModule string
-		ignoreRule   string
-		configFile   string
-		deepCheck    bool
-		awsAccessKey string
-		awsSecretKey string
-		awsRegion    string
+		version         bool
+		help            bool
+		debug           bool
+		format          string
+		ignoreModule    string
+		ignoreRule      string
+		configFile      string
+		deepCheck       bool
+		awsAccessKey    string
+		awsSecretKey    string
+		awsRegion       string
+		errorWithIssues bool
 	)
 
 	// Define option flag parse
@@ -71,6 +73,7 @@ func (cli *CLI) Run(args []string) int {
 	flags.StringVar(&awsAccessKey, "aws-access-key", "", "AWS access key used in deep check mode.")
 	flags.StringVar(&awsSecretKey, "aws-secret-key", "", "AWS secret key used in deep check mode.")
 	flags.StringVar(&awsRegion, "aws-region", "", "AWS region used in deep check mode.")
+	flags.BoolVar(&errorWithIssues, "error-with-issues", false, "return exit status code when issue exists.")
 
 	// Parse commandline flag
 	if err := flags.Parse(args[1:]); err != nil {
@@ -148,6 +151,10 @@ func (cli *CLI) Run(args []string) int {
 
 		p := printer.NewPrinter(cli.outStream, cli.errStream)
 		p.Print(issues, format)
+
+		if errorWithIssues && len(issues) > 0 {
+			return ExitCodeIssuesFound
+		}
 	}
 
 	return ExitCodeOK

--- a/help.go
+++ b/help.go
@@ -16,6 +16,7 @@ Available options:
     --aws-secret-key                        set AWS secret key used in deep check mode.
     --aws-region                            set AWS region used in deep check mode.
     -d, --debug                             enable debug mode.
+    --error-with-issues                     return exit status code when issue exists.
 
 Support aruguments:
     TFLint scans all configuration file of Terraform in current directory by default.


### PR DESCRIPTION
## WHY
When used tflint on CI, it's didn't failed although tflint return some errors.

## WHAT
Update to return 2 when issue exists.