### PR TITLE
Interpret TFState

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -144,8 +144,8 @@ func (cli *CLI) Run(args []string) int {
 
 	// If disabled test mode, generates real detector
 	if !cli.testMode {
-		listMap, _ := cli.loader.Dump()
-		cli.detector, err = detector.NewDetector(listMap, c)
+		listMap, state := cli.loader.Dump()
+		cli.detector, err = detector.NewDetector(listMap, state, c)
 	}
 	if err != nil {
 		fmt.Fprintln(cli.errStream, err)

--- a/cli.go
+++ b/cli.go
@@ -133,9 +133,9 @@ func (cli *CLI) Run(args []string) int {
 	}
 	cli.loader.LoadState()
 	if flags.NArg() > 0 {
-		err = cli.loader.LoadFile(flags.Arg(0))
+		err = cli.loader.LoadTemplate(flags.Arg(0))
 	} else {
-		err = cli.loader.LoadAllFile(".")
+		err = cli.loader.LoadAllTemplate(".")
 	}
 	if err != nil {
 		fmt.Fprintln(cli.errStream, err)
@@ -144,7 +144,8 @@ func (cli *CLI) Run(args []string) int {
 
 	// If disabled test mode, generates real detector
 	if !cli.testMode {
-		cli.detector, err = detector.NewDetector(cli.loader.DumpFiles(), c)
+		listMap, _ := cli.loader.Dump()
+		cli.detector, err = detector.NewDetector(listMap, c)
 	}
 	if err != nil {
 		fmt.Fprintln(cli.errStream, err)

--- a/cli.go
+++ b/cli.go
@@ -131,6 +131,7 @@ func (cli *CLI) Run(args []string) int {
 	if !cli.testMode {
 		cli.loader = loader.NewLoader(c.Debug)
 	}
+	cli.loader.LoadState()
 	if flags.NArg() > 0 {
 		err = cli.loader.LoadFile(flags.Arg(0))
 	} else {

--- a/cli_test.go
+++ b/cli_test.go
@@ -26,7 +26,8 @@ func TestCLIRun(t *testing.T) {
 	}
 	var loaderDefaultBehavior = func(ctrl *gomock.Controller) loader.LoaderIF {
 		loader := mock.NewMockLoaderIF(ctrl)
-		loader.EXPECT().LoadAllFile(".").Return(nil)
+		loader.EXPECT().LoadState()
+		loader.EXPECT().LoadAllTemplate(".").Return(nil)
 		return loader
 	}
 	var detectorNoErrorNoIssuesBehavior = func(ctrl *gomock.Controller) detector.DetectorIF {
@@ -153,7 +154,8 @@ func TestCLIRun(t *testing.T) {
 			Command: "./tflint",
 			LoaderGenerator: func(ctrl *gomock.Controller) loader.LoaderIF {
 				loader := mock.NewMockLoaderIF(ctrl)
-				loader.EXPECT().LoadAllFile(".").Return(errors.New("loading error!"))
+				loader.EXPECT().LoadState()
+				loader.EXPECT().LoadAllTemplate(".").Return(errors.New("loading error!"))
 				return loader
 			},
 			DetectorGenerator: func(ctrl *gomock.Controller) detector.DetectorIF { return mock.NewMockDetectorIF(ctrl) },
@@ -186,7 +188,8 @@ func TestCLIRun(t *testing.T) {
 			Command: "./tflint test_template.tf",
 			LoaderGenerator: func(ctrl *gomock.Controller) loader.LoaderIF {
 				loader := mock.NewMockLoaderIF(ctrl)
-				loader.EXPECT().LoadFile("test_template.tf").Return(nil)
+				loader.EXPECT().LoadState()
+				loader.EXPECT().LoadTemplate("test_template.tf").Return(nil)
 				return loader
 			},
 			DetectorGenerator: detectorNoErrorNoIssuesBehavior,
@@ -201,7 +204,8 @@ func TestCLIRun(t *testing.T) {
 			Command: "./tflint test_template.tf",
 			LoaderGenerator: func(ctrl *gomock.Controller) loader.LoaderIF {
 				loader := mock.NewMockLoaderIF(ctrl)
-				loader.EXPECT().LoadFile("test_template.tf").Return(errors.New("loading error!"))
+				loader.EXPECT().LoadState()
+				loader.EXPECT().LoadTemplate("test_template.tf").Return(errors.New("loading error!"))
 				return loader
 			},
 			DetectorGenerator: func(ctrl *gomock.Controller) detector.DetectorIF { return mock.NewMockDetectorIF(ctrl) },

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func (c *Config) LoadConfig(filename string) error {
 	}
 
 	l := loader.NewLoader(c.Debug)
-	if err := l.LoadFile(filename); err != nil {
+	if err := l.LoadTemplate(filename); err != nil {
 		return nil
 	}
 

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -11,6 +11,7 @@ import (
 	"github.com/wata727/tflint/evaluator"
 	"github.com/wata727/tflint/issue"
 	"github.com/wata727/tflint/logger"
+	"github.com/wata727/tflint/state"
 )
 
 type DetectorIF interface {
@@ -20,6 +21,7 @@ type DetectorIF interface {
 
 type Detector struct {
 	ListMap       map[string]*ast.ObjectList
+	State         *state.TFState
 	Config        *config.Config
 	AwsClient     *config.AwsClient
 	EvalConfig    *evaluator.Evaluator
@@ -59,7 +61,7 @@ var detectors = map[string]string{
 	"aws_elasticache_cluster_previous_type":           "CreateAwsElastiCacheClusterPreviousTypeDetector",
 }
 
-func NewDetector(listMap map[string]*ast.ObjectList, c *config.Config) (*Detector, error) {
+func NewDetector(listMap map[string]*ast.ObjectList, state *state.TFState, c *config.Config) (*Detector, error) {
 	evalConfig, err := evaluator.NewEvaluator(listMap, c)
 	if err != nil {
 		return nil, err
@@ -67,6 +69,7 @@ func NewDetector(listMap map[string]*ast.ObjectList, c *config.Config) (*Detecto
 
 	return &Detector{
 		ListMap:       listMap,
+		State:         state,
 		Config:        c,
 		AwsClient:     c.NewAwsClient(),
 		EvalConfig:    evalConfig,
@@ -142,7 +145,7 @@ func (d *Detector) Detect() []*issue.Issue {
 				continue
 			}
 			d.Logger.Info(fmt.Sprintf("detect module `%s`", name))
-			moduleDetector, err := NewDetector(m.ListMap, d.Config)
+			moduleDetector, err := NewDetector(m.ListMap, d.State, d.Config)
 			if err != nil {
 				d.Logger.Error(err)
 				continue

--- a/loader/test-fixtures/local-state/terraform.tfstate
+++ b/loader/test-fixtures/local-state/terraform.tfstate
@@ -1,0 +1,37 @@
+{
+    "version": 3,
+    "terraform_version": "0.8.5",
+    "serial": 1,
+    "lineage": "875c43e9-eb28-4406-8989-ced317ad5a82",
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {
+                "aws_db_parameter_group.production": {
+                    "type": "aws_db_parameter_group",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "production",
+                        "attributes": {
+                            "arn": "arn:aws:rds:us-east-1:hogehoge:pg:production",
+                            "description": "production-db-parameter-group",
+                            "family": "mysql5.6",
+                            "id": "production",
+                            "name": "production",
+                            "parameter.#": "0",
+                            "tags.%": "0"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": ""
+                }
+            },
+            "depends_on": []
+        }
+    ]
+}

--- a/loader/test-fixtures/remote-state/.terraform/terraform.tfstate
+++ b/loader/test-fixtures/remote-state/.terraform/terraform.tfstate
@@ -1,0 +1,37 @@
+{
+    "version": 3,
+    "terraform_version": "0.8.5",
+    "serial": 1,
+    "lineage": "875c43e9-eb28-4406-8989-ced317ad5a82",
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {
+                "aws_db_parameter_group.staging": {
+                    "type": "aws_db_parameter_group",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "staging",
+                        "attributes": {
+                            "arn": "arn:aws:rds:us-east-1:hogehoge:pg:staging",
+                            "description": "staging-db-parameter-group",
+                            "family": "mysql5.6",
+                            "id": "staging",
+                            "name": "staging",
+                            "parameter.#": "0",
+                            "tags.%": "0"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": ""
+                }
+            },
+            "depends_on": []
+        }
+    ]
+}

--- a/mock/loadermock.go
+++ b/mock/loadermock.go
@@ -6,6 +6,7 @@ package mock
 import (
 	gomock "github.com/golang/mock/gomock"
 	ast "github.com/hashicorp/hcl/hcl/ast"
+	state "github.com/wata727/tflint/state"
 )
 
 // Mock of LoaderIF interface
@@ -29,14 +30,14 @@ func (_m *MockLoaderIF) EXPECT() *_MockLoaderIFRecorder {
 	return _m.recorder
 }
 
-func (_m *MockLoaderIF) LoadFile(filename string) error {
-	ret := _m.ctrl.Call(_m, "LoadFile", filename)
+func (_m *MockLoaderIF) LoadTemplate(filename string) error {
+	ret := _m.ctrl.Call(_m, "LoadTemplate", filename)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockLoaderIFRecorder) LoadFile(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadFile", arg0)
+func (_mr *_MockLoaderIFRecorder) LoadTemplate(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadTemplate", arg0)
 }
 
 func (_m *MockLoaderIF) LoadModuleFile(moduleKey string, source string) error {
@@ -49,22 +50,31 @@ func (_mr *_MockLoaderIFRecorder) LoadModuleFile(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadModuleFile", arg0, arg1)
 }
 
-func (_m *MockLoaderIF) LoadAllFile(dir string) error {
-	ret := _m.ctrl.Call(_m, "LoadAllFile", dir)
+func (_m *MockLoaderIF) LoadAllTemplate(dir string) error {
+	ret := _m.ctrl.Call(_m, "LoadAllTemplate", dir)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockLoaderIFRecorder) LoadAllFile(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadAllFile", arg0)
+func (_mr *_MockLoaderIFRecorder) LoadAllTemplate(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadAllTemplate", arg0)
 }
 
-func (_m *MockLoaderIF) DumpFiles() map[string]*ast.ObjectList {
-	ret := _m.ctrl.Call(_m, "DumpFiles")
+func (_m *MockLoaderIF) Dump() (map[string]*ast.ObjectList, *state.TFState) {
+	ret := _m.ctrl.Call(_m, "Dump")
 	ret0, _ := ret[0].(map[string]*ast.ObjectList)
-	return ret0
+	ret1, _ := ret[1].(*state.TFState)
+	return ret0, ret1
 }
 
-func (_mr *_MockLoaderIFRecorder) DumpFiles() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DumpFiles")
+func (_mr *_MockLoaderIFRecorder) Dump() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Dump")
+}
+
+func (_m *MockLoaderIF) LoadState() {
+	_m.ctrl.Call(_m, "LoadState")
+}
+
+func (_mr *_MockLoaderIFRecorder) LoadState() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadState")
 }

--- a/state/state.go
+++ b/state/state.go
@@ -1,0 +1,24 @@
+package state
+
+const LocalStatePath string = "terraform.tfstate"
+const RemoteStatePath string = ".terraform/terraform.tfstate"
+
+type TFState struct {
+	Modules []*Module `json:"modules"`
+}
+
+type Module struct {
+	Resources map[string]*Resource `json:"resources"`
+}
+
+type Resource struct {
+	Type         string    `json:"type"`
+	Dependencies []string  `json:"depends_on"`
+	Primary      *Instance `json:"primary"`
+	Provider     string    `json:"provider"`
+}
+
+type Instance struct {
+	ID         string            `json:"id"`
+	Attributes map[string]string `json:"attributes"`
+}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1,0 +1,3 @@
+package state
+
+// Nothing to do


### PR DESCRIPTION
Fix #44 

TFState has current infrastructure state information by Terraform. In order to detect more complicated issues, it is necessary.
There are two types of TFState, local state and remote state. local state is default state, it is stored under the current directory as `terraform.tfstate`. On the other hand remote state is backend state (e.g. S3, Atlas, Consul, etc.), cache state is stored in `.terraform/terraform.tfstate`.

TFLint loads these state files. If there are not found, it will continue processing without error.
