### PR TITLE
Refactoring detector

### DIFF
--- a/detector/aws_alb_duplicate_name.go
+++ b/detector/aws_alb_duplicate_name.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
 )
 
@@ -37,29 +38,25 @@ func (d *AwsALBDuplicateNameDetector) PreProcess() {
 	}
 }
 
-func (d *AwsALBDuplicateNameDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_alb").Items {
-			nameToken, err := hclLiteralToken(item, "name")
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
-			name, err := d.evalToString(nameToken.Text)
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
+func (d *AwsALBDuplicateNameDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	nameToken, err := hclLiteralToken(item, "name")
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
+	name, err := d.evalToString(nameToken.Text)
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
 
-			if d.loadBalancers[name] && !d.State.Exists("aws_alb", hclObjectKeyText(item)) {
-				issue := &issue.Issue{
-					Type:    "ERROR",
-					Message: fmt.Sprintf("\"%s\" is duplicate name. It must be unique.", name),
-					Line:    nameToken.Pos.Line,
-					File:    filename,
-				}
-				*issues = append(*issues, issue)
-			}
+	if d.loadBalancers[name] && !d.State.Exists(d.Target, hclObjectKeyText(item)) {
+		issue := &issue.Issue{
+			Type:    d.IssueType,
+			Message: fmt.Sprintf("\"%s\" is duplicate name. It must be unique.", name),
+			Line:    nameToken.Pos.Line,
+			File:    file,
 		}
+		*issues = append(*issues, issue)
 	}
 }

--- a/detector/aws_alb_duplicate_name.go
+++ b/detector/aws_alb_duplicate_name.go
@@ -8,28 +8,34 @@ import (
 
 type AwsALBDuplicateNameDetector struct {
 	*Detector
+	loadBalancers map[string]bool
 }
 
 func (d *Detector) CreateAwsALBDuplicateNameDetector() *AwsALBDuplicateNameDetector {
-	return &AwsALBDuplicateNameDetector{d}
+	return &AwsALBDuplicateNameDetector{
+		Detector:      d,
+		loadBalancers: map[string]bool{},
+	}
 }
 
-func (d *AwsALBDuplicateNameDetector) Detect(issues *[]*issue.Issue) {
-	if !d.isDeepCheck("resource", "aws_alb") {
+func (d *AwsALBDuplicateNameDetector) PreProcess() {
+	if d.isSkippable("resource", "aws_alb") {
 		return
 	}
 
-	existLoadBalancerNames := map[string]bool{}
 	resp, err := d.AwsClient.DescribeLoadBalancers()
 	if err != nil {
 		d.Logger.Error(err)
 		d.Error = true
 		return
 	}
-	for _, loadBalancer := range resp.LoadBalancers {
-		existLoadBalancerNames[*loadBalancer.LoadBalancerName] = true
-	}
 
+	for _, loadBalancer := range resp.LoadBalancers {
+		d.loadBalancers[*loadBalancer.LoadBalancerName] = true
+	}
+}
+
+func (d *AwsALBDuplicateNameDetector) Detect(issues *[]*issue.Issue) {
 	for filename, list := range d.ListMap {
 		for _, item := range list.Filter("resource", "aws_alb").Items {
 			nameToken, err := hclLiteralToken(item, "name")
@@ -43,7 +49,7 @@ func (d *AwsALBDuplicateNameDetector) Detect(issues *[]*issue.Issue) {
 				continue
 			}
 
-			if existLoadBalancerNames[name] && !d.State.Exists("aws_alb", hclObjectKeyText(item)) {
+			if d.loadBalancers[name] && !d.State.Exists("aws_alb", hclObjectKeyText(item)) {
 				issue := &issue.Issue{
 					Type:    "ERROR",
 					Message: fmt.Sprintf("\"%s\" is duplicate name. It must be unique.", name),

--- a/detector/aws_alb_duplicate_name.go
+++ b/detector/aws_alb_duplicate_name.go
@@ -8,21 +8,23 @@ import (
 
 type AwsALBDuplicateNameDetector struct {
 	*Detector
+	IssueType     string
+	Target        string
+	DeepCheck     bool
 	loadBalancers map[string]bool
 }
 
 func (d *Detector) CreateAwsALBDuplicateNameDetector() *AwsALBDuplicateNameDetector {
 	return &AwsALBDuplicateNameDetector{
 		Detector:      d,
+		IssueType:     issue.ERROR,
+		Target:        "aws_alb",
+		DeepCheck:     true,
 		loadBalancers: map[string]bool{},
 	}
 }
 
 func (d *AwsALBDuplicateNameDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_alb") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeLoadBalancers()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_alb_invaid_security_group.go
+++ b/detector/aws_alb_invaid_security_group.go
@@ -9,21 +9,23 @@ import (
 
 type AwsALBInvalidSecurityGroupDetector struct {
 	*Detector
+	IssueType      string
+	Target         string
+	DeepCheck      bool
 	securityGroups map[string]bool
 }
 
 func (d *Detector) CreateAwsALBInvalidSecurityGroupDetector() *AwsALBInvalidSecurityGroupDetector {
 	return &AwsALBInvalidSecurityGroupDetector{
 		Detector:       d,
+		IssueType:      issue.ERROR,
+		Target:         "aws_alb",
+		DeepCheck:      true,
 		securityGroups: map[string]bool{},
 	}
 }
 
 func (d *AwsALBInvalidSecurityGroupDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_alb") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeSecurityGroups()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_alb_invaid_security_group.go
+++ b/detector/aws_alb_invaid_security_group.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/wata727/tflint/issue"
 )
@@ -38,44 +39,40 @@ func (d *AwsALBInvalidSecurityGroupDetector) PreProcess() {
 	}
 }
 
-func (d *AwsALBInvalidSecurityGroupDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_alb").Items {
-			var varToken token.Token
-			var securityGroupTokens []token.Token
-			var err error
-			if varToken, err = hclLiteralToken(item, "security_groups"); err == nil {
-				securityGroupTokens, err = d.evalToStringTokens(varToken)
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
-			} else {
-				d.Logger.Error(err)
-				securityGroupTokens, err = hclLiteralListToken(item, "security_groups")
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
-			}
+func (d *AwsALBInvalidSecurityGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	var varToken token.Token
+	var securityGroupTokens []token.Token
+	var err error
+	if varToken, err = hclLiteralToken(item, "security_groups"); err == nil {
+		securityGroupTokens, err = d.evalToStringTokens(varToken)
+		if err != nil {
+			d.Logger.Error(err)
+			return
+		}
+	} else {
+		d.Logger.Error(err)
+		securityGroupTokens, err = hclLiteralListToken(item, "security_groups")
+		if err != nil {
+			d.Logger.Error(err)
+			return
+		}
+	}
 
-			for _, securityGroupToken := range securityGroupTokens {
-				securityGroup, err := d.evalToString(securityGroupToken.Text)
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
+	for _, securityGroupToken := range securityGroupTokens {
+		securityGroup, err := d.evalToString(securityGroupToken.Text)
+		if err != nil {
+			d.Logger.Error(err)
+			continue
+		}
 
-				if !d.securityGroups[securityGroup] {
-					issue := &issue.Issue{
-						Type:    "ERROR",
-						Message: fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
-						Line:    securityGroupToken.Pos.Line,
-						File:    filename,
-					}
-					*issues = append(*issues, issue)
-				}
+		if !d.securityGroups[securityGroup] {
+			issue := &issue.Issue{
+				Type:    d.IssueType,
+				Message: fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
+				Line:    securityGroupToken.Pos.Line,
+				File:    file,
 			}
+			*issues = append(*issues, issue)
 		}
 	}
 }

--- a/detector/aws_alb_invalid_subnet.go
+++ b/detector/aws_alb_invalid_subnet.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/wata727/tflint/issue"
 )
@@ -38,44 +39,40 @@ func (d *AwsALBInvalidSubnetDetector) PreProcess() {
 	}
 }
 
-func (d *AwsALBInvalidSubnetDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_alb").Items {
-			var varToken token.Token
-			var subnetTokens []token.Token
-			var err error
-			if varToken, err = hclLiteralToken(item, "subnets"); err == nil {
-				subnetTokens, err = d.evalToStringTokens(varToken)
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
-			} else {
-				d.Logger.Error(err)
-				subnetTokens, err = hclLiteralListToken(item, "subnets")
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
-			}
+func (d *AwsALBInvalidSubnetDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	var varToken token.Token
+	var subnetTokens []token.Token
+	var err error
+	if varToken, err = hclLiteralToken(item, "subnets"); err == nil {
+		subnetTokens, err = d.evalToStringTokens(varToken)
+		if err != nil {
+			d.Logger.Error(err)
+			return
+		}
+	} else {
+		d.Logger.Error(err)
+		subnetTokens, err = hclLiteralListToken(item, "subnets")
+		if err != nil {
+			d.Logger.Error(err)
+			return
+		}
+	}
 
-			for _, subnetToken := range subnetTokens {
-				subnet, err := d.evalToString(subnetToken.Text)
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
+	for _, subnetToken := range subnetTokens {
+		subnet, err := d.evalToString(subnetToken.Text)
+		if err != nil {
+			d.Logger.Error(err)
+			continue
+		}
 
-				if !d.subnets[subnet] {
-					issue := &issue.Issue{
-						Type:    "ERROR",
-						Message: fmt.Sprintf("\"%s\" is invalid subnet ID.", subnet),
-						Line:    subnetToken.Pos.Line,
-						File:    filename,
-					}
-					*issues = append(*issues, issue)
-				}
+		if !d.subnets[subnet] {
+			issue := &issue.Issue{
+				Type:    d.IssueType,
+				Message: fmt.Sprintf("\"%s\" is invalid subnet ID.", subnet),
+				Line:    subnetToken.Pos.Line,
+				File:    file,
 			}
+			*issues = append(*issues, issue)
 		}
 	}
 }

--- a/detector/aws_alb_invalid_subnet.go
+++ b/detector/aws_alb_invalid_subnet.go
@@ -9,21 +9,23 @@ import (
 
 type AwsALBInvalidSubnetDetector struct {
 	*Detector
-	subnets map[string]bool
+	IssueType string
+	Target    string
+	DeepCheck bool
+	subnets   map[string]bool
 }
 
 func (d *Detector) CreateAwsALBInvalidSubnetDetector() *AwsALBInvalidSubnetDetector {
 	return &AwsALBInvalidSubnetDetector{
-		Detector: d,
-		subnets:  map[string]bool{},
+		Detector:  d,
+		IssueType: issue.ERROR,
+		Target:    "aws_alb",
+		DeepCheck: true,
+		subnets:   map[string]bool{},
 	}
 }
 
 func (d *AwsALBInvalidSubnetDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_alb") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeSubnets()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_db_instance_default_parameter_group.go
+++ b/detector/aws_db_instance_default_parameter_group.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
 )
 
@@ -23,30 +24,26 @@ func (d *Detector) CreateAwsDBInstanceDefaultParameterGroupDetector() *AwsDBInst
 	}
 }
 
-func (d *AwsDBInstanceDefaultParameterGroupDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_db_instance").Items {
-			parameterGroupToken, err := hclLiteralToken(item, "parameter_group_name")
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
-			parameterGroup, err := d.evalToString(parameterGroupToken.Text)
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
+func (d *AwsDBInstanceDefaultParameterGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	parameterGroupToken, err := hclLiteralToken(item, "parameter_group_name")
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
+	parameterGroup, err := d.evalToString(parameterGroupToken.Text)
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
 
-			if d.isDefaultDbParameterGroup(parameterGroup) {
-				issue := &issue.Issue{
-					Type:    "NOTICE",
-					Message: fmt.Sprintf("\"%s\" is default parameter group. You cannot edit it.", parameterGroup),
-					Line:    parameterGroupToken.Pos.Line,
-					File:    filename,
-				}
-				*issues = append(*issues, issue)
-			}
+	if d.isDefaultDbParameterGroup(parameterGroup) {
+		issue := &issue.Issue{
+			Type:    d.IssueType,
+			Message: fmt.Sprintf("\"%s\" is default parameter group. You cannot edit it.", parameterGroup),
+			Line:    parameterGroupToken.Pos.Line,
+			File:    file,
 		}
+		*issues = append(*issues, issue)
 	}
 }
 

--- a/detector/aws_db_instance_default_parameter_group.go
+++ b/detector/aws_db_instance_default_parameter_group.go
@@ -9,10 +9,18 @@ import (
 
 type AwsDBInstanceDefaultParameterGroupDetector struct {
 	*Detector
+	IssueType string
+	Target    string
+	DeepCheck bool
 }
 
 func (d *Detector) CreateAwsDBInstanceDefaultParameterGroupDetector() *AwsDBInstanceDefaultParameterGroupDetector {
-	return &AwsDBInstanceDefaultParameterGroupDetector{d}
+	return &AwsDBInstanceDefaultParameterGroupDetector{
+		Detector:  d,
+		IssueType: issue.NOTICE,
+		Target:    "aws_db_instance",
+		DeepCheck: false,
+	}
 }
 
 func (d *AwsDBInstanceDefaultParameterGroupDetector) Detect(issues *[]*issue.Issue) {

--- a/detector/aws_db_instance_duplicate_identifier.go
+++ b/detector/aws_db_instance_duplicate_identifier.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
 )
 
@@ -37,29 +38,25 @@ func (d *AwsDBInstanceDuplicateIdentifierDetector) PreProcess() {
 	}
 }
 
-func (d *AwsDBInstanceDuplicateIdentifierDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_db_instance").Items {
-			identifierToken, err := hclLiteralToken(item, "identifier")
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
-			identifier, err := d.evalToString(identifierToken.Text)
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
+func (d *AwsDBInstanceDuplicateIdentifierDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	identifierToken, err := hclLiteralToken(item, "identifier")
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
+	identifier, err := d.evalToString(identifierToken.Text)
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
 
-			if d.identifiers[identifier] && !d.State.Exists("aws_db_instance", hclObjectKeyText(item)) {
-				issue := &issue.Issue{
-					Type:    "ERROR",
-					Message: fmt.Sprintf("\"%s\" is duplicate identifier. It must be unique.", identifier),
-					Line:    identifierToken.Pos.Line,
-					File:    filename,
-				}
-				*issues = append(*issues, issue)
-			}
+	if d.identifiers[identifier] && !d.State.Exists(d.Target, hclObjectKeyText(item)) {
+		issue := &issue.Issue{
+			Type:    d.IssueType,
+			Message: fmt.Sprintf("\"%s\" is duplicate identifier. It must be unique.", identifier),
+			Line:    identifierToken.Pos.Line,
+			File:    file,
 		}
+		*issues = append(*issues, issue)
 	}
 }

--- a/detector/aws_db_instance_duplicate_identifier.go
+++ b/detector/aws_db_instance_duplicate_identifier.go
@@ -8,21 +8,23 @@ import (
 
 type AwsDBInstanceDuplicateIdentifierDetector struct {
 	*Detector
+	IssueType   string
+	Target      string
+	DeepCheck   bool
 	identifiers map[string]bool
 }
 
 func (d *Detector) CreateAwsDBInstanceDuplicateIdentifierDetector() *AwsDBInstanceDuplicateIdentifierDetector {
 	return &AwsDBInstanceDuplicateIdentifierDetector{
 		Detector:    d,
+		IssueType:   issue.ERROR,
+		Target:      "aws_db_instance",
+		DeepCheck:   true,
 		identifiers: map[string]bool{},
 	}
 }
 
 func (d *AwsDBInstanceDuplicateIdentifierDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_db_instance") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeDBInstances()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_db_instance_invalid_db_subnet_group.go
+++ b/detector/aws_db_instance_invalid_db_subnet_group.go
@@ -8,21 +8,23 @@ import (
 
 type AwsDBInstanceInvalidDBSubnetGroupDetector struct {
 	*Detector
+	IssueType    string
+	Target       string
+	DeepCheck    bool
 	subnetGroups map[string]bool
 }
 
 func (d *Detector) CreateAwsDBInstanceInvalidDBSubnetGroupDetector() *AwsDBInstanceInvalidDBSubnetGroupDetector {
 	return &AwsDBInstanceInvalidDBSubnetGroupDetector{
 		Detector:     d,
+		IssueType:    issue.ERROR,
+		Target:       "aws_db_instance",
+		DeepCheck:    true,
 		subnetGroups: map[string]bool{},
 	}
 }
 
 func (d *AwsDBInstanceInvalidDBSubnetGroupDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_db_instance") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeDBSubnetGroups()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_db_instance_invalid_db_subnet_group.go
+++ b/detector/aws_db_instance_invalid_db_subnet_group.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
 )
 
@@ -37,29 +38,25 @@ func (d *AwsDBInstanceInvalidDBSubnetGroupDetector) PreProcess() {
 	}
 }
 
-func (d *AwsDBInstanceInvalidDBSubnetGroupDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_db_instance").Items {
-			subnetGroupToken, err := hclLiteralToken(item, "db_subnet_group_name")
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
-			subnetGroup, err := d.evalToString(subnetGroupToken.Text)
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
+func (d *AwsDBInstanceInvalidDBSubnetGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	subnetGroupToken, err := hclLiteralToken(item, "db_subnet_group_name")
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
+	subnetGroup, err := d.evalToString(subnetGroupToken.Text)
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
 
-			if !d.subnetGroups[subnetGroup] {
-				issue := &issue.Issue{
-					Type:    "ERROR",
-					Message: fmt.Sprintf("\"%s\" is invalid DB subnet group name.", subnetGroup),
-					Line:    subnetGroupToken.Pos.Line,
-					File:    filename,
-				}
-				*issues = append(*issues, issue)
-			}
+	if !d.subnetGroups[subnetGroup] {
+		issue := &issue.Issue{
+			Type:    d.IssueType,
+			Message: fmt.Sprintf("\"%s\" is invalid DB subnet group name.", subnetGroup),
+			Line:    subnetGroupToken.Pos.Line,
+			File:    file,
 		}
+		*issues = append(*issues, issue)
 	}
 }

--- a/detector/aws_db_instance_invalid_option_group.go
+++ b/detector/aws_db_instance_invalid_option_group.go
@@ -8,21 +8,23 @@ import (
 
 type AwsDBInstanceInvalidOptionGroupDetector struct {
 	*Detector
+	IssueType    string
+	Target       string
+	DeepCheck    bool
 	optionGroups map[string]bool
 }
 
 func (d *Detector) CreateAwsDBInstanceInvalidOptionGroupDetector() *AwsDBInstanceInvalidOptionGroupDetector {
 	return &AwsDBInstanceInvalidOptionGroupDetector{
 		Detector:     d,
+		IssueType:    issue.ERROR,
+		Target:       "aws_db_instance",
+		DeepCheck:    true,
 		optionGroups: map[string]bool{},
 	}
 }
 
 func (d *AwsDBInstanceInvalidOptionGroupDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_db_instance") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeOptionGroups()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_db_instance_invalid_option_group.go
+++ b/detector/aws_db_instance_invalid_option_group.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
 )
 
@@ -37,29 +38,25 @@ func (d *AwsDBInstanceInvalidOptionGroupDetector) PreProcess() {
 	}
 }
 
-func (d *AwsDBInstanceInvalidOptionGroupDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_db_instance").Items {
-			optionGroupToken, err := hclLiteralToken(item, "option_group_name")
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
-			optionGroup, err := d.evalToString(optionGroupToken.Text)
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
+func (d *AwsDBInstanceInvalidOptionGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	optionGroupToken, err := hclLiteralToken(item, "option_group_name")
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
+	optionGroup, err := d.evalToString(optionGroupToken.Text)
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
 
-			if !d.optionGroups[optionGroup] {
-				issue := &issue.Issue{
-					Type:    "ERROR",
-					Message: fmt.Sprintf("\"%s\" is invalid option group name.", optionGroup),
-					Line:    optionGroupToken.Pos.Line,
-					File:    filename,
-				}
-				*issues = append(*issues, issue)
-			}
+	if !d.optionGroups[optionGroup] {
+		issue := &issue.Issue{
+			Type:    d.IssueType,
+			Message: fmt.Sprintf("\"%s\" is invalid option group name.", optionGroup),
+			Line:    optionGroupToken.Pos.Line,
+			File:    file,
 		}
+		*issues = append(*issues, issue)
 	}
 }

--- a/detector/aws_db_instance_invalid_parameter_group.go
+++ b/detector/aws_db_instance_invalid_parameter_group.go
@@ -8,21 +8,23 @@ import (
 
 type AwsDBInstanceInvalidParameterGroupDetector struct {
 	*Detector
+	IssueType       string
+	Target          string
+	DeepCheck       bool
 	parameterGroups map[string]bool
 }
 
 func (d *Detector) CreateAwsDBInstanceInvalidParameterGroupDetector() *AwsDBInstanceInvalidParameterGroupDetector {
 	return &AwsDBInstanceInvalidParameterGroupDetector{
 		Detector:        d,
+		IssueType:       issue.ERROR,
+		Target:          "aws_db_instance",
+		DeepCheck:       true,
 		parameterGroups: map[string]bool{},
 	}
 }
 
 func (d *AwsDBInstanceInvalidParameterGroupDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_db_instance") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeDBParameterGroups()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_db_instance_invalid_type.go
+++ b/detector/aws_db_instance_invalid_type.go
@@ -8,12 +8,18 @@ import (
 
 type AwsDBInstanceInvalidTypeDetector struct {
 	*Detector
+	IssueType     string
+	Target        string
+	DeepCheck     bool
 	instanceTypes map[string]bool
 }
 
 func (d *Detector) CreateAwsDBInstanceInvalidTypeDetector() *AwsDBInstanceInvalidTypeDetector {
 	return &AwsDBInstanceInvalidTypeDetector{
 		Detector:      d,
+		IssueType:     issue.ERROR,
+		Target:        "aws_db_instance",
+		DeepCheck:     false,
 		instanceTypes: map[string]bool{},
 	}
 }

--- a/detector/aws_db_instance_invalid_vpc_security_group.go
+++ b/detector/aws_db_instance_invalid_vpc_security_group.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/wata727/tflint/issue"
 )
@@ -38,44 +39,40 @@ func (d *AwsDBInstanceInvalidVPCSecurityGroupDetector) PreProcess() {
 	}
 }
 
-func (d *AwsDBInstanceInvalidVPCSecurityGroupDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_db_instance").Items {
-			var varToken token.Token
-			var securityGroupTokens []token.Token
-			var err error
-			if varToken, err = hclLiteralToken(item, "vpc_security_group_ids"); err == nil {
-				securityGroupTokens, err = d.evalToStringTokens(varToken)
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
-			} else {
-				d.Logger.Error(err)
-				securityGroupTokens, err = hclLiteralListToken(item, "vpc_security_group_ids")
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
-			}
+func (d *AwsDBInstanceInvalidVPCSecurityGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	var varToken token.Token
+	var securityGroupTokens []token.Token
+	var err error
+	if varToken, err = hclLiteralToken(item, "vpc_security_group_ids"); err == nil {
+		securityGroupTokens, err = d.evalToStringTokens(varToken)
+		if err != nil {
+			d.Logger.Error(err)
+			return
+		}
+	} else {
+		d.Logger.Error(err)
+		securityGroupTokens, err = hclLiteralListToken(item, "vpc_security_group_ids")
+		if err != nil {
+			d.Logger.Error(err)
+			return
+		}
+	}
 
-			for _, securityGroupToken := range securityGroupTokens {
-				securityGroup, err := d.evalToString(securityGroupToken.Text)
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
+	for _, securityGroupToken := range securityGroupTokens {
+		securityGroup, err := d.evalToString(securityGroupToken.Text)
+		if err != nil {
+			d.Logger.Error(err)
+			continue
+		}
 
-				if !d.securityGroups[securityGroup] {
-					issue := &issue.Issue{
-						Type:    "ERROR",
-						Message: fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
-						Line:    securityGroupToken.Pos.Line,
-						File:    filename,
-					}
-					*issues = append(*issues, issue)
-				}
+		if !d.securityGroups[securityGroup] {
+			issue := &issue.Issue{
+				Type:    d.IssueType,
+				Message: fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
+				Line:    securityGroupToken.Pos.Line,
+				File:    file,
 			}
+			*issues = append(*issues, issue)
 		}
 	}
 }

--- a/detector/aws_db_instance_invalid_vpc_security_group.go
+++ b/detector/aws_db_instance_invalid_vpc_security_group.go
@@ -9,21 +9,23 @@ import (
 
 type AwsDBInstanceInvalidVPCSecurityGroupDetector struct {
 	*Detector
+	IssueType      string
+	Target         string
+	DeepCheck      bool
 	securityGroups map[string]bool
 }
 
 func (d *Detector) CreateAwsDBInstanceInvalidVPCSecurityGroupDetector() *AwsDBInstanceInvalidVPCSecurityGroupDetector {
 	return &AwsDBInstanceInvalidVPCSecurityGroupDetector{
 		Detector:       d,
+		IssueType:      issue.ERROR,
+		Target:         "aws_db_instance",
+		DeepCheck:      true,
 		securityGroups: map[string]bool{},
 	}
 }
 
 func (d *AwsDBInstanceInvalidVPCSecurityGroupDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_db_instance") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeSecurityGroups()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_db_instance_previous_type.go
+++ b/detector/aws_db_instance_previous_type.go
@@ -8,12 +8,18 @@ import (
 
 type AwsDBInstancePreviousTypeDetector struct {
 	*Detector
+	IssueType             string
+	Target                string
+	DeepCheck             bool
 	previousInstanceTypes map[string]bool
 }
 
 func (d *Detector) CreateAwsDBInstancePreviousTypeDetector() *AwsDBInstancePreviousTypeDetector {
 	return &AwsDBInstancePreviousTypeDetector{
 		Detector:              d,
+		IssueType:             issue.WARNING,
+		Target:                "aws_db_instance",
+		DeepCheck:             false,
 		previousInstanceTypes: map[string]bool{},
 	}
 }

--- a/detector/aws_db_instance_previous_type.go
+++ b/detector/aws_db_instance_previous_type.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
 )
 
@@ -38,29 +39,25 @@ func (d *AwsDBInstancePreviousTypeDetector) PreProcess() {
 	}
 }
 
-func (d *AwsDBInstancePreviousTypeDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_db_instance").Items {
-			instanceTypeToken, err := hclLiteralToken(item, "instance_class")
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
-			instanceType, err := d.evalToString(instanceTypeToken.Text)
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
+func (d *AwsDBInstancePreviousTypeDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	instanceTypeToken, err := hclLiteralToken(item, "instance_class")
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
+	instanceType, err := d.evalToString(instanceTypeToken.Text)
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
 
-			if d.previousInstanceTypes[instanceType] {
-				issue := &issue.Issue{
-					Type:    "WARNING",
-					Message: fmt.Sprintf("\"%s\" is previous generation instance type.", instanceType),
-					Line:    instanceTypeToken.Pos.Line,
-					File:    filename,
-				}
-				*issues = append(*issues, issue)
-			}
+	if d.previousInstanceTypes[instanceType] {
+		issue := &issue.Issue{
+			Type:    d.IssueType,
+			Message: fmt.Sprintf("\"%s\" is previous generation instance type.", instanceType),
+			Line:    instanceTypeToken.Pos.Line,
+			File:    file,
 		}
+		*issues = append(*issues, issue)
 	}
 }

--- a/detector/aws_db_instance_readable_password.go
+++ b/detector/aws_db_instance_readable_password.go
@@ -1,6 +1,9 @@
 package detector
 
-import "github.com/wata727/tflint/issue"
+import (
+	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/wata727/tflint/issue"
+)
 
 type AwsDBInstanceReadablePasswordDetector struct {
 	*Detector
@@ -18,27 +21,23 @@ func (d *Detector) CreateAwsDBInstanceReadablePasswordDetector() *AwsDBInstanceR
 	}
 }
 
-func (d *AwsDBInstanceReadablePasswordDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_db_instance").Items {
-			passwordToken, err := hclLiteralToken(item, "password")
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
-			_, err = d.evalToString(passwordToken.Text)
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
-
-			issue := &issue.Issue{
-				Type:    "WARNING",
-				Message: "Password for the master DB user is readable. recommend using environment variables.",
-				Line:    passwordToken.Pos.Line,
-				File:    filename,
-			}
-			*issues = append(*issues, issue)
-		}
+func (d *AwsDBInstanceReadablePasswordDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	passwordToken, err := hclLiteralToken(item, "password")
+	if err != nil {
+		d.Logger.Error(err)
+		return
 	}
+	_, err = d.evalToString(passwordToken.Text)
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
+
+	issue := &issue.Issue{
+		Type:    d.IssueType,
+		Message: "Password for the master DB user is readable. recommend using environment variables.",
+		Line:    passwordToken.Pos.Line,
+		File:    file,
+	}
+	*issues = append(*issues, issue)
 }

--- a/detector/aws_db_instance_readable_password.go
+++ b/detector/aws_db_instance_readable_password.go
@@ -4,10 +4,18 @@ import "github.com/wata727/tflint/issue"
 
 type AwsDBInstanceReadablePasswordDetector struct {
 	*Detector
+	IssueType string
+	Target    string
+	DeepCheck bool
 }
 
 func (d *Detector) CreateAwsDBInstanceReadablePasswordDetector() *AwsDBInstanceReadablePasswordDetector {
-	return &AwsDBInstanceReadablePasswordDetector{d}
+	return &AwsDBInstanceReadablePasswordDetector{
+		Detector:  d,
+		IssueType: issue.WARNING,
+		Target:    "aws_db_instance",
+		DeepCheck: false,
+	}
 }
 
 func (d *AwsDBInstanceReadablePasswordDetector) Detect(issues *[]*issue.Issue) {

--- a/detector/aws_elasticache_cluster_default_parameter_group.go
+++ b/detector/aws_elasticache_cluster_default_parameter_group.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
 )
 
@@ -23,30 +24,26 @@ func (d *Detector) CreateAwsElastiCacheClusterDefaultParameterGroupDetector() *A
 	}
 }
 
-func (d *AwsElastiCacheClusterDefaultParameterGroupDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_elasticache_cluster").Items {
-			parameterGroupToken, err := hclLiteralToken(item, "parameter_group_name")
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
-			parameterGroup, err := d.evalToString(parameterGroupToken.Text)
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
+func (d *AwsElastiCacheClusterDefaultParameterGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	parameterGroupToken, err := hclLiteralToken(item, "parameter_group_name")
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
+	parameterGroup, err := d.evalToString(parameterGroupToken.Text)
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
 
-			if d.isDefaultCacheParameterGroup(parameterGroup) {
-				issue := &issue.Issue{
-					Type:    "NOTICE",
-					Message: fmt.Sprintf("\"%s\" is default parameter group. You cannot edit it.", parameterGroup),
-					Line:    parameterGroupToken.Pos.Line,
-					File:    filename,
-				}
-				*issues = append(*issues, issue)
-			}
+	if d.isDefaultCacheParameterGroup(parameterGroup) {
+		issue := &issue.Issue{
+			Type:    d.IssueType,
+			Message: fmt.Sprintf("\"%s\" is default parameter group. You cannot edit it.", parameterGroup),
+			Line:    parameterGroupToken.Pos.Line,
+			File:    file,
 		}
+		*issues = append(*issues, issue)
 	}
 }
 

--- a/detector/aws_elasticache_cluster_default_parameter_group.go
+++ b/detector/aws_elasticache_cluster_default_parameter_group.go
@@ -9,10 +9,18 @@ import (
 
 type AwsElastiCacheClusterDefaultParameterGroupDetector struct {
 	*Detector
+	IssueType string
+	Target    string
+	DeepCheck bool
 }
 
 func (d *Detector) CreateAwsElastiCacheClusterDefaultParameterGroupDetector() *AwsElastiCacheClusterDefaultParameterGroupDetector {
-	return &AwsElastiCacheClusterDefaultParameterGroupDetector{d}
+	return &AwsElastiCacheClusterDefaultParameterGroupDetector{
+		Detector:  d,
+		IssueType: issue.NOTICE,
+		Target:    "aws_elasticache_cluster",
+		DeepCheck: false,
+	}
 }
 
 func (d *AwsElastiCacheClusterDefaultParameterGroupDetector) Detect(issues *[]*issue.Issue) {

--- a/detector/aws_elasticache_cluster_duplicate_id.go
+++ b/detector/aws_elasticache_cluster_duplicate_id.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
 )
 
@@ -37,29 +38,25 @@ func (d *AwsElastiCacheClusterDuplicateIDDetector) PreProcess() {
 	}
 }
 
-func (d *AwsElastiCacheClusterDuplicateIDDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_elasticache_cluster").Items {
-			idToken, err := hclLiteralToken(item, "cluster_id")
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
-			id, err := d.evalToString(idToken.Text)
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
+func (d *AwsElastiCacheClusterDuplicateIDDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	idToken, err := hclLiteralToken(item, "cluster_id")
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
+	id, err := d.evalToString(idToken.Text)
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
 
-			if d.cacheClusters[id] && !d.State.Exists("aws_elasticache_cluster", hclObjectKeyText(item)) {
-				issue := &issue.Issue{
-					Type:    "ERROR",
-					Message: fmt.Sprintf("\"%s\" is duplicate Cluster ID. It must be unique.", id),
-					Line:    idToken.Pos.Line,
-					File:    filename,
-				}
-				*issues = append(*issues, issue)
-			}
+	if d.cacheClusters[id] && !d.State.Exists(d.Target, hclObjectKeyText(item)) {
+		issue := &issue.Issue{
+			Type:    d.IssueType,
+			Message: fmt.Sprintf("\"%s\" is duplicate Cluster ID. It must be unique.", id),
+			Line:    idToken.Pos.Line,
+			File:    file,
 		}
+		*issues = append(*issues, issue)
 	}
 }

--- a/detector/aws_elasticache_cluster_duplicate_id.go
+++ b/detector/aws_elasticache_cluster_duplicate_id.go
@@ -8,21 +8,23 @@ import (
 
 type AwsElastiCacheClusterDuplicateIDDetector struct {
 	*Detector
+	IssueType     string
+	Target        string
+	DeepCheck     bool
 	cacheClusters map[string]bool
 }
 
 func (d *Detector) CreateAwsElastiCacheClusterDuplicateIDDetector() *AwsElastiCacheClusterDuplicateIDDetector {
 	return &AwsElastiCacheClusterDuplicateIDDetector{
 		Detector:      d,
+		IssueType:     issue.ERROR,
+		Target:        "aws_elasticache_cluster",
+		DeepCheck:     true,
 		cacheClusters: map[string]bool{},
 	}
 }
 
 func (d *AwsElastiCacheClusterDuplicateIDDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_elasticache_cluster") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeCacheClusters()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_elasticache_cluster_invalid_parameter_group.go
+++ b/detector/aws_elasticache_cluster_invalid_parameter_group.go
@@ -8,21 +8,23 @@ import (
 
 type AwsElastiCacheClusterInvalidParameterGroupDetector struct {
 	*Detector
+	IssueType            string
+	Target               string
+	DeepCheck            bool
 	cacheParameterGroups map[string]bool
 }
 
 func (d *Detector) CreateAwsElastiCacheClusterInvalidParameterGroupDetector() *AwsElastiCacheClusterInvalidParameterGroupDetector {
 	return &AwsElastiCacheClusterInvalidParameterGroupDetector{
 		Detector:             d,
+		IssueType:            issue.ERROR,
+		Target:               "aws_elasticache_cluster",
+		DeepCheck:            true,
 		cacheParameterGroups: map[string]bool{},
 	}
 }
 
 func (d *AwsElastiCacheClusterInvalidParameterGroupDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_elasticache_cluster") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeCacheParameterGroups()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_elasticache_cluster_invalid_parameter_group.go
+++ b/detector/aws_elasticache_cluster_invalid_parameter_group.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
 )
 
@@ -37,29 +38,25 @@ func (d *AwsElastiCacheClusterInvalidParameterGroupDetector) PreProcess() {
 	}
 }
 
-func (d *AwsElastiCacheClusterInvalidParameterGroupDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_elasticache_cluster").Items {
-			parameterGroupToken, err := hclLiteralToken(item, "parameter_group_name")
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
-			parameterGroup, err := d.evalToString(parameterGroupToken.Text)
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
+func (d *AwsElastiCacheClusterInvalidParameterGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	parameterGroupToken, err := hclLiteralToken(item, "parameter_group_name")
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
+	parameterGroup, err := d.evalToString(parameterGroupToken.Text)
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
 
-			if !d.cacheParameterGroups[parameterGroup] {
-				issue := &issue.Issue{
-					Type:    "ERROR",
-					Message: fmt.Sprintf("\"%s\" is invalid parameter group name.", parameterGroup),
-					Line:    parameterGroupToken.Pos.Line,
-					File:    filename,
-				}
-				*issues = append(*issues, issue)
-			}
+	if !d.cacheParameterGroups[parameterGroup] {
+		issue := &issue.Issue{
+			Type:    d.IssueType,
+			Message: fmt.Sprintf("\"%s\" is invalid parameter group name.", parameterGroup),
+			Line:    parameterGroupToken.Pos.Line,
+			File:    file,
 		}
+		*issues = append(*issues, issue)
 	}
 }

--- a/detector/aws_elasticache_cluster_invalid_security_group.go
+++ b/detector/aws_elasticache_cluster_invalid_security_group.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/wata727/tflint/issue"
 )
@@ -38,44 +39,40 @@ func (d *AwsElastiCacheClusterInvalidSecurityGroupDetector) PreProcess() {
 	}
 }
 
-func (d *AwsElastiCacheClusterInvalidSecurityGroupDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_elasticache_cluster").Items {
-			var varToken token.Token
-			var securityGroupTokens []token.Token
-			var err error
-			if varToken, err = hclLiteralToken(item, "security_group_ids"); err == nil {
-				securityGroupTokens, err = d.evalToStringTokens(varToken)
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
-			} else {
-				d.Logger.Error(err)
-				securityGroupTokens, err = hclLiteralListToken(item, "security_group_ids")
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
-			}
+func (d *AwsElastiCacheClusterInvalidSecurityGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	var varToken token.Token
+	var securityGroupTokens []token.Token
+	var err error
+	if varToken, err = hclLiteralToken(item, "security_group_ids"); err == nil {
+		securityGroupTokens, err = d.evalToStringTokens(varToken)
+		if err != nil {
+			d.Logger.Error(err)
+			return
+		}
+	} else {
+		d.Logger.Error(err)
+		securityGroupTokens, err = hclLiteralListToken(item, "security_group_ids")
+		if err != nil {
+			d.Logger.Error(err)
+			return
+		}
+	}
 
-			for _, securityGroupToken := range securityGroupTokens {
-				securityGroup, err := d.evalToString(securityGroupToken.Text)
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
+	for _, securityGroupToken := range securityGroupTokens {
+		securityGroup, err := d.evalToString(securityGroupToken.Text)
+		if err != nil {
+			d.Logger.Error(err)
+			continue
+		}
 
-				if !d.securityGroups[securityGroup] {
-					issue := &issue.Issue{
-						Type:    "ERROR",
-						Message: fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
-						Line:    securityGroupToken.Pos.Line,
-						File:    filename,
-					}
-					*issues = append(*issues, issue)
-				}
+		if !d.securityGroups[securityGroup] {
+			issue := &issue.Issue{
+				Type:    d.IssueType,
+				Message: fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
+				Line:    securityGroupToken.Pos.Line,
+				File:    file,
 			}
+			*issues = append(*issues, issue)
 		}
 	}
 }

--- a/detector/aws_elasticache_cluster_invalid_security_group.go
+++ b/detector/aws_elasticache_cluster_invalid_security_group.go
@@ -9,21 +9,23 @@ import (
 
 type AwsElastiCacheClusterInvalidSecurityGroupDetector struct {
 	*Detector
+	IssueType      string
+	Target         string
+	DeepCheck      bool
 	securityGroups map[string]bool
 }
 
 func (d *Detector) CreateAwsElastiCacheClusterInvalidSecurityGroupDetector() *AwsElastiCacheClusterInvalidSecurityGroupDetector {
 	return &AwsElastiCacheClusterInvalidSecurityGroupDetector{
 		Detector:       d,
+		IssueType:      issue.ERROR,
+		Target:         "aws_elasticache_cluster",
+		DeepCheck:      true,
 		securityGroups: map[string]bool{},
 	}
 }
 
 func (d *AwsElastiCacheClusterInvalidSecurityGroupDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_elasticache_cluster") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeSecurityGroups()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_elasticache_cluster_invalid_subnet_group.go
+++ b/detector/aws_elasticache_cluster_invalid_subnet_group.go
@@ -8,21 +8,23 @@ import (
 
 type AwsElastiCacheClusterInvalidSubnetGroupDetector struct {
 	*Detector
+	IssueType         string
+	Target            string
+	DeepCheck         bool
 	cacheSubnetGroups map[string]bool
 }
 
 func (d *Detector) CreateAwsElastiCacheClusterInvalidSubnetGroupDetector() *AwsElastiCacheClusterInvalidSubnetGroupDetector {
 	return &AwsElastiCacheClusterInvalidSubnetGroupDetector{
 		Detector:          d,
+		IssueType:         issue.ERROR,
+		Target:            "aws_elasticache_cluster",
+		DeepCheck:         true,
 		cacheSubnetGroups: map[string]bool{},
 	}
 }
 
 func (d *AwsElastiCacheClusterInvalidSubnetGroupDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_elasticache_cluster") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeCacheSubnetGroups()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_elasticache_cluster_invalid_type.go
+++ b/detector/aws_elasticache_cluster_invalid_type.go
@@ -8,12 +8,18 @@ import (
 
 type AwsElastiCacheClusterInvalidTypeDetector struct {
 	*Detector
+	IssueType string
+	Target    string
+	DeepCheck bool
 	nodeTypes map[string]bool
 }
 
 func (d *Detector) CreateAwsElastiCacheClusterInvalidTypeDetector() *AwsElastiCacheClusterInvalidTypeDetector {
 	return &AwsElastiCacheClusterInvalidTypeDetector{
 		Detector:  d,
+		IssueType: issue.ERROR,
+		Target:    "aws_elasticache_cluster",
+		DeepCheck: false,
 		nodeTypes: map[string]bool{},
 	}
 }

--- a/detector/aws_elasticache_cluster_invalid_type.go
+++ b/detector/aws_elasticache_cluster_invalid_type.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
 )
 
@@ -55,29 +56,25 @@ func (d *AwsElastiCacheClusterInvalidTypeDetector) PreProcess() {
 	}
 }
 
-func (d *AwsElastiCacheClusterInvalidTypeDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_elasticache_cluster").Items {
-			nodeTypeToken, err := hclLiteralToken(item, "node_type")
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
-			nodeType, err := d.evalToString(nodeTypeToken.Text)
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
+func (d *AwsElastiCacheClusterInvalidTypeDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	nodeTypeToken, err := hclLiteralToken(item, "node_type")
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
+	nodeType, err := d.evalToString(nodeTypeToken.Text)
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
 
-			if !d.nodeTypes[nodeType] {
-				issue := &issue.Issue{
-					Type:    "ERROR",
-					Message: fmt.Sprintf("\"%s\" is invalid node type.", nodeType),
-					Line:    nodeTypeToken.Pos.Line,
-					File:    filename,
-				}
-				*issues = append(*issues, issue)
-			}
+	if !d.nodeTypes[nodeType] {
+		issue := &issue.Issue{
+			Type:    d.IssueType,
+			Message: fmt.Sprintf("\"%s\" is invalid node type.", nodeType),
+			Line:    nodeTypeToken.Pos.Line,
+			File:    file,
 		}
+		*issues = append(*issues, issue)
 	}
 }

--- a/detector/aws_elasticache_cluster_previous_type.go
+++ b/detector/aws_elasticache_cluster_previous_type.go
@@ -8,12 +8,18 @@ import (
 
 type AwsElastiCacheClusterPreviousTypeDetector struct {
 	*Detector
+	IssueType         string
+	Target            string
+	DeepCheck         bool
 	previousNodeTypes map[string]bool
 }
 
 func (d *Detector) CreateAwsElastiCacheClusterPreviousTypeDetector() *AwsElastiCacheClusterPreviousTypeDetector {
 	return &AwsElastiCacheClusterPreviousTypeDetector{
 		Detector:          d,
+		IssueType:         issue.WARNING,
+		Target:            "aws_elasticache_cluster",
+		DeepCheck:         false,
 		previousNodeTypes: map[string]bool{},
 	}
 }

--- a/detector/aws_elb_duplicate_name.go
+++ b/detector/aws_elb_duplicate_name.go
@@ -8,21 +8,23 @@ import (
 
 type AwsELBDuplicateNameDetector struct {
 	*Detector
+	IssueType     string
+	Target        string
+	DeepCheck     bool
 	loadBalancers map[string]bool
 }
 
 func (d *Detector) CreateAwsELBDuplicateNameDetector() *AwsELBDuplicateNameDetector {
 	return &AwsELBDuplicateNameDetector{
 		Detector:      d,
+		IssueType:     issue.ERROR,
+		Target:        "aws_elb",
+		DeepCheck:     true,
 		loadBalancers: map[string]bool{},
 	}
 }
 
 func (d *AwsELBDuplicateNameDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_elb") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeClassicLoadBalancers()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_elb_duplicate_name.go
+++ b/detector/aws_elb_duplicate_name.go
@@ -8,28 +8,34 @@ import (
 
 type AwsELBDuplicateNameDetector struct {
 	*Detector
+	loadBalancers map[string]bool
 }
 
 func (d *Detector) CreateAwsELBDuplicateNameDetector() *AwsELBDuplicateNameDetector {
-	return &AwsELBDuplicateNameDetector{d}
+	return &AwsELBDuplicateNameDetector{
+		Detector:      d,
+		loadBalancers: map[string]bool{},
+	}
 }
 
-func (d *AwsELBDuplicateNameDetector) Detect(issues *[]*issue.Issue) {
-	if !d.isDeepCheck("resource", "aws_elb") {
+func (d *AwsELBDuplicateNameDetector) PreProcess() {
+	if d.isSkippable("resource", "aws_elb") {
 		return
 	}
 
-	existLoadBalancerNames := map[string]bool{}
 	resp, err := d.AwsClient.DescribeClassicLoadBalancers()
 	if err != nil {
 		d.Logger.Error(err)
 		d.Error = true
 		return
 	}
-	for _, loadBalancer := range resp.LoadBalancerDescriptions {
-		existLoadBalancerNames[*loadBalancer.LoadBalancerName] = true
-	}
 
+	for _, loadBalancer := range resp.LoadBalancerDescriptions {
+		d.loadBalancers[*loadBalancer.LoadBalancerName] = true
+	}
+}
+
+func (d *AwsELBDuplicateNameDetector) Detect(issues *[]*issue.Issue) {
 	for filename, list := range d.ListMap {
 		for _, item := range list.Filter("resource", "aws_elb").Items {
 			nameToken, err := hclLiteralToken(item, "name")
@@ -43,7 +49,7 @@ func (d *AwsELBDuplicateNameDetector) Detect(issues *[]*issue.Issue) {
 				continue
 			}
 
-			if existLoadBalancerNames[name] && !d.State.Exists("aws_elb", hclObjectKeyText(item)) {
+			if d.loadBalancers[name] && !d.State.Exists("aws_elb", hclObjectKeyText(item)) {
 				issue := &issue.Issue{
 					Type:    "ERROR",
 					Message: fmt.Sprintf("\"%s\" is duplicate name. It must be unique.", name),

--- a/detector/aws_elb_invalid_instance.go
+++ b/detector/aws_elb_invalid_instance.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/wata727/tflint/issue"
 )
@@ -40,44 +41,40 @@ func (d *AwsELBInvalidInstanceDetector) PreProcess() {
 	}
 }
 
-func (d *AwsELBInvalidInstanceDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_elb").Items {
-			var varToken token.Token
-			var instanceTokens []token.Token
-			var err error
-			if varToken, err = hclLiteralToken(item, "instances"); err == nil {
-				instanceTokens, err = d.evalToStringTokens(varToken)
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
-			} else {
-				d.Logger.Error(err)
-				instanceTokens, err = hclLiteralListToken(item, "instances")
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
-			}
+func (d *AwsELBInvalidInstanceDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	var varToken token.Token
+	var instanceTokens []token.Token
+	var err error
+	if varToken, err = hclLiteralToken(item, "instances"); err == nil {
+		instanceTokens, err = d.evalToStringTokens(varToken)
+		if err != nil {
+			d.Logger.Error(err)
+			return
+		}
+	} else {
+		d.Logger.Error(err)
+		instanceTokens, err = hclLiteralListToken(item, "instances")
+		if err != nil {
+			d.Logger.Error(err)
+			return
+		}
+	}
 
-			for _, instanceToken := range instanceTokens {
-				instance, err := d.evalToString(instanceToken.Text)
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
+	for _, instanceToken := range instanceTokens {
+		instance, err := d.evalToString(instanceToken.Text)
+		if err != nil {
+			d.Logger.Error(err)
+			continue
+		}
 
-				if !d.instances[instance] {
-					issue := &issue.Issue{
-						Type:    "ERROR",
-						Message: fmt.Sprintf("\"%s\" is invalid instance.", instance),
-						Line:    instanceToken.Pos.Line,
-						File:    filename,
-					}
-					*issues = append(*issues, issue)
-				}
+		if !d.instances[instance] {
+			issue := &issue.Issue{
+				Type:    d.IssueType,
+				Message: fmt.Sprintf("\"%s\" is invalid instance.", instance),
+				Line:    instanceToken.Pos.Line,
+				File:    file,
 			}
+			*issues = append(*issues, issue)
 		}
 	}
 }

--- a/detector/aws_elb_invalid_instance.go
+++ b/detector/aws_elb_invalid_instance.go
@@ -9,21 +9,23 @@ import (
 
 type AwsELBInvalidInstanceDetector struct {
 	*Detector
+	IssueType string
+	Target    string
+	DeepCheck bool
 	instances map[string]bool
 }
 
 func (d *Detector) CreateAwsELBInvalidInstanceDetector() *AwsELBInvalidInstanceDetector {
 	return &AwsELBInvalidInstanceDetector{
 		Detector:  d,
+		IssueType: issue.ERROR,
+		Target:    "aws_elb",
+		DeepCheck: true,
 		instances: map[string]bool{},
 	}
 }
 
 func (d *AwsELBInvalidInstanceDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_elb") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeInstances()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_elb_invalid_security_group.go
+++ b/detector/aws_elb_invalid_security_group.go
@@ -9,21 +9,23 @@ import (
 
 type AwsELBInvalidSecurityGroupDetector struct {
 	*Detector
+	IssueType      string
+	Target         string
+	DeepCheck      bool
 	securityGroups map[string]bool
 }
 
 func (d *Detector) CreateAwsELBInvalidSecurityGroupDetector() *AwsELBInvalidSecurityGroupDetector {
 	return &AwsELBInvalidSecurityGroupDetector{
 		Detector:       d,
+		IssueType:      issue.ERROR,
+		Target:         "aws_elb",
+		DeepCheck:      true,
 		securityGroups: map[string]bool{},
 	}
 }
 
 func (d *AwsELBInvalidSecurityGroupDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_elb") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeSecurityGroups()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_elb_invalid_security_group.go
+++ b/detector/aws_elb_invalid_security_group.go
@@ -9,28 +9,34 @@ import (
 
 type AwsELBInvalidSecurityGroupDetector struct {
 	*Detector
+	securityGroups map[string]bool
 }
 
 func (d *Detector) CreateAwsELBInvalidSecurityGroupDetector() *AwsELBInvalidSecurityGroupDetector {
-	return &AwsELBInvalidSecurityGroupDetector{d}
+	return &AwsELBInvalidSecurityGroupDetector{
+		Detector:       d,
+		securityGroups: map[string]bool{},
+	}
 }
 
-func (d *AwsELBInvalidSecurityGroupDetector) Detect(issues *[]*issue.Issue) {
-	if !d.isDeepCheck("resource", "aws_elb") {
+func (d *AwsELBInvalidSecurityGroupDetector) PreProcess() {
+	if d.isSkippable("resource", "aws_elb") {
 		return
 	}
 
-	validSecurityGroups := map[string]bool{}
 	resp, err := d.AwsClient.DescribeSecurityGroups()
 	if err != nil {
 		d.Logger.Error(err)
 		d.Error = true
 		return
 	}
-	for _, securityGroup := range resp.SecurityGroups {
-		validSecurityGroups[*securityGroup.GroupId] = true
-	}
 
+	for _, securityGroup := range resp.SecurityGroups {
+		d.securityGroups[*securityGroup.GroupId] = true
+	}
+}
+
+func (d *AwsELBInvalidSecurityGroupDetector) Detect(issues *[]*issue.Issue) {
 	for filename, list := range d.ListMap {
 		for _, item := range list.Filter("resource", "aws_elb").Items {
 			var varToken token.Token
@@ -58,7 +64,7 @@ func (d *AwsELBInvalidSecurityGroupDetector) Detect(issues *[]*issue.Issue) {
 					continue
 				}
 
-				if !validSecurityGroups[securityGroup] {
+				if !d.securityGroups[securityGroup] {
 					issue := &issue.Issue{
 						Type:    "ERROR",
 						Message: fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),

--- a/detector/aws_elb_invalid_security_group.go
+++ b/detector/aws_elb_invalid_security_group.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/wata727/tflint/issue"
 )
@@ -38,44 +39,40 @@ func (d *AwsELBInvalidSecurityGroupDetector) PreProcess() {
 	}
 }
 
-func (d *AwsELBInvalidSecurityGroupDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_elb").Items {
-			var varToken token.Token
-			var securityGroupTokens []token.Token
-			var err error
-			if varToken, err = hclLiteralToken(item, "security_groups"); err == nil {
-				securityGroupTokens, err = d.evalToStringTokens(varToken)
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
-			} else {
-				d.Logger.Error(err)
-				securityGroupTokens, err = hclLiteralListToken(item, "security_groups")
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
-			}
+func (d *AwsELBInvalidSecurityGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	var varToken token.Token
+	var securityGroupTokens []token.Token
+	var err error
+	if varToken, err = hclLiteralToken(item, "security_groups"); err == nil {
+		securityGroupTokens, err = d.evalToStringTokens(varToken)
+		if err != nil {
+			d.Logger.Error(err)
+			return
+		}
+	} else {
+		d.Logger.Error(err)
+		securityGroupTokens, err = hclLiteralListToken(item, "security_groups")
+		if err != nil {
+			d.Logger.Error(err)
+			return
+		}
+	}
 
-			for _, securityGroupToken := range securityGroupTokens {
-				securityGroup, err := d.evalToString(securityGroupToken.Text)
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
+	for _, securityGroupToken := range securityGroupTokens {
+		securityGroup, err := d.evalToString(securityGroupToken.Text)
+		if err != nil {
+			d.Logger.Error(err)
+			continue
+		}
 
-				if !d.securityGroups[securityGroup] {
-					issue := &issue.Issue{
-						Type:    "ERROR",
-						Message: fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
-						Line:    securityGroupToken.Pos.Line,
-						File:    filename,
-					}
-					*issues = append(*issues, issue)
-				}
+		if !d.securityGroups[securityGroup] {
+			issue := &issue.Issue{
+				Type:    d.IssueType,
+				Message: fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
+				Line:    securityGroupToken.Pos.Line,
+				File:    file,
 			}
+			*issues = append(*issues, issue)
 		}
 	}
 }

--- a/detector/aws_elb_invalid_subnet.go
+++ b/detector/aws_elb_invalid_subnet.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/wata727/tflint/issue"
 )
@@ -38,44 +39,40 @@ func (d *AwsELBInvalidSubnetDetector) PreProcess() {
 	}
 }
 
-func (d *AwsELBInvalidSubnetDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_elb").Items {
-			var varToken token.Token
-			var subnetTokens []token.Token
-			var err error
-			if varToken, err = hclLiteralToken(item, "subnets"); err == nil {
-				subnetTokens, err = d.evalToStringTokens(varToken)
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
-			} else {
-				d.Logger.Error(err)
-				subnetTokens, err = hclLiteralListToken(item, "subnets")
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
-			}
+func (d *AwsELBInvalidSubnetDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	var varToken token.Token
+	var subnetTokens []token.Token
+	var err error
+	if varToken, err = hclLiteralToken(item, "subnets"); err == nil {
+		subnetTokens, err = d.evalToStringTokens(varToken)
+		if err != nil {
+			d.Logger.Error(err)
+			return
+		}
+	} else {
+		d.Logger.Error(err)
+		subnetTokens, err = hclLiteralListToken(item, "subnets")
+		if err != nil {
+			d.Logger.Error(err)
+			return
+		}
+	}
 
-			for _, subnetToken := range subnetTokens {
-				subnet, err := d.evalToString(subnetToken.Text)
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
+	for _, subnetToken := range subnetTokens {
+		subnet, err := d.evalToString(subnetToken.Text)
+		if err != nil {
+			d.Logger.Error(err)
+			continue
+		}
 
-				if !d.subnets[subnet] {
-					issue := &issue.Issue{
-						Type:    "ERROR",
-						Message: fmt.Sprintf("\"%s\" is invalid subnet ID.", subnet),
-						Line:    subnetToken.Pos.Line,
-						File:    filename,
-					}
-					*issues = append(*issues, issue)
-				}
+		if !d.subnets[subnet] {
+			issue := &issue.Issue{
+				Type:    d.IssueType,
+				Message: fmt.Sprintf("\"%s\" is invalid subnet ID.", subnet),
+				Line:    subnetToken.Pos.Line,
+				File:    file,
 			}
+			*issues = append(*issues, issue)
 		}
 	}
 }

--- a/detector/aws_elb_invalid_subnet.go
+++ b/detector/aws_elb_invalid_subnet.go
@@ -9,21 +9,23 @@ import (
 
 type AwsELBInvalidSubnetDetector struct {
 	*Detector
-	subnets map[string]bool
+	IssueType string
+	Target    string
+	DeepCheck bool
+	subnets   map[string]bool
 }
 
 func (d *Detector) CreateAwsELBInvalidSubnetDetector() *AwsELBInvalidSubnetDetector {
 	return &AwsELBInvalidSubnetDetector{
-		Detector: d,
-		subnets:  map[string]bool{},
+		Detector:  d,
+		IssueType: issue.ERROR,
+		Target:    "aws_elb",
+		DeepCheck: true,
+		subnets:   map[string]bool{},
 	}
 }
 
 func (d *AwsELBInvalidSubnetDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_elb") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeSubnets()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_instance_default_standard_volume.go
+++ b/detector/aws_instance_default_standard_volume.go
@@ -7,10 +7,18 @@ import (
 
 type AwsInstanceDefaultStandardVolumeDetector struct {
 	*Detector
+	IssueType string
+	Target    string
+	DeepCheck bool
 }
 
 func (d *Detector) CreateAwsInstanceDefaultStandardVolumeDetector() *AwsInstanceDefaultStandardVolumeDetector {
-	return &AwsInstanceDefaultStandardVolumeDetector{d}
+	return &AwsInstanceDefaultStandardVolumeDetector{
+		Detector:  d,
+		IssueType: issue.WARNING,
+		Target:    "aws_instance",
+		DeepCheck: false,
+	}
 }
 
 func (d *AwsInstanceDefaultStandardVolumeDetector) Detect(issues *[]*issue.Issue) {

--- a/detector/aws_instance_default_standard_volume.go
+++ b/detector/aws_instance_default_standard_volume.go
@@ -21,16 +21,12 @@ func (d *Detector) CreateAwsInstanceDefaultStandardVolumeDetector() *AwsInstance
 	}
 }
 
-func (d *AwsInstanceDefaultStandardVolumeDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_instance").Items {
-			d.detectForBlockDevices(issues, item, filename, "root_block_device")
-			d.detectForBlockDevices(issues, item, filename, "ebs_block_device")
-		}
-	}
+func (d *AwsInstanceDefaultStandardVolumeDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	d.detectForBlockDevices(issues, item, file, "root_block_device")
+	d.detectForBlockDevices(issues, item, file, "ebs_block_device")
 }
 
-func (d *AwsInstanceDefaultStandardVolumeDetector) detectForBlockDevices(issues *[]*issue.Issue, item *ast.ObjectItem, filename string, device string) {
+func (d *AwsInstanceDefaultStandardVolumeDetector) detectForBlockDevices(issues *[]*issue.Issue, item *ast.ObjectItem, file string, device string) {
 	if !IsKeyNotFound(item, device) {
 		deviceItems, err := hclObjectItems(item, device)
 		if err != nil {
@@ -41,10 +37,10 @@ func (d *AwsInstanceDefaultStandardVolumeDetector) detectForBlockDevices(issues 
 		for _, deviceItem := range deviceItems {
 			if IsKeyNotFound(deviceItem, "volume_type") {
 				issue := &issue.Issue{
-					Type:    "WARNING",
+					Type:    d.IssueType,
 					Message: "\"volume_type\" is not specified. Default standard volume type is not recommended. You can use \"gp2\", \"io1\", etc instead.",
 					Line:    deviceItem.Assign.Line,
-					File:    filename,
+					File:    file,
 				}
 				*issues = append(*issues, issue)
 			}

--- a/detector/aws_instance_invalid_ami.go
+++ b/detector/aws_instance_invalid_ami.go
@@ -8,21 +8,23 @@ import (
 
 type AwsInstanceInvalidAMIDetector struct {
 	*Detector
-	amis map[string]bool
+	IssueType string
+	Target    string
+	DeepCheck bool
+	amis      map[string]bool
 }
 
 func (d *Detector) CreateAwsInstanceInvalidAMIDetector() *AwsInstanceInvalidAMIDetector {
 	return &AwsInstanceInvalidAMIDetector{
-		Detector: d,
-		amis:     map[string]bool{},
+		Detector:  d,
+		IssueType: issue.ERROR,
+		Target:    "aws_instance",
+		DeepCheck: true,
+		amis:      map[string]bool{},
 	}
 }
 
 func (d *AwsInstanceInvalidAMIDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_instance") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeImages()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_instance_invalid_ami.go
+++ b/detector/aws_instance_invalid_ami.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
 )
 
@@ -37,29 +38,25 @@ func (d *AwsInstanceInvalidAMIDetector) PreProcess() {
 	}
 }
 
-func (d *AwsInstanceInvalidAMIDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_instance").Items {
-			amiToken, err := hclLiteralToken(item, "ami")
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
-			ami, err := d.evalToString(amiToken.Text)
-			if err != nil {
-				d.Logger.Error(err)
-				continue
-			}
+func (d *AwsInstanceInvalidAMIDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	amiToken, err := hclLiteralToken(item, "ami")
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
+	ami, err := d.evalToString(amiToken.Text)
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
 
-			if !d.amis[ami] {
-				issue := &issue.Issue{
-					Type:    "ERROR",
-					Message: fmt.Sprintf("\"%s\" is invalid AMI.", ami),
-					Line:    amiToken.Pos.Line,
-					File:    filename,
-				}
-				*issues = append(*issues, issue)
-			}
+	if !d.amis[ami] {
+		issue := &issue.Issue{
+			Type:    d.IssueType,
+			Message: fmt.Sprintf("\"%s\" is invalid AMI.", ami),
+			Line:    amiToken.Pos.Line,
+			File:    file,
 		}
+		*issues = append(*issues, issue)
 	}
 }

--- a/detector/aws_instance_invalid_iam_profile.go
+++ b/detector/aws_instance_invalid_iam_profile.go
@@ -8,28 +8,34 @@ import (
 
 type AwsInstanceInvalidIAMProfileDetector struct {
 	*Detector
+	profiles map[string]bool
 }
 
 func (d *Detector) CreateAwsInstanceInvalidIAMProfileDetector() *AwsInstanceInvalidIAMProfileDetector {
-	return &AwsInstanceInvalidIAMProfileDetector{d}
+	return &AwsInstanceInvalidIAMProfileDetector{
+		Detector: d,
+		profiles: map[string]bool{},
+	}
 }
 
-func (d *AwsInstanceInvalidIAMProfileDetector) Detect(issues *[]*issue.Issue) {
-	if !d.isDeepCheck("resource", "aws_instance") {
+func (d *AwsInstanceInvalidIAMProfileDetector) PreProcess() {
+	if d.isSkippable("resource", "aws_instance") {
 		return
 	}
 
-	validIamProfiles := map[string]bool{}
 	resp, err := d.AwsClient.ListInstanceProfiles()
 	if err != nil {
 		d.Logger.Error(err)
 		d.Error = true
 		return
 	}
-	for _, iamProfile := range resp.InstanceProfiles {
-		validIamProfiles[*iamProfile.InstanceProfileName] = true
-	}
 
+	for _, iamProfile := range resp.InstanceProfiles {
+		d.profiles[*iamProfile.InstanceProfileName] = true
+	}
+}
+
+func (d *AwsInstanceInvalidIAMProfileDetector) Detect(issues *[]*issue.Issue) {
 	for filename, list := range d.ListMap {
 		for _, item := range list.Filter("resource", "aws_instance").Items {
 			iamProfileToken, err := hclLiteralToken(item, "iam_instance_profile")
@@ -43,7 +49,7 @@ func (d *AwsInstanceInvalidIAMProfileDetector) Detect(issues *[]*issue.Issue) {
 				continue
 			}
 
-			if !validIamProfiles[iamProfile] {
+			if !d.profiles[iamProfile] {
 				issue := &issue.Issue{
 					Type:    "ERROR",
 					Message: fmt.Sprintf("\"%s\" is invalid IAM profile name.", iamProfile),

--- a/detector/aws_instance_invalid_iam_profile.go
+++ b/detector/aws_instance_invalid_iam_profile.go
@@ -8,21 +8,23 @@ import (
 
 type AwsInstanceInvalidIAMProfileDetector struct {
 	*Detector
-	profiles map[string]bool
+	IssueType string
+	Target    string
+	DeepCheck bool
+	profiles  map[string]bool
 }
 
 func (d *Detector) CreateAwsInstanceInvalidIAMProfileDetector() *AwsInstanceInvalidIAMProfileDetector {
 	return &AwsInstanceInvalidIAMProfileDetector{
-		Detector: d,
-		profiles: map[string]bool{},
+		Detector:  d,
+		IssueType: issue.ERROR,
+		Target:    "aws_instance",
+		DeepCheck: true,
+		profiles:  map[string]bool{},
 	}
 }
 
 func (d *AwsInstanceInvalidIAMProfileDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_instance") {
-		return
-	}
-
 	resp, err := d.AwsClient.ListInstanceProfiles()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_instance_invalid_key_name.go
+++ b/detector/aws_instance_invalid_key_name.go
@@ -8,21 +8,23 @@ import (
 
 type AwsInstanceInvalidKeyNameDetector struct {
 	*Detector
-	keypairs map[string]bool
+	IssueType string
+	Target    string
+	DeepCheck bool
+	keypairs  map[string]bool
 }
 
 func (d *Detector) CreateAwsInstanceInvalidKeyNameDetector() *AwsInstanceInvalidKeyNameDetector {
 	return &AwsInstanceInvalidKeyNameDetector{
-		Detector: d,
-		keypairs: map[string]bool{},
+		Detector:  d,
+		IssueType: issue.ERROR,
+		Target:    "aws_instance",
+		DeepCheck: true,
+		keypairs:  map[string]bool{},
 	}
 }
 
 func (d *AwsInstanceInvalidKeyNameDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_instance") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeKeyPairs()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_instance_invalid_subnet.go
+++ b/detector/aws_instance_invalid_subnet.go
@@ -8,21 +8,23 @@ import (
 
 type AwsInstanceInvalidSubnetDetector struct {
 	*Detector
-	subnets map[string]bool
+	IssueType string
+	Target    string
+	DeepCheck bool
+	subnets   map[string]bool
 }
 
 func (d *Detector) CreateAwsInstanceInvalidSubnetDetector() *AwsInstanceInvalidSubnetDetector {
 	return &AwsInstanceInvalidSubnetDetector{
-		Detector: d,
-		subnets:  map[string]bool{},
+		Detector:  d,
+		IssueType: issue.ERROR,
+		Target:    "aws_instance",
+		DeepCheck: true,
+		subnets:   map[string]bool{},
 	}
 }
 
 func (d *AwsInstanceInvalidSubnetDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_instance") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeSubnets()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_instance_invalid_type.go
+++ b/detector/aws_instance_invalid_type.go
@@ -8,12 +8,18 @@ import (
 
 type AwsInstanceInvalidTypeDetector struct {
 	*Detector
+	IssueType     string
+	Target        string
+	DeepCheck     bool
 	instanceTypes map[string]bool
 }
 
 func (d *Detector) CreateAwsInstanceInvalidTypeDetector() *AwsInstanceInvalidTypeDetector {
 	return &AwsInstanceInvalidTypeDetector{
 		Detector:      d,
+		IssueType:     issue.ERROR,
+		Target:        "aws_instance",
+		DeepCheck:     false,
 		instanceTypes: map[string]bool{},
 	}
 }

--- a/detector/aws_instance_invalid_vpc_security_group.go
+++ b/detector/aws_instance_invalid_vpc_security_group.go
@@ -9,21 +9,23 @@ import (
 
 type AwsInstanceInvalidVPCSecurityGroupDetector struct {
 	*Detector
+	IssueType      string
+	Target         string
+	DeepCheck      bool
 	securityGroups map[string]bool
 }
 
 func (d *Detector) CreateAwsInstanceInvalidVPCSecurityGroupDetector() *AwsInstanceInvalidVPCSecurityGroupDetector {
 	return &AwsInstanceInvalidVPCSecurityGroupDetector{
 		Detector:       d,
+		IssueType:      issue.ERROR,
+		Target:         "aws_instance",
+		DeepCheck:      true,
 		securityGroups: map[string]bool{},
 	}
 }
 
 func (d *AwsInstanceInvalidVPCSecurityGroupDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_instance") {
-		return
-	}
-
 	resp, err := d.AwsClient.DescribeSecurityGroups()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_instance_invalid_vpc_security_group.go
+++ b/detector/aws_instance_invalid_vpc_security_group.go
@@ -3,6 +3,7 @@ package detector
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/wata727/tflint/issue"
 )
@@ -38,44 +39,40 @@ func (d *AwsInstanceInvalidVPCSecurityGroupDetector) PreProcess() {
 	}
 }
 
-func (d *AwsInstanceInvalidVPCSecurityGroupDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_instance").Items {
-			var varToken token.Token
-			var securityGroupTokens []token.Token
-			var err error
-			if varToken, err = hclLiteralToken(item, "vpc_security_group_ids"); err == nil {
-				securityGroupTokens, err = d.evalToStringTokens(varToken)
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
-			} else {
-				d.Logger.Error(err)
-				securityGroupTokens, err = hclLiteralListToken(item, "vpc_security_group_ids")
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
-			}
+func (d *AwsInstanceInvalidVPCSecurityGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	var varToken token.Token
+	var securityGroupTokens []token.Token
+	var err error
+	if varToken, err = hclLiteralToken(item, "vpc_security_group_ids"); err == nil {
+		securityGroupTokens, err = d.evalToStringTokens(varToken)
+		if err != nil {
+			d.Logger.Error(err)
+			return
+		}
+	} else {
+		d.Logger.Error(err)
+		securityGroupTokens, err = hclLiteralListToken(item, "vpc_security_group_ids")
+		if err != nil {
+			d.Logger.Error(err)
+			return
+		}
+	}
 
-			for _, securityGroupToken := range securityGroupTokens {
-				securityGroup, err := d.evalToString(securityGroupToken.Text)
-				if err != nil {
-					d.Logger.Error(err)
-					continue
-				}
+	for _, securityGroupToken := range securityGroupTokens {
+		securityGroup, err := d.evalToString(securityGroupToken.Text)
+		if err != nil {
+			d.Logger.Error(err)
+			continue
+		}
 
-				if !d.securityGroups[securityGroup] {
-					issue := &issue.Issue{
-						Type:    "ERROR",
-						Message: fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
-						Line:    securityGroupToken.Pos.Line,
-						File:    filename,
-					}
-					*issues = append(*issues, issue)
-				}
+		if !d.securityGroups[securityGroup] {
+			issue := &issue.Issue{
+				Type:    d.IssueType,
+				Message: fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
+				Line:    securityGroupToken.Pos.Line,
+				File:    file,
 			}
+			*issues = append(*issues, issue)
 		}
 	}
 }

--- a/detector/aws_instance_invalid_vpc_security_group.go
+++ b/detector/aws_instance_invalid_vpc_security_group.go
@@ -9,28 +9,34 @@ import (
 
 type AwsInstanceInvalidVPCSecurityGroupDetector struct {
 	*Detector
+	securityGroups map[string]bool
 }
 
 func (d *Detector) CreateAwsInstanceInvalidVPCSecurityGroupDetector() *AwsInstanceInvalidVPCSecurityGroupDetector {
-	return &AwsInstanceInvalidVPCSecurityGroupDetector{d}
+	return &AwsInstanceInvalidVPCSecurityGroupDetector{
+		Detector:       d,
+		securityGroups: map[string]bool{},
+	}
 }
 
-func (d *AwsInstanceInvalidVPCSecurityGroupDetector) Detect(issues *[]*issue.Issue) {
-	if !d.isDeepCheck("resource", "aws_instance") {
+func (d *AwsInstanceInvalidVPCSecurityGroupDetector) PreProcess() {
+	if d.isSkippable("resource", "aws_instance") {
 		return
 	}
 
-	validSecurityGroups := map[string]bool{}
 	resp, err := d.AwsClient.DescribeSecurityGroups()
 	if err != nil {
 		d.Logger.Error(err)
 		d.Error = true
 		return
 	}
-	for _, securityGroup := range resp.SecurityGroups {
-		validSecurityGroups[*securityGroup.GroupId] = true
-	}
 
+	for _, securityGroup := range resp.SecurityGroups {
+		d.securityGroups[*securityGroup.GroupId] = true
+	}
+}
+
+func (d *AwsInstanceInvalidVPCSecurityGroupDetector) Detect(issues *[]*issue.Issue) {
 	for filename, list := range d.ListMap {
 		for _, item := range list.Filter("resource", "aws_instance").Items {
 			var varToken token.Token
@@ -58,7 +64,7 @@ func (d *AwsInstanceInvalidVPCSecurityGroupDetector) Detect(issues *[]*issue.Iss
 					continue
 				}
 
-				if !validSecurityGroups[securityGroup] {
+				if !d.securityGroups[securityGroup] {
 					issue := &issue.Issue{
 						Type:    "ERROR",
 						Message: fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),

--- a/detector/aws_instance_not_specified_iam_profile.go
+++ b/detector/aws_instance_not_specified_iam_profile.go
@@ -1,6 +1,9 @@
 package detector
 
-import "github.com/wata727/tflint/issue"
+import (
+	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/wata727/tflint/issue"
+)
 
 type AwsInstanceNotSpecifiedIAMProfileDetector struct {
 	*Detector
@@ -18,18 +21,14 @@ func (d *Detector) CreateAwsInstanceNotSpecifiedIAMProfileDetector() *AwsInstanc
 	}
 }
 
-func (d *AwsInstanceNotSpecifiedIAMProfileDetector) Detect(issues *[]*issue.Issue) {
-	for filename, list := range d.ListMap {
-		for _, item := range list.Filter("resource", "aws_instance").Items {
-			if IsKeyNotFound(item, "iam_instance_profile") {
-				issue := &issue.Issue{
-					Type:    "NOTICE",
-					Message: "\"iam_instance_profile\" is not specified. If you want to change it, you need to recreate it",
-					Line:    item.Pos().Line,
-					File:    filename,
-				}
-				*issues = append(*issues, issue)
-			}
+func (d *AwsInstanceNotSpecifiedIAMProfileDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	if IsKeyNotFound(item, "iam_instance_profile") {
+		issue := &issue.Issue{
+			Type:    d.IssueType,
+			Message: "\"iam_instance_profile\" is not specified. If you want to change it, you need to recreate it",
+			Line:    item.Pos().Line,
+			File:    file,
 		}
+		*issues = append(*issues, issue)
 	}
 }

--- a/detector/aws_instance_not_specified_iam_profile.go
+++ b/detector/aws_instance_not_specified_iam_profile.go
@@ -4,10 +4,18 @@ import "github.com/wata727/tflint/issue"
 
 type AwsInstanceNotSpecifiedIAMProfileDetector struct {
 	*Detector
+	IssueType string
+	Target    string
+	DeepCheck bool
 }
 
 func (d *Detector) CreateAwsInstanceNotSpecifiedIAMProfileDetector() *AwsInstanceNotSpecifiedIAMProfileDetector {
-	return &AwsInstanceNotSpecifiedIAMProfileDetector{d}
+	return &AwsInstanceNotSpecifiedIAMProfileDetector{
+		Detector:  d,
+		IssueType: issue.NOTICE,
+		Target:    "aws_instance",
+		DeepCheck: false,
+	}
 }
 
 func (d *AwsInstanceNotSpecifiedIAMProfileDetector) Detect(issues *[]*issue.Issue) {

--- a/detector/aws_instance_not_specified_iam_profile.go
+++ b/detector/aws_instance_not_specified_iam_profile.go
@@ -25,7 +25,3 @@ func (d *AwsInstanceNotSpecifiedIAMProfileDetector) Detect(issues *[]*issue.Issu
 		}
 	}
 }
-
-func (d *AwsInstanceNotSpecifiedIAMProfileDetector) Inherit(original *AwsInstanceNotSpecifiedIAMProfileDetector) *AwsInstanceNotSpecifiedIAMProfileDetector {
-	return original
-}

--- a/detector/aws_instance_previous_type.go
+++ b/detector/aws_instance_previous_type.go
@@ -8,12 +8,18 @@ import (
 
 type AwsInstancePreviousTypeDetector struct {
 	*Detector
+	IssueType             string
+	Target                string
+	DeepCheck             bool
 	previousInstanceTypes map[string]bool
 }
 
 func (d *Detector) CreateAwsInstancePreviousTypeDetector() *AwsInstancePreviousTypeDetector {
 	return &AwsInstancePreviousTypeDetector{
 		Detector:              d,
+		IssueType:             issue.WARNING,
+		Target:                "aws_instance",
+		DeepCheck:             false,
 		previousInstanceTypes: map[string]bool{},
 	}
 }

--- a/detector/aws_security_group_duplicate_name.go
+++ b/detector/aws_security_group_duplicate_name.go
@@ -9,6 +9,9 @@ import (
 
 type AwsSecurityGroupDuplicateDetector struct {
 	*Detector
+	IssueType     string
+	Target        string
+	DeepCheck     bool
 	securiyGroups map[string]bool
 	defaultVpc    string
 }
@@ -16,16 +19,15 @@ type AwsSecurityGroupDuplicateDetector struct {
 func (d *Detector) CreateAwsSecurityGroupDuplicateDetector() *AwsSecurityGroupDuplicateDetector {
 	return &AwsSecurityGroupDuplicateDetector{
 		Detector:      d,
+		IssueType:     issue.ERROR,
+		Target:        "aws_security_group",
+		DeepCheck:     true,
 		securiyGroups: map[string]bool{},
 		defaultVpc:    "",
 	}
 }
 
 func (d *AwsSecurityGroupDuplicateDetector) PreProcess() {
-	if d.isSkippable("resource", "aws_security_group") {
-		return
-	}
-
 	securityGroupsResp, err := d.AwsClient.DescribeSecurityGroups()
 	if err != nil {
 		d.Logger.Error(err)

--- a/detector/aws_security_group_duplicate_name_test.go
+++ b/detector/aws_security_group_duplicate_name_test.go
@@ -39,6 +39,12 @@ resource "aws_security_group" "test" {
 					VpcId:     aws.String("vpc-1234abcd"),
 				},
 			},
+			Vpcs: []*ec2.Vpc{
+				&ec2.Vpc{
+					VpcId:     aws.String("vpc-1234abcd"),
+					IsDefault: aws.Bool(true),
+				},
+			},
 			Issues: []*issue.Issue{
 				&issue.Issue{
 					Type:    "ERROR",
@@ -65,6 +71,12 @@ resource "aws_security_group" "test" {
 					VpcId:     aws.String("vpc-1234abcd"),
 				},
 			},
+			Vpcs: []*ec2.Vpc{
+				&ec2.Vpc{
+					VpcId:     aws.String("vpc-1234abcd"),
+					IsDefault: aws.Bool(true),
+				},
+			},
 			Issues: []*issue.Issue{},
 		},
 		{
@@ -82,6 +94,12 @@ resource "aws_security_group" "test" {
 				&ec2.SecurityGroup{
 					GroupName: aws.String("custom"),
 					VpcId:     aws.String("vpc-abcd1234"),
+				},
+			},
+			Vpcs: []*ec2.Vpc{
+				&ec2.Vpc{
+					VpcId:     aws.String("vpc-1234abcd"),
+					IsDefault: aws.Bool(true),
 				},
 			},
 			Issues: []*issue.Issue{},
@@ -189,6 +207,12 @@ resource "aws_security_group" "test" {
 					VpcId:     aws.String("vpc-1234abcd"),
 				},
 			},
+			Vpcs: []*ec2.Vpc{
+				&ec2.Vpc{
+					VpcId:     aws.String("vpc-1234abcd"),
+					IsDefault: aws.Bool(true),
+				},
+			},
 			Issues: []*issue.Issue{},
 		},
 	}
@@ -204,11 +228,9 @@ resource "aws_security_group" "test" {
 		ec2mock.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{}).Return(&ec2.DescribeSecurityGroupsOutput{
 			SecurityGroups: tc.SecurityGroups,
 		}, nil)
-		if tc.Vpcs != nil {
-			ec2mock.EXPECT().DescribeVpcs(&ec2.DescribeVpcsInput{}).Return(&ec2.DescribeVpcsOutput{
-				Vpcs: tc.Vpcs,
-			}, nil)
-		}
+		ec2mock.EXPECT().DescribeVpcs(&ec2.DescribeVpcsInput{}).Return(&ec2.DescribeVpcsOutput{
+			Vpcs: tc.Vpcs,
+		}, nil)
 		awsClient.Ec2 = ec2mock
 
 		var issues = []*issue.Issue{}

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -143,6 +143,11 @@ func (d *Detector) Detect() []*issue.Issue {
 		d.Logger.Info(fmt.Sprintf("detect by `%s`", ruleName))
 		creator := reflect.ValueOf(d).MethodByName(creatorMethod)
 		detector := creator.Call([]reflect.Value{})[0]
+
+		if reflect.Indirect(detector).FieldByName("DeepCheck").Bool() && !d.Config.DeepCheck {
+			d.Logger.Info("skip this rule.")
+			continue
+		}
 		if preprocess := detector.MethodByName("PreProcess"); preprocess.IsValid() {
 			preprocess.Call([]reflect.Value{})
 		}
@@ -166,6 +171,11 @@ func (d *Detector) Detect() []*issue.Issue {
 			moduleDetector.Error = d.Error
 			creator := reflect.ValueOf(moduleDetector).MethodByName(creatorMethod)
 			detector := creator.Call([]reflect.Value{})[0]
+
+			if reflect.Indirect(detector).FieldByName("DeepCheck").Bool() && !d.Config.DeepCheck {
+				d.Logger.Info("skip this rule.")
+				continue
+			}
 			if preprocess := detector.MethodByName("PreProcess"); preprocess.IsValid() {
 				preprocess.Call([]reflect.Value{})
 			}

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -151,8 +151,16 @@ func (d *Detector) Detect() []*issue.Issue {
 		if preprocess := detector.MethodByName("PreProcess"); preprocess.IsValid() {
 			preprocess.Call([]reflect.Value{})
 		}
-		detect := detector.MethodByName("Detect")
-		detect.Call([]reflect.Value{reflect.ValueOf(&issues)})
+		for file, list := range d.ListMap {
+			for _, item := range list.Filter("resource", reflect.Indirect(detector).FieldByName("Target").String()).Items {
+				detect := detector.MethodByName("Detect")
+				detect.Call([]reflect.Value{
+					reflect.ValueOf(file),
+					reflect.ValueOf(item),
+					reflect.ValueOf(&issues),
+				})
+			}
+		}
 
 		for name, m := range modules {
 			if d.Config.IgnoreModule[m.Source] {
@@ -179,8 +187,16 @@ func (d *Detector) Detect() []*issue.Issue {
 			if preprocess := detector.MethodByName("PreProcess"); preprocess.IsValid() {
 				preprocess.Call([]reflect.Value{})
 			}
-			detect := detector.MethodByName("Detect")
-			detect.Call([]reflect.Value{reflect.ValueOf(&issues)})
+			for file, list := range d.ListMap {
+				for _, item := range list.Filter("resource", reflect.Indirect(detector).FieldByName("Target").String()).Items {
+					detect := detector.MethodByName("Detect")
+					detect.Call([]reflect.Value{
+						reflect.ValueOf(file),
+						reflect.ValueOf(item),
+						reflect.ValueOf(&issues),
+					})
+				}
+			}
 		}
 	}
 

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -65,6 +65,8 @@ func TestDetect(t *testing.T) {
 
 		listMap := make(map[string]*ast.ObjectList)
 		root, _ := parser.Parse([]byte(`
+resource "aws_instance" {}
+
 module "ec2_instance" {
     source = "./tf_aws_ec2_instance"
     ami = "ami-12345"
@@ -686,11 +688,12 @@ variable "array" {
 	}
 }
 
-func TestIsSkippable(t *testing.T) {
+func TestIsSkip(t *testing.T) {
 	type Input struct {
-		File      string
-		DeepCheck bool
-		Resources []string
+		File              string
+		DeepCheckMode     bool
+		DeepCheckDetector bool
+		Target            string
 	}
 
 	cases := []struct {
@@ -705,8 +708,9 @@ func TestIsSkippable(t *testing.T) {
 resource "aws_instance" {
     ami = "ami-12345"
 }`,
-				DeepCheck: true,
-				Resources: []string{"resource", "aws_instance"},
+				DeepCheckMode:     true,
+				DeepCheckDetector: true,
+				Target:            "aws_instance",
 			},
 			Result: false,
 		},
@@ -717,10 +721,37 @@ resource "aws_instance" {
 resource "aws_instance" {
     ami = "ami-12345"
 }`,
-				DeepCheck: false,
-				Resources: []string{"resource", "aws_instance"},
+				DeepCheckMode:     false,
+				DeepCheckDetector: true,
+				Target:            "aws_instance",
 			},
 			Result: true,
+		},
+		{
+			Name: "return false when disabled deep checking but not deep check detector",
+			Input: Input{
+				File: `
+resource "aws_instance" {
+    ami = "ami-12345"
+}`,
+				DeepCheckMode:     false,
+				DeepCheckDetector: false,
+				Target:            "aws_instance",
+			},
+			Result: false,
+		},
+		{
+			Name: "return false when enabled deep checking and not deep check detector",
+			Input: Input{
+				File: `
+resource "aws_instance" {
+    ami = "ami-12345"
+}`,
+				DeepCheckMode:     true,
+				DeepCheckDetector: false,
+				Target:            "aws_instance",
+			},
+			Result: false,
 		},
 		{
 			Name: "return true when target resources are not found",
@@ -729,8 +760,9 @@ resource "aws_instance" {
 resource "aws_instance" {
     ami = "ami-12345"
 }`,
-				DeepCheck: true,
-				Resources: []string{"resource", "not_found"},
+				DeepCheckMode:     true,
+				DeepCheckDetector: true,
+				Target:            "aws_db_instance",
 			},
 			Result: true,
 		},
@@ -747,9 +779,9 @@ resource "aws_instance" {
 			Config:  config.Init(),
 			Logger:  logger.Init(false),
 		}
-		d.Config.DeepCheck = tc.Input.DeepCheck
+		d.Config.DeepCheck = tc.Input.DeepCheckMode
 
-		result := d.isSkippable(tc.Input.Resources...)
+		result := d.isSkip(tc.Input.DeepCheckDetector, tc.Input.Target)
 		if result != tc.Result {
 			t.Fatalf("\nBad: %t\nExpected: %t\n\ntestcase: %s", result, tc.Result, tc.Name)
 		}

--- a/detector/detector_test.go
+++ b/detector/detector_test.go
@@ -686,7 +686,7 @@ variable "array" {
 	}
 }
 
-func TestIsDeepCheck(t *testing.T) {
+func TestIsSkippable(t *testing.T) {
 	type Input struct {
 		File      string
 		DeepCheck bool
@@ -699,7 +699,7 @@ func TestIsDeepCheck(t *testing.T) {
 		Result bool
 	}{
 		{
-			Name: "return true when enabled deep checking",
+			Name: "return false when enabled deep checking",
 			Input: Input{
 				File: `
 resource "aws_instance" {
@@ -708,10 +708,10 @@ resource "aws_instance" {
 				DeepCheck: true,
 				Resources: []string{"resource", "aws_instance"},
 			},
-			Result: true,
+			Result: false,
 		},
 		{
-			Name: "return false when disabled deep checking",
+			Name: "return true when disabled deep checking",
 			Input: Input{
 				File: `
 resource "aws_instance" {
@@ -720,10 +720,10 @@ resource "aws_instance" {
 				DeepCheck: false,
 				Resources: []string{"resource", "aws_instance"},
 			},
-			Result: false,
+			Result: true,
 		},
 		{
-			Name: "return false when target resources are not found",
+			Name: "return true when target resources are not found",
 			Input: Input{
 				File: `
 resource "aws_instance" {
@@ -732,7 +732,7 @@ resource "aws_instance" {
 				DeepCheck: true,
 				Resources: []string{"resource", "not_found"},
 			},
-			Result: false,
+			Result: true,
 		},
 	}
 
@@ -749,7 +749,7 @@ resource "aws_instance" {
 		}
 		d.Config.DeepCheck = tc.Input.DeepCheck
 
-		result := d.isDeepCheck(tc.Input.Resources...)
+		result := d.isSkippable(tc.Input.Resources...)
 		if result != tc.Result {
 			t.Fatalf("\nBad: %t\nExpected: %t\n\ntestcase: %s", result, tc.Result, tc.Name)
 		}

--- a/detector/test-fixtures/.terraform/modules/0cf2d4dab02de8de33c7058799b6f81e/template.tf
+++ b/detector/test-fixtures/.terraform/modules/0cf2d4dab02de8de33c7058799b6f81e/template.tf
@@ -1,0 +1,1 @@
+resource "aws_instance" "web" {}

--- a/detector/test-fixtures/.terraform/modules/960d94c2f60d34845dc3051edfad76e1/template.tf
+++ b/detector/test-fixtures/.terraform/modules/960d94c2f60d34845dc3051edfad76e1/template.tf
@@ -1,0 +1,1 @@
+resource "aws_instance" "web" {}

--- a/detector/test_helper.go
+++ b/detector/test_helper.go
@@ -53,7 +53,10 @@ func TestDetectByCreatorName(creatorMethod string, src string, stateJSON string,
 	}).MethodByName(creatorMethod)
 	detector := creator.Call([]reflect.Value{})[0]
 
-	method := detector.MethodByName("Detect")
-	method.Call([]reflect.Value{reflect.ValueOf(issues)})
+	if preprocess := detector.MethodByName("PreProcess"); preprocess.IsValid() {
+		preprocess.Call([]reflect.Value{})
+	}
+	detect := detector.MethodByName("Detect")
+	detect.Call([]reflect.Value{reflect.ValueOf(issues)})
 	return nil
 }

--- a/detector/test_helper.go
+++ b/detector/test_helper.go
@@ -16,10 +16,18 @@ import (
 
 type TestDetector struct {
 	*Detector
+	IssueType string
+	Target    string
+	DeepCheck bool
 }
 
 func (d *Detector) CreateTestDetector() *TestDetector {
-	return &TestDetector{d}
+	return &TestDetector{
+		Detector:  d,
+		IssueType: "TEST",
+		Target:    "aws_instance",
+		DeepCheck: false,
+	}
 }
 
 func (d *TestDetector) Detect(issues *[]*issue.Issue) {

--- a/issue/issue.go
+++ b/issue/issue.go
@@ -7,6 +7,10 @@ type Issue struct {
 	File    string `json:"file"`
 }
 
+const ERROR = "ERROR"
+const WARNING = "WARNING"
+const NOTICE = "NOTICE"
+
 type Issues []*Issue
 
 func (is Issues) Len() int      { return len(is) }


### PR DESCRIPTION
This PR includes three changes.

## Introduce `PreProcess` step
For example, to detect invalid references, TFLint needs to call AWS API. However, this process is not detection. We should give a different process name like the `PreProcess`.
In `PreProcess` step,  It does not need AST, although it is necessary for detection.

## Embed deep check etc
If disabled deep check mode, ignore some deep check detectors. This logic is outside the each detectors by embedding as attributes value of detector.

## Simplify `Detect` method
Simplify `Detect` method by putting resource iterations out.
