### PR TITLE
Add --fast option

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -39,6 +39,7 @@ type TestCLIOptions struct {
 type ConfigurableArgs struct {
 	Debug        bool
 	DeepCheck    bool
+	Fast         bool
 	AwsAccessKey string
 	AwsSecretKey string
 	AwsRegion    string
@@ -79,6 +80,7 @@ func (cli *CLI) Run(args []string) int {
 	flags.StringVar(&configArgs.AwsSecretKey, "aws-secret-key", "", "AWS secret key used in deep check mode.")
 	flags.StringVar(&configArgs.AwsRegion, "aws-region", "", "AWS region used in deep check mode.")
 	flags.BoolVar(&errorWithIssues, "error-with-issues", false, "return error code when issue exists.")
+	flags.BoolVar(&configArgs.Fast, "fast", false, "ignore slow rules.")
 
 	// Parse commandline flag
 	if err := flags.Parse(args[1:]); err != nil {
@@ -164,6 +166,10 @@ func (cli *CLI) setupConfig(args ConfigurableArgs) (*config.Config, error) {
 	if args.DeepCheck || c.DeepCheck {
 		c.DeepCheck = true
 		c.SetAwsCredentials(args.AwsAccessKey, args.AwsSecretKey, args.AwsRegion)
+	}
+	// `aws_instance_invalid_ami` is very slow...
+	if args.Fast {
+		c.SetIgnoreRule("aws_instance_invalid_ami")
 	}
 	if args.IgnoreModule != "" {
 		c.SetIgnoreModule(args.IgnoreModule)

--- a/cli_test.go
+++ b/cli_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/k0kubun/pp"
 	"github.com/wata727/tflint/config"
 	"github.com/wata727/tflint/detector"
 	"github.com/wata727/tflint/issue"
@@ -467,6 +468,26 @@ func TestCLIRun(t *testing.T) {
 			},
 		},
 		{
+			Name:              "enable fast mode",
+			Command:           "./tflint --fast",
+			LoaderGenerator:   loaderDefaultBehavior,
+			DetectorGenerator: detectorNoErrorNoIssuesBehavior,
+			PrinterGenerator:  printerNoIssuesDefaultBehaviour,
+			Result: Result{
+				Status: ExitCodeOK,
+				CLIOptions: TestCLIOptions{
+					Config: &config.Config{
+						Debug:          false,
+						DeepCheck:      false,
+						AwsCredentials: map[string]string{},
+						IgnoreModule:   map[string]bool{},
+						IgnoreRule:     map[string]bool{"aws_instance_invalid_ami": true},
+					},
+					ConfigFile: ".tflint.hcl",
+				},
+			},
+		},
+		{
 			Name:              "invalid options",
 			Command:           "./tflint --invalid-option",
 			LoaderGenerator:   func(ctrl *gomock.Controller) loader.LoaderIF { return mock.NewMockLoaderIF(ctrl) },
@@ -505,7 +526,7 @@ func TestCLIRun(t *testing.T) {
 			t.Fatalf("\nBad: %s\nExpected Contains: %s\n\ntestcase: %s", errStream.String(), tc.Result.Stderr, tc.Name)
 		}
 		if !reflect.DeepEqual(cli.TestCLIOptions, tc.Result.CLIOptions) {
-			t.Fatalf("\nBad: %+v\nExpected: %+v\n\ntestcase: %s", cli.TestCLIOptions, tc.Result.CLIOptions, tc.Name)
+			t.Fatalf("\nBad: %s\nExpected: %s\n\ntestcase: %s", pp.Sprint(cli.TestCLIOptions), pp.Sprint(tc.Result.CLIOptions), tc.Name)
 		}
 	}
 }

--- a/help.go
+++ b/help.go
@@ -17,6 +17,7 @@ Available options:
     --aws-region                            set AWS region used in deep check mode.
     -d, --debug                             enable debug mode.
     --error-with-issues                     return error code when issue exists.
+    --fast                                  ignore slow rules. currently, ignore only 'aws_instance_invalid_ami'
 
 Support aruguments:
     TFLint scans all configuration file of Terraform in current directory by default.


### PR DESCRIPTION
Currently, running TFLint enabled deep check mode is very slowly. This is because `aws_instance_invalid_ami` rule gets all the AMIs.
The `--fast` option ignores slow rule. By this option, we can specify deprecated rules if you want to do so quickly.

