### PR TITLE
Support shared credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Please show `tflint --help`
 --deep                                  enable deep check mode.
 --aws-access-key                        set AWS access key used in deep check mode.
 --aws-secret-key                        set AWS secret key used in deep check mode.
+--aws-profile                           set AWS shared credential profile name in deep check mode.
 --aws-region                            set AWS region used in deep check mode.
 -d, --debug                             enable debug mode.
 --error-with-issues                     return error code when issue exists.
@@ -122,6 +123,55 @@ If you want to create a configuration file with a different name, specify the fi
 
 ```
 $ tflint --config other_config.hcl
+```
+
+### Credentials
+TFLint supports various credential providers. It is used with the following priority:
+
+- Static credentials
+- Shared credentials
+- Environment credentials
+- Default shared credentials
+
+#### Static Credentials
+If you have access key and secret key, you can specify these credentials.
+
+```
+$ tflint --aws-access-key AWS_ACCESS_KEY --aws-secret-key AWS_SECRET_KEY --aws-region us-east-1
+```
+
+```
+config {
+  aws_credentials = {
+    access_key = "AWS_ACCESS_KEY"
+    secret_key = "AWS_SECRET_KEY"
+    region     = "us-east-1"
+  }
+}
+```
+
+#### Shared Credentials
+If you have [shared credentials](https://aws.amazon.com/jp/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/), you can specify credentials profile name. However TFLint supports only `~/.aws/credentials` as shared credentials location.
+
+```
+$ tflint --aws-profile AWS_PROFILE --aws-region us-east-1
+```
+
+```
+config {
+  aws_credentials = {
+    profile = "AWS_PROFILE"
+    region  = "us-east-1"
+  }
+}
+```
+
+#### Environment Credentials
+TFLint looks `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` environment values. This is useful when you do not want to explicitly specify credentials.
+
+```
+$ export AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY
+$ export AWS_SECRET_ACCESS_KEY=AWS_SECRET_KEY
 ```
 
 ## Interpolation Syntax Support

--- a/cli.go
+++ b/cli.go
@@ -43,6 +43,7 @@ type ConfigurableArgs struct {
 	AwsAccessKey string
 	AwsSecretKey string
 	AwsRegion    string
+	AwsProfile   string
 	IgnoreModule string
 	IgnoreRule   string
 	Varfile      string
@@ -79,6 +80,7 @@ func (cli *CLI) Run(args []string) int {
 	flags.BoolVar(&configArgs.DeepCheck, "deep", false, "enable deep check mode.")
 	flags.StringVar(&configArgs.AwsAccessKey, "aws-access-key", "", "AWS access key used in deep check mode.")
 	flags.StringVar(&configArgs.AwsSecretKey, "aws-secret-key", "", "AWS secret key used in deep check mode.")
+	flags.StringVar(&configArgs.AwsProfile, "aws-profile", "", "AWS shared credential profile name used in deep check mode")
 	flags.StringVar(&configArgs.AwsRegion, "aws-region", "", "AWS region used in deep check mode.")
 	flags.BoolVar(&errorWithIssues, "error-with-issues", false, "return error code when issue exists.")
 	flags.BoolVar(&configArgs.Fast, "fast", false, "ignore slow rules.")
@@ -168,7 +170,7 @@ func (cli *CLI) setupConfig(args ConfigurableArgs) (*config.Config, error) {
 	}
 	if args.DeepCheck || c.DeepCheck {
 		c.DeepCheck = true
-		c.SetAwsCredentials(args.AwsAccessKey, args.AwsSecretKey, args.AwsRegion)
+		c.SetAwsCredentials(args.AwsAccessKey, args.AwsSecretKey, args.AwsProfile, args.AwsRegion)
 	}
 	// `aws_instance_invalid_ami` is very slow...
 	if args.Fast {

--- a/cli_test.go
+++ b/cli_test.go
@@ -438,7 +438,7 @@ func TestCLIRun(t *testing.T) {
 			},
 		},
 		{
-			Name:              "set aws credentials",
+			Name:              "set aws static credentials",
 			Command:           "./tflint --deep --aws-access-key AWS_ACCESS_KEY_ID --aws-secret-key AWS_SECRET_ACCESS_KEY --aws-region us-east-1",
 			LoaderGenerator:   loaderDefaultBehavior,
 			DetectorGenerator: detectorNoErrorNoIssuesBehavior,
@@ -453,6 +453,30 @@ func TestCLIRun(t *testing.T) {
 							"access_key": "AWS_ACCESS_KEY_ID",
 							"secret_key": "AWS_SECRET_ACCESS_KEY",
 							"region":     "us-east-1",
+						},
+						IgnoreModule: map[string]bool{},
+						IgnoreRule:   map[string]bool{},
+						Varfile:      []string{"terraform.tfvars"},
+					},
+					ConfigFile: ".tflint.hcl",
+				},
+			},
+		},
+		{
+			Name:              "set aws shared credentials",
+			Command:           "./tflint --deep --aws-profile account1 --aws-region us-east-1",
+			LoaderGenerator:   loaderDefaultBehavior,
+			DetectorGenerator: detectorNoErrorNoIssuesBehavior,
+			PrinterGenerator:  printerNoIssuesDefaultBehaviour,
+			Result: Result{
+				Status: ExitCodeOK,
+				CLIOptions: TestCLIOptions{
+					Config: &config.Config{
+						Debug:     false,
+						DeepCheck: true,
+						AwsCredentials: map[string]string{
+							"profile": "account1",
+							"region":  "us-east-1",
 						},
 						IgnoreModule: map[string]bool{},
 						IgnoreRule:   map[string]bool{},

--- a/config/aws.go
+++ b/config/aws.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+	homedir "github.com/mitchellh/go-homedir"
 	"github.com/wata727/tflint/logger"
 )
 
@@ -55,7 +56,18 @@ func (c *Config) NewAwsSession() *session.Session {
 			Region: aws.String(c.AwsCredentials["region"]),
 		})
 	}
-	if c.HasAwsCredentials() {
+	if c.HasAwsSharedCredentials() {
+		l.Info("set AWS shared credentials")
+		path, err := homedir.Expand("~/.aws/credentials")
+		if err != nil {
+			l.Error(err)
+		}
+		s = session.New(&aws.Config{
+			Credentials: credentials.NewSharedCredentials(path, c.AwsCredentials["profile"]),
+			Region:      aws.String(c.AwsCredentials["region"]),
+		})
+	}
+	if c.HasAwsStaticCredentials() {
 		l.Info("set AWS credentials")
 		s = session.New(&aws.Config{
 			Credentials: credentials.NewStaticCredentials(c.AwsCredentials["access_key"], c.AwsCredentials["secret_key"], ""),

--- a/config/aws_test.go
+++ b/config/aws_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/k0kubun/pp"
+	homedir "github.com/mitchellh/go-homedir"
 )
 
 func TestNewAwsSession(t *testing.T) {
@@ -14,6 +15,7 @@ func TestNewAwsSession(t *testing.T) {
 		Credentials *credentials.Credentials
 		Region      *string
 	}
+	path, _ := homedir.Expand("~/.aws/credentials")
 
 	cases := []struct {
 		Name   string
@@ -21,7 +23,7 @@ func TestNewAwsSession(t *testing.T) {
 		Result Result
 	}{
 		{
-			Name: "set credentials",
+			Name: "set static credentials",
 			Input: &Config{
 				AwsCredentials: map[string]string{
 					"access_key": "AWS_ACCESS_KEY",
@@ -31,6 +33,19 @@ func TestNewAwsSession(t *testing.T) {
 			},
 			Result: Result{
 				Credentials: credentials.NewStaticCredentials("AWS_ACCESS_KEY", "AWS_SECRET_KEY", ""),
+				Region:      aws.String("us-east-1"),
+			},
+		},
+		{
+			Name: "set shared credentials",
+			Input: &Config{
+				AwsCredentials: map[string]string{
+					"profile": "account1",
+					"region":  "us-east-1",
+				},
+			},
+			Result: Result{
+				Credentials: credentials.NewSharedCredentials(path, "account1"),
 				Region:      aws.String("us-east-1"),
 			},
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -46,12 +46,15 @@ func (c *Config) LoadConfig(filename string) error {
 	return nil
 }
 
-func (c *Config) SetAwsCredentials(accessKey string, secretKey string, region string) {
+func (c *Config) SetAwsCredentials(accessKey string, secretKey string, profile string, region string) {
 	if accessKey != "" {
 		c.AwsCredentials["access_key"] = accessKey
 	}
 	if secretKey != "" {
 		c.AwsCredentials["secret_key"] = secretKey
+	}
+	if profile != "" {
+		c.AwsCredentials["profile"] = profile
 	}
 	if region != "" {
 		c.AwsCredentials["region"] = region
@@ -62,7 +65,11 @@ func (c *Config) HasAwsRegion() bool {
 	return c.AwsCredentials["region"] != ""
 }
 
-func (c *Config) HasAwsCredentials() bool {
+func (c *Config) HasAwsSharedCredentials() bool {
+	return c.AwsCredentials["profile"] != "" && c.AwsCredentials["region"] != ""
+}
+
+func (c *Config) HasAwsStaticCredentials() bool {
 	return c.AwsCredentials["access_key"] != "" && c.AwsCredentials["secret_key"] != "" && c.AwsCredentials["region"] != ""
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -61,6 +61,7 @@ func TestSetAwsCredentials(t *testing.T) {
 	type Input struct {
 		AccessKey string
 		SecretKey string
+		Profile   string
 		Region    string
 	}
 
@@ -78,12 +79,14 @@ func TestSetAwsCredentials(t *testing.T) {
 			Input: Input{
 				AccessKey: "AWS_ACCESS_KEY",
 				SecretKey: "AWS_SECRET_KEY",
+				Profile:   "account1",
 				Region:    "us-east-1",
 			},
 			Result: &Config{
 				AwsCredentials: map[string]string{
 					"access_key": "AWS_ACCESS_KEY",
 					"secret_key": "AWS_SECRET_KEY",
+					"profile":    "account1",
 					"region":     "us-east-1",
 				},
 			},
@@ -94,6 +97,7 @@ func TestSetAwsCredentials(t *testing.T) {
 				AwsCredentials: map[string]string{
 					"access_key": "AWS_ACCESS_KEY",
 					"secret_key": "AWS_SECRET_KEY",
+					"profile":    "account1",
 					"region":     "us-east-1",
 				},
 			},
@@ -106,6 +110,7 @@ func TestSetAwsCredentials(t *testing.T) {
 				AwsCredentials: map[string]string{
 					"access_key": "AWS_ACCESS_KEY",
 					"secret_key": "AWS_SECRET_KEY",
+					"profile":    "account1",
 					"region":     "us-east-1",
 				},
 			},
@@ -113,7 +118,7 @@ func TestSetAwsCredentials(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc.Config.SetAwsCredentials(tc.Input.AccessKey, tc.Input.SecretKey, tc.Input.Region)
+		tc.Config.SetAwsCredentials(tc.Input.AccessKey, tc.Input.SecretKey, tc.Input.Profile, tc.Input.Region)
 		if !reflect.DeepEqual(tc.Config, tc.Result) {
 			t.Fatalf("\nBad: %s\nExpected: %s\n\ntestcase: %s", pp.Sprint(tc.Config), pp.Sprint(tc.Result), tc.Name)
 		}
@@ -152,7 +157,51 @@ func TestHasAwsRegion(t *testing.T) {
 	}
 }
 
-func TestHasAwsCredentials(t *testing.T) {
+func TestHasAwsSharedCredentials(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Input  *Config
+		Result bool
+	}{
+		{
+			Name: "has credentials",
+			Input: &Config{
+				AwsCredentials: map[string]string{
+					"profile": "account1",
+					"region":  "us-east-1",
+				},
+			},
+			Result: true,
+		},
+		{
+			Name: "does not have profile",
+			Input: &Config{
+				AwsCredentials: map[string]string{
+					"region": "us-east-1",
+				},
+			},
+			Result: false,
+		},
+		{
+			Name: "does not have region",
+			Input: &Config{
+				AwsCredentials: map[string]string{
+					"profile": "account1",
+				},
+			},
+			Result: false,
+		},
+	}
+
+	for _, tc := range cases {
+		result := tc.Input.HasAwsSharedCredentials()
+		if !reflect.DeepEqual(result, tc.Result) {
+			t.Fatalf("\nBad: %s\nExpected: %s\n\ntestcase: %s", pp.Sprint(result), pp.Sprint(tc.Result), tc.Name)
+		}
+	}
+}
+
+func TestHasAwsStaticCredentials(t *testing.T) {
 	cases := []struct {
 		Name   string
 		Input  *Config
@@ -202,7 +251,7 @@ func TestHasAwsCredentials(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		result := tc.Input.HasAwsCredentials()
+		result := tc.Input.HasAwsStaticCredentials()
 		if !reflect.DeepEqual(result, tc.Result) {
 			t.Fatalf("\nBad: %s\nExpected: %s\n\ntestcase: %s", pp.Sprint(result), pp.Sprint(tc.Result), tc.Name)
 		}

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 9c6d780bc448a108b457770e8ca5d2448d52d90b8a3b2308caa4a79436f48d13
-updated: 2017-03-12T22:23:49.595299074+09:00
+hash: a221ec3e41af391aa494ffc92408f3ad5785207ede47c1c73462b0156b593539
+updated: 2017-03-25T22:04:15.372373828+09:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 819b71cf8430e434c1eee7e7e8b0f2b8870be899
+  version: d122c9c0e1d875585918c85cf6eba7e5e43f221d
   subpackages:
   - aws
   - aws/awserr
@@ -26,7 +26,6 @@ imports:
   - private/protocol/query/queryutil
   - private/protocol/rest
   - private/protocol/xml/xmlutil
-  - private/waiter
   - service/ec2
   - service/ec2/ec2iface
   - service/elasticache

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,3 +27,4 @@ import:
 - package: github.com/hashicorp/terraform
   subpackages:
   - helper/variables
+- package: github.com/mitchellh/go-homedir

--- a/help.go
+++ b/help.go
@@ -15,6 +15,7 @@ Available Options:
     --deep                                  enable deep check mode.
     --aws-access-key                        set AWS access key used in deep check mode.
     --aws-secret-key                        set AWS secret key used in deep check mode.
+    --aws-profile                           set AWS shared credential profile name in deep check mode.
     --aws-region                            set AWS region used in deep check mode.
     -d, --debug                             enable debug mode.
     --error-with-issues                     return error code when issue exists.

--- a/mock/ec2mock.go
+++ b/mock/ec2mock.go
@@ -4,6 +4,7 @@
 package mock
 
 import (
+	aws "github.com/aws/aws-sdk-go/aws"
 	request "github.com/aws/aws-sdk-go/aws/request"
 	ec2 "github.com/aws/aws-sdk-go/service/ec2"
 	gomock "github.com/golang/mock/gomock"
@@ -30,17 +31,6 @@ func (_m *MockEC2API) EXPECT() *_MockEC2APIRecorder {
 	return _m.recorder
 }
 
-func (_m *MockEC2API) AcceptReservedInstancesExchangeQuoteRequest(_param0 *ec2.AcceptReservedInstancesExchangeQuoteInput) (*request.Request, *ec2.AcceptReservedInstancesExchangeQuoteOutput) {
-	ret := _m.ctrl.Call(_m, "AcceptReservedInstancesExchangeQuoteRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AcceptReservedInstancesExchangeQuoteOutput)
-	return ret0, ret1
-}
-
-func (_mr *_MockEC2APIRecorder) AcceptReservedInstancesExchangeQuoteRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AcceptReservedInstancesExchangeQuoteRequest", arg0)
-}
-
 func (_m *MockEC2API) AcceptReservedInstancesExchangeQuote(_param0 *ec2.AcceptReservedInstancesExchangeQuoteInput) (*ec2.AcceptReservedInstancesExchangeQuoteOutput, error) {
 	ret := _m.ctrl.Call(_m, "AcceptReservedInstancesExchangeQuote", _param0)
 	ret0, _ := ret[0].(*ec2.AcceptReservedInstancesExchangeQuoteOutput)
@@ -52,15 +42,31 @@ func (_mr *_MockEC2APIRecorder) AcceptReservedInstancesExchangeQuote(arg0 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AcceptReservedInstancesExchangeQuote", arg0)
 }
 
-func (_m *MockEC2API) AcceptVpcPeeringConnectionRequest(_param0 *ec2.AcceptVpcPeeringConnectionInput) (*request.Request, *ec2.AcceptVpcPeeringConnectionOutput) {
-	ret := _m.ctrl.Call(_m, "AcceptVpcPeeringConnectionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AcceptVpcPeeringConnectionOutput)
+func (_m *MockEC2API) AcceptReservedInstancesExchangeQuoteWithContext(_param0 aws.Context, _param1 *ec2.AcceptReservedInstancesExchangeQuoteInput, _param2 ...request.Option) (*ec2.AcceptReservedInstancesExchangeQuoteOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AcceptReservedInstancesExchangeQuoteWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.AcceptReservedInstancesExchangeQuoteOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) AcceptVpcPeeringConnectionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AcceptVpcPeeringConnectionRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AcceptReservedInstancesExchangeQuoteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AcceptReservedInstancesExchangeQuoteWithContext", _s...)
+}
+
+func (_m *MockEC2API) AcceptReservedInstancesExchangeQuoteRequest(_param0 *ec2.AcceptReservedInstancesExchangeQuoteInput) (*request.Request, *ec2.AcceptReservedInstancesExchangeQuoteOutput) {
+	ret := _m.ctrl.Call(_m, "AcceptReservedInstancesExchangeQuoteRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AcceptReservedInstancesExchangeQuoteOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AcceptReservedInstancesExchangeQuoteRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AcceptReservedInstancesExchangeQuoteRequest", arg0)
 }
 
 func (_m *MockEC2API) AcceptVpcPeeringConnection(_param0 *ec2.AcceptVpcPeeringConnectionInput) (*ec2.AcceptVpcPeeringConnectionOutput, error) {
@@ -74,15 +80,31 @@ func (_mr *_MockEC2APIRecorder) AcceptVpcPeeringConnection(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AcceptVpcPeeringConnection", arg0)
 }
 
-func (_m *MockEC2API) AllocateAddressRequest(_param0 *ec2.AllocateAddressInput) (*request.Request, *ec2.AllocateAddressOutput) {
-	ret := _m.ctrl.Call(_m, "AllocateAddressRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AllocateAddressOutput)
+func (_m *MockEC2API) AcceptVpcPeeringConnectionWithContext(_param0 aws.Context, _param1 *ec2.AcceptVpcPeeringConnectionInput, _param2 ...request.Option) (*ec2.AcceptVpcPeeringConnectionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AcceptVpcPeeringConnectionWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.AcceptVpcPeeringConnectionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) AllocateAddressRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AllocateAddressRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AcceptVpcPeeringConnectionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AcceptVpcPeeringConnectionWithContext", _s...)
+}
+
+func (_m *MockEC2API) AcceptVpcPeeringConnectionRequest(_param0 *ec2.AcceptVpcPeeringConnectionInput) (*request.Request, *ec2.AcceptVpcPeeringConnectionOutput) {
+	ret := _m.ctrl.Call(_m, "AcceptVpcPeeringConnectionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AcceptVpcPeeringConnectionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AcceptVpcPeeringConnectionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AcceptVpcPeeringConnectionRequest", arg0)
 }
 
 func (_m *MockEC2API) AllocateAddress(_param0 *ec2.AllocateAddressInput) (*ec2.AllocateAddressOutput, error) {
@@ -96,15 +118,31 @@ func (_mr *_MockEC2APIRecorder) AllocateAddress(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AllocateAddress", arg0)
 }
 
-func (_m *MockEC2API) AllocateHostsRequest(_param0 *ec2.AllocateHostsInput) (*request.Request, *ec2.AllocateHostsOutput) {
-	ret := _m.ctrl.Call(_m, "AllocateHostsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AllocateHostsOutput)
+func (_m *MockEC2API) AllocateAddressWithContext(_param0 aws.Context, _param1 *ec2.AllocateAddressInput, _param2 ...request.Option) (*ec2.AllocateAddressOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AllocateAddressWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.AllocateAddressOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) AllocateHostsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AllocateHostsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AllocateAddressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AllocateAddressWithContext", _s...)
+}
+
+func (_m *MockEC2API) AllocateAddressRequest(_param0 *ec2.AllocateAddressInput) (*request.Request, *ec2.AllocateAddressOutput) {
+	ret := _m.ctrl.Call(_m, "AllocateAddressRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AllocateAddressOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AllocateAddressRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AllocateAddressRequest", arg0)
 }
 
 func (_m *MockEC2API) AllocateHosts(_param0 *ec2.AllocateHostsInput) (*ec2.AllocateHostsOutput, error) {
@@ -118,15 +156,31 @@ func (_mr *_MockEC2APIRecorder) AllocateHosts(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AllocateHosts", arg0)
 }
 
-func (_m *MockEC2API) AssignIpv6AddressesRequest(_param0 *ec2.AssignIpv6AddressesInput) (*request.Request, *ec2.AssignIpv6AddressesOutput) {
-	ret := _m.ctrl.Call(_m, "AssignIpv6AddressesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AssignIpv6AddressesOutput)
+func (_m *MockEC2API) AllocateHostsWithContext(_param0 aws.Context, _param1 *ec2.AllocateHostsInput, _param2 ...request.Option) (*ec2.AllocateHostsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AllocateHostsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.AllocateHostsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) AssignIpv6AddressesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssignIpv6AddressesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AllocateHostsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AllocateHostsWithContext", _s...)
+}
+
+func (_m *MockEC2API) AllocateHostsRequest(_param0 *ec2.AllocateHostsInput) (*request.Request, *ec2.AllocateHostsOutput) {
+	ret := _m.ctrl.Call(_m, "AllocateHostsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AllocateHostsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AllocateHostsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AllocateHostsRequest", arg0)
 }
 
 func (_m *MockEC2API) AssignIpv6Addresses(_param0 *ec2.AssignIpv6AddressesInput) (*ec2.AssignIpv6AddressesOutput, error) {
@@ -140,15 +194,31 @@ func (_mr *_MockEC2APIRecorder) AssignIpv6Addresses(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssignIpv6Addresses", arg0)
 }
 
-func (_m *MockEC2API) AssignPrivateIpAddressesRequest(_param0 *ec2.AssignPrivateIpAddressesInput) (*request.Request, *ec2.AssignPrivateIpAddressesOutput) {
-	ret := _m.ctrl.Call(_m, "AssignPrivateIpAddressesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AssignPrivateIpAddressesOutput)
+func (_m *MockEC2API) AssignIpv6AddressesWithContext(_param0 aws.Context, _param1 *ec2.AssignIpv6AddressesInput, _param2 ...request.Option) (*ec2.AssignIpv6AddressesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AssignIpv6AddressesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.AssignIpv6AddressesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) AssignPrivateIpAddressesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssignPrivateIpAddressesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AssignIpv6AddressesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssignIpv6AddressesWithContext", _s...)
+}
+
+func (_m *MockEC2API) AssignIpv6AddressesRequest(_param0 *ec2.AssignIpv6AddressesInput) (*request.Request, *ec2.AssignIpv6AddressesOutput) {
+	ret := _m.ctrl.Call(_m, "AssignIpv6AddressesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AssignIpv6AddressesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AssignIpv6AddressesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssignIpv6AddressesRequest", arg0)
 }
 
 func (_m *MockEC2API) AssignPrivateIpAddresses(_param0 *ec2.AssignPrivateIpAddressesInput) (*ec2.AssignPrivateIpAddressesOutput, error) {
@@ -162,15 +232,31 @@ func (_mr *_MockEC2APIRecorder) AssignPrivateIpAddresses(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssignPrivateIpAddresses", arg0)
 }
 
-func (_m *MockEC2API) AssociateAddressRequest(_param0 *ec2.AssociateAddressInput) (*request.Request, *ec2.AssociateAddressOutput) {
-	ret := _m.ctrl.Call(_m, "AssociateAddressRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AssociateAddressOutput)
+func (_m *MockEC2API) AssignPrivateIpAddressesWithContext(_param0 aws.Context, _param1 *ec2.AssignPrivateIpAddressesInput, _param2 ...request.Option) (*ec2.AssignPrivateIpAddressesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AssignPrivateIpAddressesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.AssignPrivateIpAddressesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) AssociateAddressRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateAddressRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AssignPrivateIpAddressesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssignPrivateIpAddressesWithContext", _s...)
+}
+
+func (_m *MockEC2API) AssignPrivateIpAddressesRequest(_param0 *ec2.AssignPrivateIpAddressesInput) (*request.Request, *ec2.AssignPrivateIpAddressesOutput) {
+	ret := _m.ctrl.Call(_m, "AssignPrivateIpAddressesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AssignPrivateIpAddressesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AssignPrivateIpAddressesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssignPrivateIpAddressesRequest", arg0)
 }
 
 func (_m *MockEC2API) AssociateAddress(_param0 *ec2.AssociateAddressInput) (*ec2.AssociateAddressOutput, error) {
@@ -184,15 +270,31 @@ func (_mr *_MockEC2APIRecorder) AssociateAddress(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateAddress", arg0)
 }
 
-func (_m *MockEC2API) AssociateDhcpOptionsRequest(_param0 *ec2.AssociateDhcpOptionsInput) (*request.Request, *ec2.AssociateDhcpOptionsOutput) {
-	ret := _m.ctrl.Call(_m, "AssociateDhcpOptionsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AssociateDhcpOptionsOutput)
+func (_m *MockEC2API) AssociateAddressWithContext(_param0 aws.Context, _param1 *ec2.AssociateAddressInput, _param2 ...request.Option) (*ec2.AssociateAddressOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AssociateAddressWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.AssociateAddressOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) AssociateDhcpOptionsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateDhcpOptionsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AssociateAddressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateAddressWithContext", _s...)
+}
+
+func (_m *MockEC2API) AssociateAddressRequest(_param0 *ec2.AssociateAddressInput) (*request.Request, *ec2.AssociateAddressOutput) {
+	ret := _m.ctrl.Call(_m, "AssociateAddressRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AssociateAddressOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AssociateAddressRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateAddressRequest", arg0)
 }
 
 func (_m *MockEC2API) AssociateDhcpOptions(_param0 *ec2.AssociateDhcpOptionsInput) (*ec2.AssociateDhcpOptionsOutput, error) {
@@ -206,15 +308,31 @@ func (_mr *_MockEC2APIRecorder) AssociateDhcpOptions(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateDhcpOptions", arg0)
 }
 
-func (_m *MockEC2API) AssociateIamInstanceProfileRequest(_param0 *ec2.AssociateIamInstanceProfileInput) (*request.Request, *ec2.AssociateIamInstanceProfileOutput) {
-	ret := _m.ctrl.Call(_m, "AssociateIamInstanceProfileRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AssociateIamInstanceProfileOutput)
+func (_m *MockEC2API) AssociateDhcpOptionsWithContext(_param0 aws.Context, _param1 *ec2.AssociateDhcpOptionsInput, _param2 ...request.Option) (*ec2.AssociateDhcpOptionsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AssociateDhcpOptionsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.AssociateDhcpOptionsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) AssociateIamInstanceProfileRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateIamInstanceProfileRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AssociateDhcpOptionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateDhcpOptionsWithContext", _s...)
+}
+
+func (_m *MockEC2API) AssociateDhcpOptionsRequest(_param0 *ec2.AssociateDhcpOptionsInput) (*request.Request, *ec2.AssociateDhcpOptionsOutput) {
+	ret := _m.ctrl.Call(_m, "AssociateDhcpOptionsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AssociateDhcpOptionsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AssociateDhcpOptionsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateDhcpOptionsRequest", arg0)
 }
 
 func (_m *MockEC2API) AssociateIamInstanceProfile(_param0 *ec2.AssociateIamInstanceProfileInput) (*ec2.AssociateIamInstanceProfileOutput, error) {
@@ -228,15 +346,31 @@ func (_mr *_MockEC2APIRecorder) AssociateIamInstanceProfile(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateIamInstanceProfile", arg0)
 }
 
-func (_m *MockEC2API) AssociateRouteTableRequest(_param0 *ec2.AssociateRouteTableInput) (*request.Request, *ec2.AssociateRouteTableOutput) {
-	ret := _m.ctrl.Call(_m, "AssociateRouteTableRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AssociateRouteTableOutput)
+func (_m *MockEC2API) AssociateIamInstanceProfileWithContext(_param0 aws.Context, _param1 *ec2.AssociateIamInstanceProfileInput, _param2 ...request.Option) (*ec2.AssociateIamInstanceProfileOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AssociateIamInstanceProfileWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.AssociateIamInstanceProfileOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) AssociateRouteTableRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateRouteTableRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AssociateIamInstanceProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateIamInstanceProfileWithContext", _s...)
+}
+
+func (_m *MockEC2API) AssociateIamInstanceProfileRequest(_param0 *ec2.AssociateIamInstanceProfileInput) (*request.Request, *ec2.AssociateIamInstanceProfileOutput) {
+	ret := _m.ctrl.Call(_m, "AssociateIamInstanceProfileRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AssociateIamInstanceProfileOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AssociateIamInstanceProfileRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateIamInstanceProfileRequest", arg0)
 }
 
 func (_m *MockEC2API) AssociateRouteTable(_param0 *ec2.AssociateRouteTableInput) (*ec2.AssociateRouteTableOutput, error) {
@@ -250,15 +384,31 @@ func (_mr *_MockEC2APIRecorder) AssociateRouteTable(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateRouteTable", arg0)
 }
 
-func (_m *MockEC2API) AssociateSubnetCidrBlockRequest(_param0 *ec2.AssociateSubnetCidrBlockInput) (*request.Request, *ec2.AssociateSubnetCidrBlockOutput) {
-	ret := _m.ctrl.Call(_m, "AssociateSubnetCidrBlockRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AssociateSubnetCidrBlockOutput)
+func (_m *MockEC2API) AssociateRouteTableWithContext(_param0 aws.Context, _param1 *ec2.AssociateRouteTableInput, _param2 ...request.Option) (*ec2.AssociateRouteTableOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AssociateRouteTableWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.AssociateRouteTableOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) AssociateSubnetCidrBlockRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateSubnetCidrBlockRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AssociateRouteTableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateRouteTableWithContext", _s...)
+}
+
+func (_m *MockEC2API) AssociateRouteTableRequest(_param0 *ec2.AssociateRouteTableInput) (*request.Request, *ec2.AssociateRouteTableOutput) {
+	ret := _m.ctrl.Call(_m, "AssociateRouteTableRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AssociateRouteTableOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AssociateRouteTableRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateRouteTableRequest", arg0)
 }
 
 func (_m *MockEC2API) AssociateSubnetCidrBlock(_param0 *ec2.AssociateSubnetCidrBlockInput) (*ec2.AssociateSubnetCidrBlockOutput, error) {
@@ -272,15 +422,31 @@ func (_mr *_MockEC2APIRecorder) AssociateSubnetCidrBlock(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateSubnetCidrBlock", arg0)
 }
 
-func (_m *MockEC2API) AssociateVpcCidrBlockRequest(_param0 *ec2.AssociateVpcCidrBlockInput) (*request.Request, *ec2.AssociateVpcCidrBlockOutput) {
-	ret := _m.ctrl.Call(_m, "AssociateVpcCidrBlockRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AssociateVpcCidrBlockOutput)
+func (_m *MockEC2API) AssociateSubnetCidrBlockWithContext(_param0 aws.Context, _param1 *ec2.AssociateSubnetCidrBlockInput, _param2 ...request.Option) (*ec2.AssociateSubnetCidrBlockOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AssociateSubnetCidrBlockWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.AssociateSubnetCidrBlockOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) AssociateVpcCidrBlockRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateVpcCidrBlockRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AssociateSubnetCidrBlockWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateSubnetCidrBlockWithContext", _s...)
+}
+
+func (_m *MockEC2API) AssociateSubnetCidrBlockRequest(_param0 *ec2.AssociateSubnetCidrBlockInput) (*request.Request, *ec2.AssociateSubnetCidrBlockOutput) {
+	ret := _m.ctrl.Call(_m, "AssociateSubnetCidrBlockRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AssociateSubnetCidrBlockOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AssociateSubnetCidrBlockRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateSubnetCidrBlockRequest", arg0)
 }
 
 func (_m *MockEC2API) AssociateVpcCidrBlock(_param0 *ec2.AssociateVpcCidrBlockInput) (*ec2.AssociateVpcCidrBlockOutput, error) {
@@ -294,15 +460,31 @@ func (_mr *_MockEC2APIRecorder) AssociateVpcCidrBlock(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateVpcCidrBlock", arg0)
 }
 
-func (_m *MockEC2API) AttachClassicLinkVpcRequest(_param0 *ec2.AttachClassicLinkVpcInput) (*request.Request, *ec2.AttachClassicLinkVpcOutput) {
-	ret := _m.ctrl.Call(_m, "AttachClassicLinkVpcRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AttachClassicLinkVpcOutput)
+func (_m *MockEC2API) AssociateVpcCidrBlockWithContext(_param0 aws.Context, _param1 *ec2.AssociateVpcCidrBlockInput, _param2 ...request.Option) (*ec2.AssociateVpcCidrBlockOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AssociateVpcCidrBlockWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.AssociateVpcCidrBlockOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) AttachClassicLinkVpcRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachClassicLinkVpcRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AssociateVpcCidrBlockWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateVpcCidrBlockWithContext", _s...)
+}
+
+func (_m *MockEC2API) AssociateVpcCidrBlockRequest(_param0 *ec2.AssociateVpcCidrBlockInput) (*request.Request, *ec2.AssociateVpcCidrBlockOutput) {
+	ret := _m.ctrl.Call(_m, "AssociateVpcCidrBlockRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AssociateVpcCidrBlockOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AssociateVpcCidrBlockRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AssociateVpcCidrBlockRequest", arg0)
 }
 
 func (_m *MockEC2API) AttachClassicLinkVpc(_param0 *ec2.AttachClassicLinkVpcInput) (*ec2.AttachClassicLinkVpcOutput, error) {
@@ -316,15 +498,31 @@ func (_mr *_MockEC2APIRecorder) AttachClassicLinkVpc(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachClassicLinkVpc", arg0)
 }
 
-func (_m *MockEC2API) AttachInternetGatewayRequest(_param0 *ec2.AttachInternetGatewayInput) (*request.Request, *ec2.AttachInternetGatewayOutput) {
-	ret := _m.ctrl.Call(_m, "AttachInternetGatewayRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AttachInternetGatewayOutput)
+func (_m *MockEC2API) AttachClassicLinkVpcWithContext(_param0 aws.Context, _param1 *ec2.AttachClassicLinkVpcInput, _param2 ...request.Option) (*ec2.AttachClassicLinkVpcOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AttachClassicLinkVpcWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.AttachClassicLinkVpcOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) AttachInternetGatewayRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachInternetGatewayRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AttachClassicLinkVpcWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachClassicLinkVpcWithContext", _s...)
+}
+
+func (_m *MockEC2API) AttachClassicLinkVpcRequest(_param0 *ec2.AttachClassicLinkVpcInput) (*request.Request, *ec2.AttachClassicLinkVpcOutput) {
+	ret := _m.ctrl.Call(_m, "AttachClassicLinkVpcRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AttachClassicLinkVpcOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AttachClassicLinkVpcRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachClassicLinkVpcRequest", arg0)
 }
 
 func (_m *MockEC2API) AttachInternetGateway(_param0 *ec2.AttachInternetGatewayInput) (*ec2.AttachInternetGatewayOutput, error) {
@@ -338,15 +536,31 @@ func (_mr *_MockEC2APIRecorder) AttachInternetGateway(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachInternetGateway", arg0)
 }
 
-func (_m *MockEC2API) AttachNetworkInterfaceRequest(_param0 *ec2.AttachNetworkInterfaceInput) (*request.Request, *ec2.AttachNetworkInterfaceOutput) {
-	ret := _m.ctrl.Call(_m, "AttachNetworkInterfaceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AttachNetworkInterfaceOutput)
+func (_m *MockEC2API) AttachInternetGatewayWithContext(_param0 aws.Context, _param1 *ec2.AttachInternetGatewayInput, _param2 ...request.Option) (*ec2.AttachInternetGatewayOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AttachInternetGatewayWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.AttachInternetGatewayOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) AttachNetworkInterfaceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachNetworkInterfaceRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AttachInternetGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachInternetGatewayWithContext", _s...)
+}
+
+func (_m *MockEC2API) AttachInternetGatewayRequest(_param0 *ec2.AttachInternetGatewayInput) (*request.Request, *ec2.AttachInternetGatewayOutput) {
+	ret := _m.ctrl.Call(_m, "AttachInternetGatewayRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AttachInternetGatewayOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AttachInternetGatewayRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachInternetGatewayRequest", arg0)
 }
 
 func (_m *MockEC2API) AttachNetworkInterface(_param0 *ec2.AttachNetworkInterfaceInput) (*ec2.AttachNetworkInterfaceOutput, error) {
@@ -360,15 +574,31 @@ func (_mr *_MockEC2APIRecorder) AttachNetworkInterface(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachNetworkInterface", arg0)
 }
 
-func (_m *MockEC2API) AttachVolumeRequest(_param0 *ec2.AttachVolumeInput) (*request.Request, *ec2.VolumeAttachment) {
-	ret := _m.ctrl.Call(_m, "AttachVolumeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.VolumeAttachment)
+func (_m *MockEC2API) AttachNetworkInterfaceWithContext(_param0 aws.Context, _param1 *ec2.AttachNetworkInterfaceInput, _param2 ...request.Option) (*ec2.AttachNetworkInterfaceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AttachNetworkInterfaceWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.AttachNetworkInterfaceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) AttachVolumeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachVolumeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AttachNetworkInterfaceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachNetworkInterfaceWithContext", _s...)
+}
+
+func (_m *MockEC2API) AttachNetworkInterfaceRequest(_param0 *ec2.AttachNetworkInterfaceInput) (*request.Request, *ec2.AttachNetworkInterfaceOutput) {
+	ret := _m.ctrl.Call(_m, "AttachNetworkInterfaceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AttachNetworkInterfaceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AttachNetworkInterfaceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachNetworkInterfaceRequest", arg0)
 }
 
 func (_m *MockEC2API) AttachVolume(_param0 *ec2.AttachVolumeInput) (*ec2.VolumeAttachment, error) {
@@ -382,15 +612,31 @@ func (_mr *_MockEC2APIRecorder) AttachVolume(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachVolume", arg0)
 }
 
-func (_m *MockEC2API) AttachVpnGatewayRequest(_param0 *ec2.AttachVpnGatewayInput) (*request.Request, *ec2.AttachVpnGatewayOutput) {
-	ret := _m.ctrl.Call(_m, "AttachVpnGatewayRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AttachVpnGatewayOutput)
+func (_m *MockEC2API) AttachVolumeWithContext(_param0 aws.Context, _param1 *ec2.AttachVolumeInput, _param2 ...request.Option) (*ec2.VolumeAttachment, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AttachVolumeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.VolumeAttachment)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) AttachVpnGatewayRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachVpnGatewayRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AttachVolumeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachVolumeWithContext", _s...)
+}
+
+func (_m *MockEC2API) AttachVolumeRequest(_param0 *ec2.AttachVolumeInput) (*request.Request, *ec2.VolumeAttachment) {
+	ret := _m.ctrl.Call(_m, "AttachVolumeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.VolumeAttachment)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AttachVolumeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachVolumeRequest", arg0)
 }
 
 func (_m *MockEC2API) AttachVpnGateway(_param0 *ec2.AttachVpnGatewayInput) (*ec2.AttachVpnGatewayOutput, error) {
@@ -404,15 +650,31 @@ func (_mr *_MockEC2APIRecorder) AttachVpnGateway(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachVpnGateway", arg0)
 }
 
-func (_m *MockEC2API) AuthorizeSecurityGroupEgressRequest(_param0 *ec2.AuthorizeSecurityGroupEgressInput) (*request.Request, *ec2.AuthorizeSecurityGroupEgressOutput) {
-	ret := _m.ctrl.Call(_m, "AuthorizeSecurityGroupEgressRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AuthorizeSecurityGroupEgressOutput)
+func (_m *MockEC2API) AttachVpnGatewayWithContext(_param0 aws.Context, _param1 *ec2.AttachVpnGatewayInput, _param2 ...request.Option) (*ec2.AttachVpnGatewayOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AttachVpnGatewayWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.AttachVpnGatewayOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) AuthorizeSecurityGroupEgressRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AuthorizeSecurityGroupEgressRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AttachVpnGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachVpnGatewayWithContext", _s...)
+}
+
+func (_m *MockEC2API) AttachVpnGatewayRequest(_param0 *ec2.AttachVpnGatewayInput) (*request.Request, *ec2.AttachVpnGatewayOutput) {
+	ret := _m.ctrl.Call(_m, "AttachVpnGatewayRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AttachVpnGatewayOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AttachVpnGatewayRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachVpnGatewayRequest", arg0)
 }
 
 func (_m *MockEC2API) AuthorizeSecurityGroupEgress(_param0 *ec2.AuthorizeSecurityGroupEgressInput) (*ec2.AuthorizeSecurityGroupEgressOutput, error) {
@@ -426,15 +688,31 @@ func (_mr *_MockEC2APIRecorder) AuthorizeSecurityGroupEgress(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AuthorizeSecurityGroupEgress", arg0)
 }
 
-func (_m *MockEC2API) AuthorizeSecurityGroupIngressRequest(_param0 *ec2.AuthorizeSecurityGroupIngressInput) (*request.Request, *ec2.AuthorizeSecurityGroupIngressOutput) {
-	ret := _m.ctrl.Call(_m, "AuthorizeSecurityGroupIngressRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.AuthorizeSecurityGroupIngressOutput)
+func (_m *MockEC2API) AuthorizeSecurityGroupEgressWithContext(_param0 aws.Context, _param1 *ec2.AuthorizeSecurityGroupEgressInput, _param2 ...request.Option) (*ec2.AuthorizeSecurityGroupEgressOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AuthorizeSecurityGroupEgressWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.AuthorizeSecurityGroupEgressOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) AuthorizeSecurityGroupIngressRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AuthorizeSecurityGroupIngressRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AuthorizeSecurityGroupEgressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AuthorizeSecurityGroupEgressWithContext", _s...)
+}
+
+func (_m *MockEC2API) AuthorizeSecurityGroupEgressRequest(_param0 *ec2.AuthorizeSecurityGroupEgressInput) (*request.Request, *ec2.AuthorizeSecurityGroupEgressOutput) {
+	ret := _m.ctrl.Call(_m, "AuthorizeSecurityGroupEgressRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AuthorizeSecurityGroupEgressOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AuthorizeSecurityGroupEgressRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AuthorizeSecurityGroupEgressRequest", arg0)
 }
 
 func (_m *MockEC2API) AuthorizeSecurityGroupIngress(_param0 *ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
@@ -448,15 +726,31 @@ func (_mr *_MockEC2APIRecorder) AuthorizeSecurityGroupIngress(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AuthorizeSecurityGroupIngress", arg0)
 }
 
-func (_m *MockEC2API) BundleInstanceRequest(_param0 *ec2.BundleInstanceInput) (*request.Request, *ec2.BundleInstanceOutput) {
-	ret := _m.ctrl.Call(_m, "BundleInstanceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.BundleInstanceOutput)
+func (_m *MockEC2API) AuthorizeSecurityGroupIngressWithContext(_param0 aws.Context, _param1 *ec2.AuthorizeSecurityGroupIngressInput, _param2 ...request.Option) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AuthorizeSecurityGroupIngressWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.AuthorizeSecurityGroupIngressOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) BundleInstanceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "BundleInstanceRequest", arg0)
+func (_mr *_MockEC2APIRecorder) AuthorizeSecurityGroupIngressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AuthorizeSecurityGroupIngressWithContext", _s...)
+}
+
+func (_m *MockEC2API) AuthorizeSecurityGroupIngressRequest(_param0 *ec2.AuthorizeSecurityGroupIngressInput) (*request.Request, *ec2.AuthorizeSecurityGroupIngressOutput) {
+	ret := _m.ctrl.Call(_m, "AuthorizeSecurityGroupIngressRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AuthorizeSecurityGroupIngressOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) AuthorizeSecurityGroupIngressRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AuthorizeSecurityGroupIngressRequest", arg0)
 }
 
 func (_m *MockEC2API) BundleInstance(_param0 *ec2.BundleInstanceInput) (*ec2.BundleInstanceOutput, error) {
@@ -470,15 +764,31 @@ func (_mr *_MockEC2APIRecorder) BundleInstance(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BundleInstance", arg0)
 }
 
-func (_m *MockEC2API) CancelBundleTaskRequest(_param0 *ec2.CancelBundleTaskInput) (*request.Request, *ec2.CancelBundleTaskOutput) {
-	ret := _m.ctrl.Call(_m, "CancelBundleTaskRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CancelBundleTaskOutput)
+func (_m *MockEC2API) BundleInstanceWithContext(_param0 aws.Context, _param1 *ec2.BundleInstanceInput, _param2 ...request.Option) (*ec2.BundleInstanceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "BundleInstanceWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.BundleInstanceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CancelBundleTaskRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelBundleTaskRequest", arg0)
+func (_mr *_MockEC2APIRecorder) BundleInstanceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "BundleInstanceWithContext", _s...)
+}
+
+func (_m *MockEC2API) BundleInstanceRequest(_param0 *ec2.BundleInstanceInput) (*request.Request, *ec2.BundleInstanceOutput) {
+	ret := _m.ctrl.Call(_m, "BundleInstanceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.BundleInstanceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) BundleInstanceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "BundleInstanceRequest", arg0)
 }
 
 func (_m *MockEC2API) CancelBundleTask(_param0 *ec2.CancelBundleTaskInput) (*ec2.CancelBundleTaskOutput, error) {
@@ -492,15 +802,31 @@ func (_mr *_MockEC2APIRecorder) CancelBundleTask(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelBundleTask", arg0)
 }
 
-func (_m *MockEC2API) CancelConversionTaskRequest(_param0 *ec2.CancelConversionTaskInput) (*request.Request, *ec2.CancelConversionTaskOutput) {
-	ret := _m.ctrl.Call(_m, "CancelConversionTaskRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CancelConversionTaskOutput)
+func (_m *MockEC2API) CancelBundleTaskWithContext(_param0 aws.Context, _param1 *ec2.CancelBundleTaskInput, _param2 ...request.Option) (*ec2.CancelBundleTaskOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CancelBundleTaskWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CancelBundleTaskOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CancelConversionTaskRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelConversionTaskRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CancelBundleTaskWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelBundleTaskWithContext", _s...)
+}
+
+func (_m *MockEC2API) CancelBundleTaskRequest(_param0 *ec2.CancelBundleTaskInput) (*request.Request, *ec2.CancelBundleTaskOutput) {
+	ret := _m.ctrl.Call(_m, "CancelBundleTaskRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CancelBundleTaskOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CancelBundleTaskRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelBundleTaskRequest", arg0)
 }
 
 func (_m *MockEC2API) CancelConversionTask(_param0 *ec2.CancelConversionTaskInput) (*ec2.CancelConversionTaskOutput, error) {
@@ -514,15 +840,31 @@ func (_mr *_MockEC2APIRecorder) CancelConversionTask(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelConversionTask", arg0)
 }
 
-func (_m *MockEC2API) CancelExportTaskRequest(_param0 *ec2.CancelExportTaskInput) (*request.Request, *ec2.CancelExportTaskOutput) {
-	ret := _m.ctrl.Call(_m, "CancelExportTaskRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CancelExportTaskOutput)
+func (_m *MockEC2API) CancelConversionTaskWithContext(_param0 aws.Context, _param1 *ec2.CancelConversionTaskInput, _param2 ...request.Option) (*ec2.CancelConversionTaskOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CancelConversionTaskWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CancelConversionTaskOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CancelExportTaskRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelExportTaskRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CancelConversionTaskWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelConversionTaskWithContext", _s...)
+}
+
+func (_m *MockEC2API) CancelConversionTaskRequest(_param0 *ec2.CancelConversionTaskInput) (*request.Request, *ec2.CancelConversionTaskOutput) {
+	ret := _m.ctrl.Call(_m, "CancelConversionTaskRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CancelConversionTaskOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CancelConversionTaskRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelConversionTaskRequest", arg0)
 }
 
 func (_m *MockEC2API) CancelExportTask(_param0 *ec2.CancelExportTaskInput) (*ec2.CancelExportTaskOutput, error) {
@@ -536,15 +878,31 @@ func (_mr *_MockEC2APIRecorder) CancelExportTask(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelExportTask", arg0)
 }
 
-func (_m *MockEC2API) CancelImportTaskRequest(_param0 *ec2.CancelImportTaskInput) (*request.Request, *ec2.CancelImportTaskOutput) {
-	ret := _m.ctrl.Call(_m, "CancelImportTaskRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CancelImportTaskOutput)
+func (_m *MockEC2API) CancelExportTaskWithContext(_param0 aws.Context, _param1 *ec2.CancelExportTaskInput, _param2 ...request.Option) (*ec2.CancelExportTaskOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CancelExportTaskWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CancelExportTaskOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CancelImportTaskRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelImportTaskRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CancelExportTaskWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelExportTaskWithContext", _s...)
+}
+
+func (_m *MockEC2API) CancelExportTaskRequest(_param0 *ec2.CancelExportTaskInput) (*request.Request, *ec2.CancelExportTaskOutput) {
+	ret := _m.ctrl.Call(_m, "CancelExportTaskRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CancelExportTaskOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CancelExportTaskRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelExportTaskRequest", arg0)
 }
 
 func (_m *MockEC2API) CancelImportTask(_param0 *ec2.CancelImportTaskInput) (*ec2.CancelImportTaskOutput, error) {
@@ -558,15 +916,31 @@ func (_mr *_MockEC2APIRecorder) CancelImportTask(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelImportTask", arg0)
 }
 
-func (_m *MockEC2API) CancelReservedInstancesListingRequest(_param0 *ec2.CancelReservedInstancesListingInput) (*request.Request, *ec2.CancelReservedInstancesListingOutput) {
-	ret := _m.ctrl.Call(_m, "CancelReservedInstancesListingRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CancelReservedInstancesListingOutput)
+func (_m *MockEC2API) CancelImportTaskWithContext(_param0 aws.Context, _param1 *ec2.CancelImportTaskInput, _param2 ...request.Option) (*ec2.CancelImportTaskOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CancelImportTaskWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CancelImportTaskOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CancelReservedInstancesListingRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelReservedInstancesListingRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CancelImportTaskWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelImportTaskWithContext", _s...)
+}
+
+func (_m *MockEC2API) CancelImportTaskRequest(_param0 *ec2.CancelImportTaskInput) (*request.Request, *ec2.CancelImportTaskOutput) {
+	ret := _m.ctrl.Call(_m, "CancelImportTaskRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CancelImportTaskOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CancelImportTaskRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelImportTaskRequest", arg0)
 }
 
 func (_m *MockEC2API) CancelReservedInstancesListing(_param0 *ec2.CancelReservedInstancesListingInput) (*ec2.CancelReservedInstancesListingOutput, error) {
@@ -580,15 +954,31 @@ func (_mr *_MockEC2APIRecorder) CancelReservedInstancesListing(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelReservedInstancesListing", arg0)
 }
 
-func (_m *MockEC2API) CancelSpotFleetRequestsRequest(_param0 *ec2.CancelSpotFleetRequestsInput) (*request.Request, *ec2.CancelSpotFleetRequestsOutput) {
-	ret := _m.ctrl.Call(_m, "CancelSpotFleetRequestsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CancelSpotFleetRequestsOutput)
+func (_m *MockEC2API) CancelReservedInstancesListingWithContext(_param0 aws.Context, _param1 *ec2.CancelReservedInstancesListingInput, _param2 ...request.Option) (*ec2.CancelReservedInstancesListingOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CancelReservedInstancesListingWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CancelReservedInstancesListingOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CancelSpotFleetRequestsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelSpotFleetRequestsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CancelReservedInstancesListingWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelReservedInstancesListingWithContext", _s...)
+}
+
+func (_m *MockEC2API) CancelReservedInstancesListingRequest(_param0 *ec2.CancelReservedInstancesListingInput) (*request.Request, *ec2.CancelReservedInstancesListingOutput) {
+	ret := _m.ctrl.Call(_m, "CancelReservedInstancesListingRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CancelReservedInstancesListingOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CancelReservedInstancesListingRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelReservedInstancesListingRequest", arg0)
 }
 
 func (_m *MockEC2API) CancelSpotFleetRequests(_param0 *ec2.CancelSpotFleetRequestsInput) (*ec2.CancelSpotFleetRequestsOutput, error) {
@@ -602,15 +992,31 @@ func (_mr *_MockEC2APIRecorder) CancelSpotFleetRequests(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelSpotFleetRequests", arg0)
 }
 
-func (_m *MockEC2API) CancelSpotInstanceRequestsRequest(_param0 *ec2.CancelSpotInstanceRequestsInput) (*request.Request, *ec2.CancelSpotInstanceRequestsOutput) {
-	ret := _m.ctrl.Call(_m, "CancelSpotInstanceRequestsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CancelSpotInstanceRequestsOutput)
+func (_m *MockEC2API) CancelSpotFleetRequestsWithContext(_param0 aws.Context, _param1 *ec2.CancelSpotFleetRequestsInput, _param2 ...request.Option) (*ec2.CancelSpotFleetRequestsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CancelSpotFleetRequestsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CancelSpotFleetRequestsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CancelSpotInstanceRequestsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelSpotInstanceRequestsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CancelSpotFleetRequestsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelSpotFleetRequestsWithContext", _s...)
+}
+
+func (_m *MockEC2API) CancelSpotFleetRequestsRequest(_param0 *ec2.CancelSpotFleetRequestsInput) (*request.Request, *ec2.CancelSpotFleetRequestsOutput) {
+	ret := _m.ctrl.Call(_m, "CancelSpotFleetRequestsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CancelSpotFleetRequestsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CancelSpotFleetRequestsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelSpotFleetRequestsRequest", arg0)
 }
 
 func (_m *MockEC2API) CancelSpotInstanceRequests(_param0 *ec2.CancelSpotInstanceRequestsInput) (*ec2.CancelSpotInstanceRequestsOutput, error) {
@@ -624,15 +1030,31 @@ func (_mr *_MockEC2APIRecorder) CancelSpotInstanceRequests(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelSpotInstanceRequests", arg0)
 }
 
-func (_m *MockEC2API) ConfirmProductInstanceRequest(_param0 *ec2.ConfirmProductInstanceInput) (*request.Request, *ec2.ConfirmProductInstanceOutput) {
-	ret := _m.ctrl.Call(_m, "ConfirmProductInstanceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ConfirmProductInstanceOutput)
+func (_m *MockEC2API) CancelSpotInstanceRequestsWithContext(_param0 aws.Context, _param1 *ec2.CancelSpotInstanceRequestsInput, _param2 ...request.Option) (*ec2.CancelSpotInstanceRequestsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CancelSpotInstanceRequestsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CancelSpotInstanceRequestsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ConfirmProductInstanceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfirmProductInstanceRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CancelSpotInstanceRequestsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelSpotInstanceRequestsWithContext", _s...)
+}
+
+func (_m *MockEC2API) CancelSpotInstanceRequestsRequest(_param0 *ec2.CancelSpotInstanceRequestsInput) (*request.Request, *ec2.CancelSpotInstanceRequestsOutput) {
+	ret := _m.ctrl.Call(_m, "CancelSpotInstanceRequestsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CancelSpotInstanceRequestsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CancelSpotInstanceRequestsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelSpotInstanceRequestsRequest", arg0)
 }
 
 func (_m *MockEC2API) ConfirmProductInstance(_param0 *ec2.ConfirmProductInstanceInput) (*ec2.ConfirmProductInstanceOutput, error) {
@@ -646,15 +1068,31 @@ func (_mr *_MockEC2APIRecorder) ConfirmProductInstance(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfirmProductInstance", arg0)
 }
 
-func (_m *MockEC2API) CopyImageRequest(_param0 *ec2.CopyImageInput) (*request.Request, *ec2.CopyImageOutput) {
-	ret := _m.ctrl.Call(_m, "CopyImageRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CopyImageOutput)
+func (_m *MockEC2API) ConfirmProductInstanceWithContext(_param0 aws.Context, _param1 *ec2.ConfirmProductInstanceInput, _param2 ...request.Option) (*ec2.ConfirmProductInstanceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ConfirmProductInstanceWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ConfirmProductInstanceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CopyImageRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyImageRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ConfirmProductInstanceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfirmProductInstanceWithContext", _s...)
+}
+
+func (_m *MockEC2API) ConfirmProductInstanceRequest(_param0 *ec2.ConfirmProductInstanceInput) (*request.Request, *ec2.ConfirmProductInstanceOutput) {
+	ret := _m.ctrl.Call(_m, "ConfirmProductInstanceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ConfirmProductInstanceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ConfirmProductInstanceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfirmProductInstanceRequest", arg0)
 }
 
 func (_m *MockEC2API) CopyImage(_param0 *ec2.CopyImageInput) (*ec2.CopyImageOutput, error) {
@@ -668,15 +1106,31 @@ func (_mr *_MockEC2APIRecorder) CopyImage(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyImage", arg0)
 }
 
-func (_m *MockEC2API) CopySnapshotRequest(_param0 *ec2.CopySnapshotInput) (*request.Request, *ec2.CopySnapshotOutput) {
-	ret := _m.ctrl.Call(_m, "CopySnapshotRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CopySnapshotOutput)
+func (_m *MockEC2API) CopyImageWithContext(_param0 aws.Context, _param1 *ec2.CopyImageInput, _param2 ...request.Option) (*ec2.CopyImageOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CopyImageWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CopyImageOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CopySnapshotRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopySnapshotRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CopyImageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyImageWithContext", _s...)
+}
+
+func (_m *MockEC2API) CopyImageRequest(_param0 *ec2.CopyImageInput) (*request.Request, *ec2.CopyImageOutput) {
+	ret := _m.ctrl.Call(_m, "CopyImageRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CopyImageOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CopyImageRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyImageRequest", arg0)
 }
 
 func (_m *MockEC2API) CopySnapshot(_param0 *ec2.CopySnapshotInput) (*ec2.CopySnapshotOutput, error) {
@@ -690,15 +1144,31 @@ func (_mr *_MockEC2APIRecorder) CopySnapshot(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopySnapshot", arg0)
 }
 
-func (_m *MockEC2API) CreateCustomerGatewayRequest(_param0 *ec2.CreateCustomerGatewayInput) (*request.Request, *ec2.CreateCustomerGatewayOutput) {
-	ret := _m.ctrl.Call(_m, "CreateCustomerGatewayRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateCustomerGatewayOutput)
+func (_m *MockEC2API) CopySnapshotWithContext(_param0 aws.Context, _param1 *ec2.CopySnapshotInput, _param2 ...request.Option) (*ec2.CopySnapshotOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CopySnapshotWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CopySnapshotOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateCustomerGatewayRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCustomerGatewayRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CopySnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopySnapshotWithContext", _s...)
+}
+
+func (_m *MockEC2API) CopySnapshotRequest(_param0 *ec2.CopySnapshotInput) (*request.Request, *ec2.CopySnapshotOutput) {
+	ret := _m.ctrl.Call(_m, "CopySnapshotRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CopySnapshotOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CopySnapshotRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopySnapshotRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateCustomerGateway(_param0 *ec2.CreateCustomerGatewayInput) (*ec2.CreateCustomerGatewayOutput, error) {
@@ -712,15 +1182,31 @@ func (_mr *_MockEC2APIRecorder) CreateCustomerGateway(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCustomerGateway", arg0)
 }
 
-func (_m *MockEC2API) CreateDhcpOptionsRequest(_param0 *ec2.CreateDhcpOptionsInput) (*request.Request, *ec2.CreateDhcpOptionsOutput) {
-	ret := _m.ctrl.Call(_m, "CreateDhcpOptionsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateDhcpOptionsOutput)
+func (_m *MockEC2API) CreateCustomerGatewayWithContext(_param0 aws.Context, _param1 *ec2.CreateCustomerGatewayInput, _param2 ...request.Option) (*ec2.CreateCustomerGatewayOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateCustomerGatewayWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateCustomerGatewayOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateDhcpOptionsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDhcpOptionsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateCustomerGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCustomerGatewayWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateCustomerGatewayRequest(_param0 *ec2.CreateCustomerGatewayInput) (*request.Request, *ec2.CreateCustomerGatewayOutput) {
+	ret := _m.ctrl.Call(_m, "CreateCustomerGatewayRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateCustomerGatewayOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateCustomerGatewayRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCustomerGatewayRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateDhcpOptions(_param0 *ec2.CreateDhcpOptionsInput) (*ec2.CreateDhcpOptionsOutput, error) {
@@ -734,15 +1220,31 @@ func (_mr *_MockEC2APIRecorder) CreateDhcpOptions(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDhcpOptions", arg0)
 }
 
-func (_m *MockEC2API) CreateEgressOnlyInternetGatewayRequest(_param0 *ec2.CreateEgressOnlyInternetGatewayInput) (*request.Request, *ec2.CreateEgressOnlyInternetGatewayOutput) {
-	ret := _m.ctrl.Call(_m, "CreateEgressOnlyInternetGatewayRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateEgressOnlyInternetGatewayOutput)
+func (_m *MockEC2API) CreateDhcpOptionsWithContext(_param0 aws.Context, _param1 *ec2.CreateDhcpOptionsInput, _param2 ...request.Option) (*ec2.CreateDhcpOptionsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateDhcpOptionsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateDhcpOptionsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateEgressOnlyInternetGatewayRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateEgressOnlyInternetGatewayRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateDhcpOptionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDhcpOptionsWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateDhcpOptionsRequest(_param0 *ec2.CreateDhcpOptionsInput) (*request.Request, *ec2.CreateDhcpOptionsOutput) {
+	ret := _m.ctrl.Call(_m, "CreateDhcpOptionsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateDhcpOptionsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateDhcpOptionsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDhcpOptionsRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateEgressOnlyInternetGateway(_param0 *ec2.CreateEgressOnlyInternetGatewayInput) (*ec2.CreateEgressOnlyInternetGatewayOutput, error) {
@@ -756,15 +1258,31 @@ func (_mr *_MockEC2APIRecorder) CreateEgressOnlyInternetGateway(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateEgressOnlyInternetGateway", arg0)
 }
 
-func (_m *MockEC2API) CreateFlowLogsRequest(_param0 *ec2.CreateFlowLogsInput) (*request.Request, *ec2.CreateFlowLogsOutput) {
-	ret := _m.ctrl.Call(_m, "CreateFlowLogsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateFlowLogsOutput)
+func (_m *MockEC2API) CreateEgressOnlyInternetGatewayWithContext(_param0 aws.Context, _param1 *ec2.CreateEgressOnlyInternetGatewayInput, _param2 ...request.Option) (*ec2.CreateEgressOnlyInternetGatewayOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateEgressOnlyInternetGatewayWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateEgressOnlyInternetGatewayOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateFlowLogsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateFlowLogsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateEgressOnlyInternetGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateEgressOnlyInternetGatewayWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateEgressOnlyInternetGatewayRequest(_param0 *ec2.CreateEgressOnlyInternetGatewayInput) (*request.Request, *ec2.CreateEgressOnlyInternetGatewayOutput) {
+	ret := _m.ctrl.Call(_m, "CreateEgressOnlyInternetGatewayRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateEgressOnlyInternetGatewayOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateEgressOnlyInternetGatewayRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateEgressOnlyInternetGatewayRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateFlowLogs(_param0 *ec2.CreateFlowLogsInput) (*ec2.CreateFlowLogsOutput, error) {
@@ -778,15 +1296,31 @@ func (_mr *_MockEC2APIRecorder) CreateFlowLogs(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateFlowLogs", arg0)
 }
 
-func (_m *MockEC2API) CreateImageRequest(_param0 *ec2.CreateImageInput) (*request.Request, *ec2.CreateImageOutput) {
-	ret := _m.ctrl.Call(_m, "CreateImageRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateImageOutput)
+func (_m *MockEC2API) CreateFlowLogsWithContext(_param0 aws.Context, _param1 *ec2.CreateFlowLogsInput, _param2 ...request.Option) (*ec2.CreateFlowLogsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateFlowLogsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateFlowLogsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateImageRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateImageRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateFlowLogsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateFlowLogsWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateFlowLogsRequest(_param0 *ec2.CreateFlowLogsInput) (*request.Request, *ec2.CreateFlowLogsOutput) {
+	ret := _m.ctrl.Call(_m, "CreateFlowLogsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateFlowLogsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateFlowLogsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateFlowLogsRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateImage(_param0 *ec2.CreateImageInput) (*ec2.CreateImageOutput, error) {
@@ -800,15 +1334,31 @@ func (_mr *_MockEC2APIRecorder) CreateImage(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateImage", arg0)
 }
 
-func (_m *MockEC2API) CreateInstanceExportTaskRequest(_param0 *ec2.CreateInstanceExportTaskInput) (*request.Request, *ec2.CreateInstanceExportTaskOutput) {
-	ret := _m.ctrl.Call(_m, "CreateInstanceExportTaskRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateInstanceExportTaskOutput)
+func (_m *MockEC2API) CreateImageWithContext(_param0 aws.Context, _param1 *ec2.CreateImageInput, _param2 ...request.Option) (*ec2.CreateImageOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateImageWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateImageOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateInstanceExportTaskRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateInstanceExportTaskRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateImageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateImageWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateImageRequest(_param0 *ec2.CreateImageInput) (*request.Request, *ec2.CreateImageOutput) {
+	ret := _m.ctrl.Call(_m, "CreateImageRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateImageOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateImageRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateImageRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateInstanceExportTask(_param0 *ec2.CreateInstanceExportTaskInput) (*ec2.CreateInstanceExportTaskOutput, error) {
@@ -822,15 +1372,31 @@ func (_mr *_MockEC2APIRecorder) CreateInstanceExportTask(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateInstanceExportTask", arg0)
 }
 
-func (_m *MockEC2API) CreateInternetGatewayRequest(_param0 *ec2.CreateInternetGatewayInput) (*request.Request, *ec2.CreateInternetGatewayOutput) {
-	ret := _m.ctrl.Call(_m, "CreateInternetGatewayRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateInternetGatewayOutput)
+func (_m *MockEC2API) CreateInstanceExportTaskWithContext(_param0 aws.Context, _param1 *ec2.CreateInstanceExportTaskInput, _param2 ...request.Option) (*ec2.CreateInstanceExportTaskOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateInstanceExportTaskWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateInstanceExportTaskOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateInternetGatewayRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateInternetGatewayRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateInstanceExportTaskWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateInstanceExportTaskWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateInstanceExportTaskRequest(_param0 *ec2.CreateInstanceExportTaskInput) (*request.Request, *ec2.CreateInstanceExportTaskOutput) {
+	ret := _m.ctrl.Call(_m, "CreateInstanceExportTaskRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateInstanceExportTaskOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateInstanceExportTaskRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateInstanceExportTaskRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateInternetGateway(_param0 *ec2.CreateInternetGatewayInput) (*ec2.CreateInternetGatewayOutput, error) {
@@ -844,15 +1410,31 @@ func (_mr *_MockEC2APIRecorder) CreateInternetGateway(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateInternetGateway", arg0)
 }
 
-func (_m *MockEC2API) CreateKeyPairRequest(_param0 *ec2.CreateKeyPairInput) (*request.Request, *ec2.CreateKeyPairOutput) {
-	ret := _m.ctrl.Call(_m, "CreateKeyPairRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateKeyPairOutput)
+func (_m *MockEC2API) CreateInternetGatewayWithContext(_param0 aws.Context, _param1 *ec2.CreateInternetGatewayInput, _param2 ...request.Option) (*ec2.CreateInternetGatewayOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateInternetGatewayWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateInternetGatewayOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateKeyPairRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateKeyPairRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateInternetGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateInternetGatewayWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateInternetGatewayRequest(_param0 *ec2.CreateInternetGatewayInput) (*request.Request, *ec2.CreateInternetGatewayOutput) {
+	ret := _m.ctrl.Call(_m, "CreateInternetGatewayRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateInternetGatewayOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateInternetGatewayRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateInternetGatewayRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateKeyPair(_param0 *ec2.CreateKeyPairInput) (*ec2.CreateKeyPairOutput, error) {
@@ -866,15 +1448,31 @@ func (_mr *_MockEC2APIRecorder) CreateKeyPair(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateKeyPair", arg0)
 }
 
-func (_m *MockEC2API) CreateNatGatewayRequest(_param0 *ec2.CreateNatGatewayInput) (*request.Request, *ec2.CreateNatGatewayOutput) {
-	ret := _m.ctrl.Call(_m, "CreateNatGatewayRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateNatGatewayOutput)
+func (_m *MockEC2API) CreateKeyPairWithContext(_param0 aws.Context, _param1 *ec2.CreateKeyPairInput, _param2 ...request.Option) (*ec2.CreateKeyPairOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateKeyPairWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateKeyPairOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateNatGatewayRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateNatGatewayRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateKeyPairWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateKeyPairWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateKeyPairRequest(_param0 *ec2.CreateKeyPairInput) (*request.Request, *ec2.CreateKeyPairOutput) {
+	ret := _m.ctrl.Call(_m, "CreateKeyPairRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateKeyPairOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateKeyPairRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateKeyPairRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateNatGateway(_param0 *ec2.CreateNatGatewayInput) (*ec2.CreateNatGatewayOutput, error) {
@@ -888,15 +1486,31 @@ func (_mr *_MockEC2APIRecorder) CreateNatGateway(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateNatGateway", arg0)
 }
 
-func (_m *MockEC2API) CreateNetworkAclRequest(_param0 *ec2.CreateNetworkAclInput) (*request.Request, *ec2.CreateNetworkAclOutput) {
-	ret := _m.ctrl.Call(_m, "CreateNetworkAclRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateNetworkAclOutput)
+func (_m *MockEC2API) CreateNatGatewayWithContext(_param0 aws.Context, _param1 *ec2.CreateNatGatewayInput, _param2 ...request.Option) (*ec2.CreateNatGatewayOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateNatGatewayWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateNatGatewayOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateNetworkAclRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateNetworkAclRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateNatGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateNatGatewayWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateNatGatewayRequest(_param0 *ec2.CreateNatGatewayInput) (*request.Request, *ec2.CreateNatGatewayOutput) {
+	ret := _m.ctrl.Call(_m, "CreateNatGatewayRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateNatGatewayOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateNatGatewayRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateNatGatewayRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateNetworkAcl(_param0 *ec2.CreateNetworkAclInput) (*ec2.CreateNetworkAclOutput, error) {
@@ -910,15 +1524,31 @@ func (_mr *_MockEC2APIRecorder) CreateNetworkAcl(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateNetworkAcl", arg0)
 }
 
-func (_m *MockEC2API) CreateNetworkAclEntryRequest(_param0 *ec2.CreateNetworkAclEntryInput) (*request.Request, *ec2.CreateNetworkAclEntryOutput) {
-	ret := _m.ctrl.Call(_m, "CreateNetworkAclEntryRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateNetworkAclEntryOutput)
+func (_m *MockEC2API) CreateNetworkAclWithContext(_param0 aws.Context, _param1 *ec2.CreateNetworkAclInput, _param2 ...request.Option) (*ec2.CreateNetworkAclOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateNetworkAclWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateNetworkAclOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateNetworkAclEntryRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateNetworkAclEntryRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateNetworkAclWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateNetworkAclWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateNetworkAclRequest(_param0 *ec2.CreateNetworkAclInput) (*request.Request, *ec2.CreateNetworkAclOutput) {
+	ret := _m.ctrl.Call(_m, "CreateNetworkAclRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateNetworkAclOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateNetworkAclRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateNetworkAclRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateNetworkAclEntry(_param0 *ec2.CreateNetworkAclEntryInput) (*ec2.CreateNetworkAclEntryOutput, error) {
@@ -932,15 +1562,31 @@ func (_mr *_MockEC2APIRecorder) CreateNetworkAclEntry(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateNetworkAclEntry", arg0)
 }
 
-func (_m *MockEC2API) CreateNetworkInterfaceRequest(_param0 *ec2.CreateNetworkInterfaceInput) (*request.Request, *ec2.CreateNetworkInterfaceOutput) {
-	ret := _m.ctrl.Call(_m, "CreateNetworkInterfaceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateNetworkInterfaceOutput)
+func (_m *MockEC2API) CreateNetworkAclEntryWithContext(_param0 aws.Context, _param1 *ec2.CreateNetworkAclEntryInput, _param2 ...request.Option) (*ec2.CreateNetworkAclEntryOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateNetworkAclEntryWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateNetworkAclEntryOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateNetworkInterfaceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateNetworkInterfaceRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateNetworkAclEntryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateNetworkAclEntryWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateNetworkAclEntryRequest(_param0 *ec2.CreateNetworkAclEntryInput) (*request.Request, *ec2.CreateNetworkAclEntryOutput) {
+	ret := _m.ctrl.Call(_m, "CreateNetworkAclEntryRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateNetworkAclEntryOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateNetworkAclEntryRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateNetworkAclEntryRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateNetworkInterface(_param0 *ec2.CreateNetworkInterfaceInput) (*ec2.CreateNetworkInterfaceOutput, error) {
@@ -954,15 +1600,31 @@ func (_mr *_MockEC2APIRecorder) CreateNetworkInterface(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateNetworkInterface", arg0)
 }
 
-func (_m *MockEC2API) CreatePlacementGroupRequest(_param0 *ec2.CreatePlacementGroupInput) (*request.Request, *ec2.CreatePlacementGroupOutput) {
-	ret := _m.ctrl.Call(_m, "CreatePlacementGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreatePlacementGroupOutput)
+func (_m *MockEC2API) CreateNetworkInterfaceWithContext(_param0 aws.Context, _param1 *ec2.CreateNetworkInterfaceInput, _param2 ...request.Option) (*ec2.CreateNetworkInterfaceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateNetworkInterfaceWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateNetworkInterfaceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreatePlacementGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreatePlacementGroupRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateNetworkInterfaceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateNetworkInterfaceWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateNetworkInterfaceRequest(_param0 *ec2.CreateNetworkInterfaceInput) (*request.Request, *ec2.CreateNetworkInterfaceOutput) {
+	ret := _m.ctrl.Call(_m, "CreateNetworkInterfaceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateNetworkInterfaceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateNetworkInterfaceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateNetworkInterfaceRequest", arg0)
 }
 
 func (_m *MockEC2API) CreatePlacementGroup(_param0 *ec2.CreatePlacementGroupInput) (*ec2.CreatePlacementGroupOutput, error) {
@@ -976,15 +1638,31 @@ func (_mr *_MockEC2APIRecorder) CreatePlacementGroup(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreatePlacementGroup", arg0)
 }
 
-func (_m *MockEC2API) CreateReservedInstancesListingRequest(_param0 *ec2.CreateReservedInstancesListingInput) (*request.Request, *ec2.CreateReservedInstancesListingOutput) {
-	ret := _m.ctrl.Call(_m, "CreateReservedInstancesListingRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateReservedInstancesListingOutput)
+func (_m *MockEC2API) CreatePlacementGroupWithContext(_param0 aws.Context, _param1 *ec2.CreatePlacementGroupInput, _param2 ...request.Option) (*ec2.CreatePlacementGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreatePlacementGroupWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreatePlacementGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateReservedInstancesListingRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateReservedInstancesListingRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreatePlacementGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreatePlacementGroupWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreatePlacementGroupRequest(_param0 *ec2.CreatePlacementGroupInput) (*request.Request, *ec2.CreatePlacementGroupOutput) {
+	ret := _m.ctrl.Call(_m, "CreatePlacementGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreatePlacementGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreatePlacementGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreatePlacementGroupRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateReservedInstancesListing(_param0 *ec2.CreateReservedInstancesListingInput) (*ec2.CreateReservedInstancesListingOutput, error) {
@@ -998,15 +1676,31 @@ func (_mr *_MockEC2APIRecorder) CreateReservedInstancesListing(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateReservedInstancesListing", arg0)
 }
 
-func (_m *MockEC2API) CreateRouteRequest(_param0 *ec2.CreateRouteInput) (*request.Request, *ec2.CreateRouteOutput) {
-	ret := _m.ctrl.Call(_m, "CreateRouteRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateRouteOutput)
+func (_m *MockEC2API) CreateReservedInstancesListingWithContext(_param0 aws.Context, _param1 *ec2.CreateReservedInstancesListingInput, _param2 ...request.Option) (*ec2.CreateReservedInstancesListingOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateReservedInstancesListingWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateReservedInstancesListingOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateRouteRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateRouteRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateReservedInstancesListingWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateReservedInstancesListingWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateReservedInstancesListingRequest(_param0 *ec2.CreateReservedInstancesListingInput) (*request.Request, *ec2.CreateReservedInstancesListingOutput) {
+	ret := _m.ctrl.Call(_m, "CreateReservedInstancesListingRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateReservedInstancesListingOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateReservedInstancesListingRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateReservedInstancesListingRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateRoute(_param0 *ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error) {
@@ -1020,15 +1714,31 @@ func (_mr *_MockEC2APIRecorder) CreateRoute(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateRoute", arg0)
 }
 
-func (_m *MockEC2API) CreateRouteTableRequest(_param0 *ec2.CreateRouteTableInput) (*request.Request, *ec2.CreateRouteTableOutput) {
-	ret := _m.ctrl.Call(_m, "CreateRouteTableRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateRouteTableOutput)
+func (_m *MockEC2API) CreateRouteWithContext(_param0 aws.Context, _param1 *ec2.CreateRouteInput, _param2 ...request.Option) (*ec2.CreateRouteOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateRouteWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateRouteOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateRouteTableRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateRouteTableRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateRouteWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateRouteRequest(_param0 *ec2.CreateRouteInput) (*request.Request, *ec2.CreateRouteOutput) {
+	ret := _m.ctrl.Call(_m, "CreateRouteRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateRouteOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateRouteRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateRouteRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateRouteTable(_param0 *ec2.CreateRouteTableInput) (*ec2.CreateRouteTableOutput, error) {
@@ -1042,15 +1752,31 @@ func (_mr *_MockEC2APIRecorder) CreateRouteTable(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateRouteTable", arg0)
 }
 
-func (_m *MockEC2API) CreateSecurityGroupRequest(_param0 *ec2.CreateSecurityGroupInput) (*request.Request, *ec2.CreateSecurityGroupOutput) {
-	ret := _m.ctrl.Call(_m, "CreateSecurityGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateSecurityGroupOutput)
+func (_m *MockEC2API) CreateRouteTableWithContext(_param0 aws.Context, _param1 *ec2.CreateRouteTableInput, _param2 ...request.Option) (*ec2.CreateRouteTableOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateRouteTableWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateRouteTableOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateSecurityGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSecurityGroupRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateRouteTableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateRouteTableWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateRouteTableRequest(_param0 *ec2.CreateRouteTableInput) (*request.Request, *ec2.CreateRouteTableOutput) {
+	ret := _m.ctrl.Call(_m, "CreateRouteTableRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateRouteTableOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateRouteTableRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateRouteTableRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateSecurityGroup(_param0 *ec2.CreateSecurityGroupInput) (*ec2.CreateSecurityGroupOutput, error) {
@@ -1064,15 +1790,31 @@ func (_mr *_MockEC2APIRecorder) CreateSecurityGroup(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSecurityGroup", arg0)
 }
 
-func (_m *MockEC2API) CreateSnapshotRequest(_param0 *ec2.CreateSnapshotInput) (*request.Request, *ec2.Snapshot) {
-	ret := _m.ctrl.Call(_m, "CreateSnapshotRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.Snapshot)
+func (_m *MockEC2API) CreateSecurityGroupWithContext(_param0 aws.Context, _param1 *ec2.CreateSecurityGroupInput, _param2 ...request.Option) (*ec2.CreateSecurityGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateSecurityGroupWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateSecurityGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateSnapshotRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSnapshotRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateSecurityGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSecurityGroupWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateSecurityGroupRequest(_param0 *ec2.CreateSecurityGroupInput) (*request.Request, *ec2.CreateSecurityGroupOutput) {
+	ret := _m.ctrl.Call(_m, "CreateSecurityGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateSecurityGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateSecurityGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSecurityGroupRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateSnapshot(_param0 *ec2.CreateSnapshotInput) (*ec2.Snapshot, error) {
@@ -1086,15 +1828,31 @@ func (_mr *_MockEC2APIRecorder) CreateSnapshot(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSnapshot", arg0)
 }
 
-func (_m *MockEC2API) CreateSpotDatafeedSubscriptionRequest(_param0 *ec2.CreateSpotDatafeedSubscriptionInput) (*request.Request, *ec2.CreateSpotDatafeedSubscriptionOutput) {
-	ret := _m.ctrl.Call(_m, "CreateSpotDatafeedSubscriptionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateSpotDatafeedSubscriptionOutput)
+func (_m *MockEC2API) CreateSnapshotWithContext(_param0 aws.Context, _param1 *ec2.CreateSnapshotInput, _param2 ...request.Option) (*ec2.Snapshot, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateSnapshotWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.Snapshot)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateSpotDatafeedSubscriptionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSpotDatafeedSubscriptionRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateSnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSnapshotWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateSnapshotRequest(_param0 *ec2.CreateSnapshotInput) (*request.Request, *ec2.Snapshot) {
+	ret := _m.ctrl.Call(_m, "CreateSnapshotRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.Snapshot)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateSnapshotRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSnapshotRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateSpotDatafeedSubscription(_param0 *ec2.CreateSpotDatafeedSubscriptionInput) (*ec2.CreateSpotDatafeedSubscriptionOutput, error) {
@@ -1108,15 +1866,31 @@ func (_mr *_MockEC2APIRecorder) CreateSpotDatafeedSubscription(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSpotDatafeedSubscription", arg0)
 }
 
-func (_m *MockEC2API) CreateSubnetRequest(_param0 *ec2.CreateSubnetInput) (*request.Request, *ec2.CreateSubnetOutput) {
-	ret := _m.ctrl.Call(_m, "CreateSubnetRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateSubnetOutput)
+func (_m *MockEC2API) CreateSpotDatafeedSubscriptionWithContext(_param0 aws.Context, _param1 *ec2.CreateSpotDatafeedSubscriptionInput, _param2 ...request.Option) (*ec2.CreateSpotDatafeedSubscriptionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateSpotDatafeedSubscriptionWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateSpotDatafeedSubscriptionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateSubnetRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSubnetRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateSpotDatafeedSubscriptionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSpotDatafeedSubscriptionWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateSpotDatafeedSubscriptionRequest(_param0 *ec2.CreateSpotDatafeedSubscriptionInput) (*request.Request, *ec2.CreateSpotDatafeedSubscriptionOutput) {
+	ret := _m.ctrl.Call(_m, "CreateSpotDatafeedSubscriptionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateSpotDatafeedSubscriptionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateSpotDatafeedSubscriptionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSpotDatafeedSubscriptionRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateSubnet(_param0 *ec2.CreateSubnetInput) (*ec2.CreateSubnetOutput, error) {
@@ -1130,15 +1904,31 @@ func (_mr *_MockEC2APIRecorder) CreateSubnet(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSubnet", arg0)
 }
 
-func (_m *MockEC2API) CreateTagsRequest(_param0 *ec2.CreateTagsInput) (*request.Request, *ec2.CreateTagsOutput) {
-	ret := _m.ctrl.Call(_m, "CreateTagsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateTagsOutput)
+func (_m *MockEC2API) CreateSubnetWithContext(_param0 aws.Context, _param1 *ec2.CreateSubnetInput, _param2 ...request.Option) (*ec2.CreateSubnetOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateSubnetWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateSubnetOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateTagsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateTagsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateSubnetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSubnetWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateSubnetRequest(_param0 *ec2.CreateSubnetInput) (*request.Request, *ec2.CreateSubnetOutput) {
+	ret := _m.ctrl.Call(_m, "CreateSubnetRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateSubnetOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateSubnetRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSubnetRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateTags(_param0 *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
@@ -1152,15 +1942,31 @@ func (_mr *_MockEC2APIRecorder) CreateTags(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateTags", arg0)
 }
 
-func (_m *MockEC2API) CreateVolumeRequest(_param0 *ec2.CreateVolumeInput) (*request.Request, *ec2.Volume) {
-	ret := _m.ctrl.Call(_m, "CreateVolumeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.Volume)
+func (_m *MockEC2API) CreateTagsWithContext(_param0 aws.Context, _param1 *ec2.CreateTagsInput, _param2 ...request.Option) (*ec2.CreateTagsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateTagsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateTagsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateVolumeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVolumeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateTagsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateTagsWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateTagsRequest(_param0 *ec2.CreateTagsInput) (*request.Request, *ec2.CreateTagsOutput) {
+	ret := _m.ctrl.Call(_m, "CreateTagsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateTagsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateTagsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateTagsRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateVolume(_param0 *ec2.CreateVolumeInput) (*ec2.Volume, error) {
@@ -1174,15 +1980,31 @@ func (_mr *_MockEC2APIRecorder) CreateVolume(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVolume", arg0)
 }
 
-func (_m *MockEC2API) CreateVpcRequest(_param0 *ec2.CreateVpcInput) (*request.Request, *ec2.CreateVpcOutput) {
-	ret := _m.ctrl.Call(_m, "CreateVpcRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateVpcOutput)
+func (_m *MockEC2API) CreateVolumeWithContext(_param0 aws.Context, _param1 *ec2.CreateVolumeInput, _param2 ...request.Option) (*ec2.Volume, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateVolumeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.Volume)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateVpcRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpcRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateVolumeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVolumeWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateVolumeRequest(_param0 *ec2.CreateVolumeInput) (*request.Request, *ec2.Volume) {
+	ret := _m.ctrl.Call(_m, "CreateVolumeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.Volume)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateVolumeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVolumeRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateVpc(_param0 *ec2.CreateVpcInput) (*ec2.CreateVpcOutput, error) {
@@ -1196,15 +2018,31 @@ func (_mr *_MockEC2APIRecorder) CreateVpc(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpc", arg0)
 }
 
-func (_m *MockEC2API) CreateVpcEndpointRequest(_param0 *ec2.CreateVpcEndpointInput) (*request.Request, *ec2.CreateVpcEndpointOutput) {
-	ret := _m.ctrl.Call(_m, "CreateVpcEndpointRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateVpcEndpointOutput)
+func (_m *MockEC2API) CreateVpcWithContext(_param0 aws.Context, _param1 *ec2.CreateVpcInput, _param2 ...request.Option) (*ec2.CreateVpcOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateVpcWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateVpcOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateVpcEndpointRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpcEndpointRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateVpcWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpcWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateVpcRequest(_param0 *ec2.CreateVpcInput) (*request.Request, *ec2.CreateVpcOutput) {
+	ret := _m.ctrl.Call(_m, "CreateVpcRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateVpcOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateVpcRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpcRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateVpcEndpoint(_param0 *ec2.CreateVpcEndpointInput) (*ec2.CreateVpcEndpointOutput, error) {
@@ -1218,15 +2056,31 @@ func (_mr *_MockEC2APIRecorder) CreateVpcEndpoint(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpcEndpoint", arg0)
 }
 
-func (_m *MockEC2API) CreateVpcPeeringConnectionRequest(_param0 *ec2.CreateVpcPeeringConnectionInput) (*request.Request, *ec2.CreateVpcPeeringConnectionOutput) {
-	ret := _m.ctrl.Call(_m, "CreateVpcPeeringConnectionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateVpcPeeringConnectionOutput)
+func (_m *MockEC2API) CreateVpcEndpointWithContext(_param0 aws.Context, _param1 *ec2.CreateVpcEndpointInput, _param2 ...request.Option) (*ec2.CreateVpcEndpointOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateVpcEndpointWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateVpcEndpointOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateVpcPeeringConnectionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpcPeeringConnectionRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateVpcEndpointWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpcEndpointWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateVpcEndpointRequest(_param0 *ec2.CreateVpcEndpointInput) (*request.Request, *ec2.CreateVpcEndpointOutput) {
+	ret := _m.ctrl.Call(_m, "CreateVpcEndpointRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateVpcEndpointOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateVpcEndpointRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpcEndpointRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateVpcPeeringConnection(_param0 *ec2.CreateVpcPeeringConnectionInput) (*ec2.CreateVpcPeeringConnectionOutput, error) {
@@ -1240,15 +2094,31 @@ func (_mr *_MockEC2APIRecorder) CreateVpcPeeringConnection(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpcPeeringConnection", arg0)
 }
 
-func (_m *MockEC2API) CreateVpnConnectionRequest(_param0 *ec2.CreateVpnConnectionInput) (*request.Request, *ec2.CreateVpnConnectionOutput) {
-	ret := _m.ctrl.Call(_m, "CreateVpnConnectionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateVpnConnectionOutput)
+func (_m *MockEC2API) CreateVpcPeeringConnectionWithContext(_param0 aws.Context, _param1 *ec2.CreateVpcPeeringConnectionInput, _param2 ...request.Option) (*ec2.CreateVpcPeeringConnectionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateVpcPeeringConnectionWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateVpcPeeringConnectionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateVpnConnectionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpnConnectionRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateVpcPeeringConnectionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpcPeeringConnectionWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateVpcPeeringConnectionRequest(_param0 *ec2.CreateVpcPeeringConnectionInput) (*request.Request, *ec2.CreateVpcPeeringConnectionOutput) {
+	ret := _m.ctrl.Call(_m, "CreateVpcPeeringConnectionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateVpcPeeringConnectionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateVpcPeeringConnectionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpcPeeringConnectionRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateVpnConnection(_param0 *ec2.CreateVpnConnectionInput) (*ec2.CreateVpnConnectionOutput, error) {
@@ -1262,15 +2132,31 @@ func (_mr *_MockEC2APIRecorder) CreateVpnConnection(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpnConnection", arg0)
 }
 
-func (_m *MockEC2API) CreateVpnConnectionRouteRequest(_param0 *ec2.CreateVpnConnectionRouteInput) (*request.Request, *ec2.CreateVpnConnectionRouteOutput) {
-	ret := _m.ctrl.Call(_m, "CreateVpnConnectionRouteRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateVpnConnectionRouteOutput)
+func (_m *MockEC2API) CreateVpnConnectionWithContext(_param0 aws.Context, _param1 *ec2.CreateVpnConnectionInput, _param2 ...request.Option) (*ec2.CreateVpnConnectionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateVpnConnectionWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateVpnConnectionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateVpnConnectionRouteRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpnConnectionRouteRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateVpnConnectionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpnConnectionWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateVpnConnectionRequest(_param0 *ec2.CreateVpnConnectionInput) (*request.Request, *ec2.CreateVpnConnectionOutput) {
+	ret := _m.ctrl.Call(_m, "CreateVpnConnectionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateVpnConnectionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateVpnConnectionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpnConnectionRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateVpnConnectionRoute(_param0 *ec2.CreateVpnConnectionRouteInput) (*ec2.CreateVpnConnectionRouteOutput, error) {
@@ -1284,15 +2170,31 @@ func (_mr *_MockEC2APIRecorder) CreateVpnConnectionRoute(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpnConnectionRoute", arg0)
 }
 
-func (_m *MockEC2API) CreateVpnGatewayRequest(_param0 *ec2.CreateVpnGatewayInput) (*request.Request, *ec2.CreateVpnGatewayOutput) {
-	ret := _m.ctrl.Call(_m, "CreateVpnGatewayRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.CreateVpnGatewayOutput)
+func (_m *MockEC2API) CreateVpnConnectionRouteWithContext(_param0 aws.Context, _param1 *ec2.CreateVpnConnectionRouteInput, _param2 ...request.Option) (*ec2.CreateVpnConnectionRouteOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateVpnConnectionRouteWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateVpnConnectionRouteOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) CreateVpnGatewayRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpnGatewayRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateVpnConnectionRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpnConnectionRouteWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateVpnConnectionRouteRequest(_param0 *ec2.CreateVpnConnectionRouteInput) (*request.Request, *ec2.CreateVpnConnectionRouteOutput) {
+	ret := _m.ctrl.Call(_m, "CreateVpnConnectionRouteRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateVpnConnectionRouteOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateVpnConnectionRouteRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpnConnectionRouteRequest", arg0)
 }
 
 func (_m *MockEC2API) CreateVpnGateway(_param0 *ec2.CreateVpnGatewayInput) (*ec2.CreateVpnGatewayOutput, error) {
@@ -1306,15 +2208,31 @@ func (_mr *_MockEC2APIRecorder) CreateVpnGateway(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpnGateway", arg0)
 }
 
-func (_m *MockEC2API) DeleteCustomerGatewayRequest(_param0 *ec2.DeleteCustomerGatewayInput) (*request.Request, *ec2.DeleteCustomerGatewayOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteCustomerGatewayRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteCustomerGatewayOutput)
+func (_m *MockEC2API) CreateVpnGatewayWithContext(_param0 aws.Context, _param1 *ec2.CreateVpnGatewayInput, _param2 ...request.Option) (*ec2.CreateVpnGatewayOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateVpnGatewayWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.CreateVpnGatewayOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteCustomerGatewayRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCustomerGatewayRequest", arg0)
+func (_mr *_MockEC2APIRecorder) CreateVpnGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpnGatewayWithContext", _s...)
+}
+
+func (_m *MockEC2API) CreateVpnGatewayRequest(_param0 *ec2.CreateVpnGatewayInput) (*request.Request, *ec2.CreateVpnGatewayOutput) {
+	ret := _m.ctrl.Call(_m, "CreateVpnGatewayRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateVpnGatewayOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) CreateVpnGatewayRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVpnGatewayRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteCustomerGateway(_param0 *ec2.DeleteCustomerGatewayInput) (*ec2.DeleteCustomerGatewayOutput, error) {
@@ -1328,15 +2246,31 @@ func (_mr *_MockEC2APIRecorder) DeleteCustomerGateway(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCustomerGateway", arg0)
 }
 
-func (_m *MockEC2API) DeleteDhcpOptionsRequest(_param0 *ec2.DeleteDhcpOptionsInput) (*request.Request, *ec2.DeleteDhcpOptionsOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteDhcpOptionsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteDhcpOptionsOutput)
+func (_m *MockEC2API) DeleteCustomerGatewayWithContext(_param0 aws.Context, _param1 *ec2.DeleteCustomerGatewayInput, _param2 ...request.Option) (*ec2.DeleteCustomerGatewayOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteCustomerGatewayWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteCustomerGatewayOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteDhcpOptionsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDhcpOptionsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteCustomerGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCustomerGatewayWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteCustomerGatewayRequest(_param0 *ec2.DeleteCustomerGatewayInput) (*request.Request, *ec2.DeleteCustomerGatewayOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteCustomerGatewayRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteCustomerGatewayOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteCustomerGatewayRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCustomerGatewayRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteDhcpOptions(_param0 *ec2.DeleteDhcpOptionsInput) (*ec2.DeleteDhcpOptionsOutput, error) {
@@ -1350,15 +2284,31 @@ func (_mr *_MockEC2APIRecorder) DeleteDhcpOptions(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDhcpOptions", arg0)
 }
 
-func (_m *MockEC2API) DeleteEgressOnlyInternetGatewayRequest(_param0 *ec2.DeleteEgressOnlyInternetGatewayInput) (*request.Request, *ec2.DeleteEgressOnlyInternetGatewayOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteEgressOnlyInternetGatewayRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteEgressOnlyInternetGatewayOutput)
+func (_m *MockEC2API) DeleteDhcpOptionsWithContext(_param0 aws.Context, _param1 *ec2.DeleteDhcpOptionsInput, _param2 ...request.Option) (*ec2.DeleteDhcpOptionsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteDhcpOptionsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteDhcpOptionsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteEgressOnlyInternetGatewayRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteEgressOnlyInternetGatewayRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteDhcpOptionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDhcpOptionsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteDhcpOptionsRequest(_param0 *ec2.DeleteDhcpOptionsInput) (*request.Request, *ec2.DeleteDhcpOptionsOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteDhcpOptionsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteDhcpOptionsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteDhcpOptionsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDhcpOptionsRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteEgressOnlyInternetGateway(_param0 *ec2.DeleteEgressOnlyInternetGatewayInput) (*ec2.DeleteEgressOnlyInternetGatewayOutput, error) {
@@ -1372,15 +2322,31 @@ func (_mr *_MockEC2APIRecorder) DeleteEgressOnlyInternetGateway(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteEgressOnlyInternetGateway", arg0)
 }
 
-func (_m *MockEC2API) DeleteFlowLogsRequest(_param0 *ec2.DeleteFlowLogsInput) (*request.Request, *ec2.DeleteFlowLogsOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteFlowLogsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteFlowLogsOutput)
+func (_m *MockEC2API) DeleteEgressOnlyInternetGatewayWithContext(_param0 aws.Context, _param1 *ec2.DeleteEgressOnlyInternetGatewayInput, _param2 ...request.Option) (*ec2.DeleteEgressOnlyInternetGatewayOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteEgressOnlyInternetGatewayWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteEgressOnlyInternetGatewayOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteFlowLogsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteFlowLogsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteEgressOnlyInternetGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteEgressOnlyInternetGatewayWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteEgressOnlyInternetGatewayRequest(_param0 *ec2.DeleteEgressOnlyInternetGatewayInput) (*request.Request, *ec2.DeleteEgressOnlyInternetGatewayOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteEgressOnlyInternetGatewayRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteEgressOnlyInternetGatewayOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteEgressOnlyInternetGatewayRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteEgressOnlyInternetGatewayRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteFlowLogs(_param0 *ec2.DeleteFlowLogsInput) (*ec2.DeleteFlowLogsOutput, error) {
@@ -1394,15 +2360,31 @@ func (_mr *_MockEC2APIRecorder) DeleteFlowLogs(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteFlowLogs", arg0)
 }
 
-func (_m *MockEC2API) DeleteInternetGatewayRequest(_param0 *ec2.DeleteInternetGatewayInput) (*request.Request, *ec2.DeleteInternetGatewayOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteInternetGatewayRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteInternetGatewayOutput)
+func (_m *MockEC2API) DeleteFlowLogsWithContext(_param0 aws.Context, _param1 *ec2.DeleteFlowLogsInput, _param2 ...request.Option) (*ec2.DeleteFlowLogsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteFlowLogsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteFlowLogsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteInternetGatewayRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteInternetGatewayRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteFlowLogsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteFlowLogsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteFlowLogsRequest(_param0 *ec2.DeleteFlowLogsInput) (*request.Request, *ec2.DeleteFlowLogsOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteFlowLogsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteFlowLogsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteFlowLogsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteFlowLogsRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteInternetGateway(_param0 *ec2.DeleteInternetGatewayInput) (*ec2.DeleteInternetGatewayOutput, error) {
@@ -1416,15 +2398,31 @@ func (_mr *_MockEC2APIRecorder) DeleteInternetGateway(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteInternetGateway", arg0)
 }
 
-func (_m *MockEC2API) DeleteKeyPairRequest(_param0 *ec2.DeleteKeyPairInput) (*request.Request, *ec2.DeleteKeyPairOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteKeyPairRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteKeyPairOutput)
+func (_m *MockEC2API) DeleteInternetGatewayWithContext(_param0 aws.Context, _param1 *ec2.DeleteInternetGatewayInput, _param2 ...request.Option) (*ec2.DeleteInternetGatewayOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteInternetGatewayWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteInternetGatewayOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteKeyPairRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteKeyPairRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteInternetGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteInternetGatewayWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteInternetGatewayRequest(_param0 *ec2.DeleteInternetGatewayInput) (*request.Request, *ec2.DeleteInternetGatewayOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteInternetGatewayRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteInternetGatewayOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteInternetGatewayRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteInternetGatewayRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteKeyPair(_param0 *ec2.DeleteKeyPairInput) (*ec2.DeleteKeyPairOutput, error) {
@@ -1438,15 +2436,31 @@ func (_mr *_MockEC2APIRecorder) DeleteKeyPair(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteKeyPair", arg0)
 }
 
-func (_m *MockEC2API) DeleteNatGatewayRequest(_param0 *ec2.DeleteNatGatewayInput) (*request.Request, *ec2.DeleteNatGatewayOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteNatGatewayRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteNatGatewayOutput)
+func (_m *MockEC2API) DeleteKeyPairWithContext(_param0 aws.Context, _param1 *ec2.DeleteKeyPairInput, _param2 ...request.Option) (*ec2.DeleteKeyPairOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteKeyPairWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteKeyPairOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteNatGatewayRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteNatGatewayRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteKeyPairWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteKeyPairWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteKeyPairRequest(_param0 *ec2.DeleteKeyPairInput) (*request.Request, *ec2.DeleteKeyPairOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteKeyPairRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteKeyPairOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteKeyPairRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteKeyPairRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteNatGateway(_param0 *ec2.DeleteNatGatewayInput) (*ec2.DeleteNatGatewayOutput, error) {
@@ -1460,15 +2474,31 @@ func (_mr *_MockEC2APIRecorder) DeleteNatGateway(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteNatGateway", arg0)
 }
 
-func (_m *MockEC2API) DeleteNetworkAclRequest(_param0 *ec2.DeleteNetworkAclInput) (*request.Request, *ec2.DeleteNetworkAclOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteNetworkAclRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteNetworkAclOutput)
+func (_m *MockEC2API) DeleteNatGatewayWithContext(_param0 aws.Context, _param1 *ec2.DeleteNatGatewayInput, _param2 ...request.Option) (*ec2.DeleteNatGatewayOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteNatGatewayWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteNatGatewayOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteNetworkAclRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteNetworkAclRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteNatGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteNatGatewayWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteNatGatewayRequest(_param0 *ec2.DeleteNatGatewayInput) (*request.Request, *ec2.DeleteNatGatewayOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteNatGatewayRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteNatGatewayOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteNatGatewayRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteNatGatewayRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteNetworkAcl(_param0 *ec2.DeleteNetworkAclInput) (*ec2.DeleteNetworkAclOutput, error) {
@@ -1482,15 +2512,31 @@ func (_mr *_MockEC2APIRecorder) DeleteNetworkAcl(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteNetworkAcl", arg0)
 }
 
-func (_m *MockEC2API) DeleteNetworkAclEntryRequest(_param0 *ec2.DeleteNetworkAclEntryInput) (*request.Request, *ec2.DeleteNetworkAclEntryOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteNetworkAclEntryRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteNetworkAclEntryOutput)
+func (_m *MockEC2API) DeleteNetworkAclWithContext(_param0 aws.Context, _param1 *ec2.DeleteNetworkAclInput, _param2 ...request.Option) (*ec2.DeleteNetworkAclOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteNetworkAclWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteNetworkAclOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteNetworkAclEntryRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteNetworkAclEntryRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteNetworkAclWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteNetworkAclWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteNetworkAclRequest(_param0 *ec2.DeleteNetworkAclInput) (*request.Request, *ec2.DeleteNetworkAclOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteNetworkAclRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteNetworkAclOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteNetworkAclRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteNetworkAclRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteNetworkAclEntry(_param0 *ec2.DeleteNetworkAclEntryInput) (*ec2.DeleteNetworkAclEntryOutput, error) {
@@ -1504,15 +2550,31 @@ func (_mr *_MockEC2APIRecorder) DeleteNetworkAclEntry(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteNetworkAclEntry", arg0)
 }
 
-func (_m *MockEC2API) DeleteNetworkInterfaceRequest(_param0 *ec2.DeleteNetworkInterfaceInput) (*request.Request, *ec2.DeleteNetworkInterfaceOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteNetworkInterfaceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteNetworkInterfaceOutput)
+func (_m *MockEC2API) DeleteNetworkAclEntryWithContext(_param0 aws.Context, _param1 *ec2.DeleteNetworkAclEntryInput, _param2 ...request.Option) (*ec2.DeleteNetworkAclEntryOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteNetworkAclEntryWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteNetworkAclEntryOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteNetworkInterfaceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteNetworkInterfaceRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteNetworkAclEntryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteNetworkAclEntryWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteNetworkAclEntryRequest(_param0 *ec2.DeleteNetworkAclEntryInput) (*request.Request, *ec2.DeleteNetworkAclEntryOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteNetworkAclEntryRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteNetworkAclEntryOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteNetworkAclEntryRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteNetworkAclEntryRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteNetworkInterface(_param0 *ec2.DeleteNetworkInterfaceInput) (*ec2.DeleteNetworkInterfaceOutput, error) {
@@ -1526,15 +2588,31 @@ func (_mr *_MockEC2APIRecorder) DeleteNetworkInterface(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteNetworkInterface", arg0)
 }
 
-func (_m *MockEC2API) DeletePlacementGroupRequest(_param0 *ec2.DeletePlacementGroupInput) (*request.Request, *ec2.DeletePlacementGroupOutput) {
-	ret := _m.ctrl.Call(_m, "DeletePlacementGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeletePlacementGroupOutput)
+func (_m *MockEC2API) DeleteNetworkInterfaceWithContext(_param0 aws.Context, _param1 *ec2.DeleteNetworkInterfaceInput, _param2 ...request.Option) (*ec2.DeleteNetworkInterfaceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteNetworkInterfaceWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteNetworkInterfaceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeletePlacementGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeletePlacementGroupRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteNetworkInterfaceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteNetworkInterfaceWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteNetworkInterfaceRequest(_param0 *ec2.DeleteNetworkInterfaceInput) (*request.Request, *ec2.DeleteNetworkInterfaceOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteNetworkInterfaceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteNetworkInterfaceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteNetworkInterfaceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteNetworkInterfaceRequest", arg0)
 }
 
 func (_m *MockEC2API) DeletePlacementGroup(_param0 *ec2.DeletePlacementGroupInput) (*ec2.DeletePlacementGroupOutput, error) {
@@ -1548,15 +2626,31 @@ func (_mr *_MockEC2APIRecorder) DeletePlacementGroup(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeletePlacementGroup", arg0)
 }
 
-func (_m *MockEC2API) DeleteRouteRequest(_param0 *ec2.DeleteRouteInput) (*request.Request, *ec2.DeleteRouteOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteRouteRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteRouteOutput)
+func (_m *MockEC2API) DeletePlacementGroupWithContext(_param0 aws.Context, _param1 *ec2.DeletePlacementGroupInput, _param2 ...request.Option) (*ec2.DeletePlacementGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeletePlacementGroupWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeletePlacementGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteRouteRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRouteRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeletePlacementGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeletePlacementGroupWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeletePlacementGroupRequest(_param0 *ec2.DeletePlacementGroupInput) (*request.Request, *ec2.DeletePlacementGroupOutput) {
+	ret := _m.ctrl.Call(_m, "DeletePlacementGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeletePlacementGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeletePlacementGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeletePlacementGroupRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteRoute(_param0 *ec2.DeleteRouteInput) (*ec2.DeleteRouteOutput, error) {
@@ -1570,15 +2664,31 @@ func (_mr *_MockEC2APIRecorder) DeleteRoute(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRoute", arg0)
 }
 
-func (_m *MockEC2API) DeleteRouteTableRequest(_param0 *ec2.DeleteRouteTableInput) (*request.Request, *ec2.DeleteRouteTableOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteRouteTableRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteRouteTableOutput)
+func (_m *MockEC2API) DeleteRouteWithContext(_param0 aws.Context, _param1 *ec2.DeleteRouteInput, _param2 ...request.Option) (*ec2.DeleteRouteOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteRouteWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteRouteOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteRouteTableRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRouteTableRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRouteWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteRouteRequest(_param0 *ec2.DeleteRouteInput) (*request.Request, *ec2.DeleteRouteOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteRouteRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteRouteOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteRouteRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRouteRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteRouteTable(_param0 *ec2.DeleteRouteTableInput) (*ec2.DeleteRouteTableOutput, error) {
@@ -1592,15 +2702,31 @@ func (_mr *_MockEC2APIRecorder) DeleteRouteTable(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRouteTable", arg0)
 }
 
-func (_m *MockEC2API) DeleteSecurityGroupRequest(_param0 *ec2.DeleteSecurityGroupInput) (*request.Request, *ec2.DeleteSecurityGroupOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteSecurityGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteSecurityGroupOutput)
+func (_m *MockEC2API) DeleteRouteTableWithContext(_param0 aws.Context, _param1 *ec2.DeleteRouteTableInput, _param2 ...request.Option) (*ec2.DeleteRouteTableOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteRouteTableWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteRouteTableOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteSecurityGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSecurityGroupRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteRouteTableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRouteTableWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteRouteTableRequest(_param0 *ec2.DeleteRouteTableInput) (*request.Request, *ec2.DeleteRouteTableOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteRouteTableRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteRouteTableOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteRouteTableRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRouteTableRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteSecurityGroup(_param0 *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
@@ -1614,15 +2740,31 @@ func (_mr *_MockEC2APIRecorder) DeleteSecurityGroup(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSecurityGroup", arg0)
 }
 
-func (_m *MockEC2API) DeleteSnapshotRequest(_param0 *ec2.DeleteSnapshotInput) (*request.Request, *ec2.DeleteSnapshotOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteSnapshotRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteSnapshotOutput)
+func (_m *MockEC2API) DeleteSecurityGroupWithContext(_param0 aws.Context, _param1 *ec2.DeleteSecurityGroupInput, _param2 ...request.Option) (*ec2.DeleteSecurityGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteSecurityGroupWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteSecurityGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteSnapshotRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSnapshotRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteSecurityGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSecurityGroupWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteSecurityGroupRequest(_param0 *ec2.DeleteSecurityGroupInput) (*request.Request, *ec2.DeleteSecurityGroupOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteSecurityGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteSecurityGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteSecurityGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSecurityGroupRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteSnapshot(_param0 *ec2.DeleteSnapshotInput) (*ec2.DeleteSnapshotOutput, error) {
@@ -1636,15 +2778,31 @@ func (_mr *_MockEC2APIRecorder) DeleteSnapshot(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSnapshot", arg0)
 }
 
-func (_m *MockEC2API) DeleteSpotDatafeedSubscriptionRequest(_param0 *ec2.DeleteSpotDatafeedSubscriptionInput) (*request.Request, *ec2.DeleteSpotDatafeedSubscriptionOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteSpotDatafeedSubscriptionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteSpotDatafeedSubscriptionOutput)
+func (_m *MockEC2API) DeleteSnapshotWithContext(_param0 aws.Context, _param1 *ec2.DeleteSnapshotInput, _param2 ...request.Option) (*ec2.DeleteSnapshotOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteSnapshotWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteSnapshotOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteSpotDatafeedSubscriptionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSpotDatafeedSubscriptionRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteSnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSnapshotWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteSnapshotRequest(_param0 *ec2.DeleteSnapshotInput) (*request.Request, *ec2.DeleteSnapshotOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteSnapshotRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteSnapshotOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteSnapshotRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSnapshotRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteSpotDatafeedSubscription(_param0 *ec2.DeleteSpotDatafeedSubscriptionInput) (*ec2.DeleteSpotDatafeedSubscriptionOutput, error) {
@@ -1658,15 +2816,31 @@ func (_mr *_MockEC2APIRecorder) DeleteSpotDatafeedSubscription(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSpotDatafeedSubscription", arg0)
 }
 
-func (_m *MockEC2API) DeleteSubnetRequest(_param0 *ec2.DeleteSubnetInput) (*request.Request, *ec2.DeleteSubnetOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteSubnetRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteSubnetOutput)
+func (_m *MockEC2API) DeleteSpotDatafeedSubscriptionWithContext(_param0 aws.Context, _param1 *ec2.DeleteSpotDatafeedSubscriptionInput, _param2 ...request.Option) (*ec2.DeleteSpotDatafeedSubscriptionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteSpotDatafeedSubscriptionWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteSpotDatafeedSubscriptionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteSubnetRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSubnetRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteSpotDatafeedSubscriptionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSpotDatafeedSubscriptionWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteSpotDatafeedSubscriptionRequest(_param0 *ec2.DeleteSpotDatafeedSubscriptionInput) (*request.Request, *ec2.DeleteSpotDatafeedSubscriptionOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteSpotDatafeedSubscriptionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteSpotDatafeedSubscriptionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteSpotDatafeedSubscriptionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSpotDatafeedSubscriptionRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteSubnet(_param0 *ec2.DeleteSubnetInput) (*ec2.DeleteSubnetOutput, error) {
@@ -1680,15 +2854,31 @@ func (_mr *_MockEC2APIRecorder) DeleteSubnet(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSubnet", arg0)
 }
 
-func (_m *MockEC2API) DeleteTagsRequest(_param0 *ec2.DeleteTagsInput) (*request.Request, *ec2.DeleteTagsOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteTagsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteTagsOutput)
+func (_m *MockEC2API) DeleteSubnetWithContext(_param0 aws.Context, _param1 *ec2.DeleteSubnetInput, _param2 ...request.Option) (*ec2.DeleteSubnetOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteSubnetWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteSubnetOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteTagsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteTagsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteSubnetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSubnetWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteSubnetRequest(_param0 *ec2.DeleteSubnetInput) (*request.Request, *ec2.DeleteSubnetOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteSubnetRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteSubnetOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteSubnetRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSubnetRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteTags(_param0 *ec2.DeleteTagsInput) (*ec2.DeleteTagsOutput, error) {
@@ -1702,15 +2892,31 @@ func (_mr *_MockEC2APIRecorder) DeleteTags(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteTags", arg0)
 }
 
-func (_m *MockEC2API) DeleteVolumeRequest(_param0 *ec2.DeleteVolumeInput) (*request.Request, *ec2.DeleteVolumeOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteVolumeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteVolumeOutput)
+func (_m *MockEC2API) DeleteTagsWithContext(_param0 aws.Context, _param1 *ec2.DeleteTagsInput, _param2 ...request.Option) (*ec2.DeleteTagsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteTagsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteTagsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteVolumeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVolumeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteTagsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteTagsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteTagsRequest(_param0 *ec2.DeleteTagsInput) (*request.Request, *ec2.DeleteTagsOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteTagsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteTagsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteTagsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteTagsRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteVolume(_param0 *ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error) {
@@ -1724,15 +2930,31 @@ func (_mr *_MockEC2APIRecorder) DeleteVolume(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVolume", arg0)
 }
 
-func (_m *MockEC2API) DeleteVpcRequest(_param0 *ec2.DeleteVpcInput) (*request.Request, *ec2.DeleteVpcOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteVpcRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteVpcOutput)
+func (_m *MockEC2API) DeleteVolumeWithContext(_param0 aws.Context, _param1 *ec2.DeleteVolumeInput, _param2 ...request.Option) (*ec2.DeleteVolumeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteVolumeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteVolumeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteVpcRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpcRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteVolumeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVolumeWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteVolumeRequest(_param0 *ec2.DeleteVolumeInput) (*request.Request, *ec2.DeleteVolumeOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteVolumeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteVolumeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteVolumeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVolumeRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteVpc(_param0 *ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, error) {
@@ -1746,15 +2968,31 @@ func (_mr *_MockEC2APIRecorder) DeleteVpc(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpc", arg0)
 }
 
-func (_m *MockEC2API) DeleteVpcEndpointsRequest(_param0 *ec2.DeleteVpcEndpointsInput) (*request.Request, *ec2.DeleteVpcEndpointsOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteVpcEndpointsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteVpcEndpointsOutput)
+func (_m *MockEC2API) DeleteVpcWithContext(_param0 aws.Context, _param1 *ec2.DeleteVpcInput, _param2 ...request.Option) (*ec2.DeleteVpcOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteVpcWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteVpcOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteVpcEndpointsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpcEndpointsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteVpcWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpcWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteVpcRequest(_param0 *ec2.DeleteVpcInput) (*request.Request, *ec2.DeleteVpcOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteVpcRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteVpcOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteVpcRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpcRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteVpcEndpoints(_param0 *ec2.DeleteVpcEndpointsInput) (*ec2.DeleteVpcEndpointsOutput, error) {
@@ -1768,15 +3006,31 @@ func (_mr *_MockEC2APIRecorder) DeleteVpcEndpoints(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpcEndpoints", arg0)
 }
 
-func (_m *MockEC2API) DeleteVpcPeeringConnectionRequest(_param0 *ec2.DeleteVpcPeeringConnectionInput) (*request.Request, *ec2.DeleteVpcPeeringConnectionOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteVpcPeeringConnectionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteVpcPeeringConnectionOutput)
+func (_m *MockEC2API) DeleteVpcEndpointsWithContext(_param0 aws.Context, _param1 *ec2.DeleteVpcEndpointsInput, _param2 ...request.Option) (*ec2.DeleteVpcEndpointsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteVpcEndpointsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteVpcEndpointsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteVpcPeeringConnectionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpcPeeringConnectionRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteVpcEndpointsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpcEndpointsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteVpcEndpointsRequest(_param0 *ec2.DeleteVpcEndpointsInput) (*request.Request, *ec2.DeleteVpcEndpointsOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteVpcEndpointsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteVpcEndpointsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteVpcEndpointsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpcEndpointsRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteVpcPeeringConnection(_param0 *ec2.DeleteVpcPeeringConnectionInput) (*ec2.DeleteVpcPeeringConnectionOutput, error) {
@@ -1790,15 +3044,31 @@ func (_mr *_MockEC2APIRecorder) DeleteVpcPeeringConnection(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpcPeeringConnection", arg0)
 }
 
-func (_m *MockEC2API) DeleteVpnConnectionRequest(_param0 *ec2.DeleteVpnConnectionInput) (*request.Request, *ec2.DeleteVpnConnectionOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteVpnConnectionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteVpnConnectionOutput)
+func (_m *MockEC2API) DeleteVpcPeeringConnectionWithContext(_param0 aws.Context, _param1 *ec2.DeleteVpcPeeringConnectionInput, _param2 ...request.Option) (*ec2.DeleteVpcPeeringConnectionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteVpcPeeringConnectionWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteVpcPeeringConnectionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteVpnConnectionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpnConnectionRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteVpcPeeringConnectionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpcPeeringConnectionWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteVpcPeeringConnectionRequest(_param0 *ec2.DeleteVpcPeeringConnectionInput) (*request.Request, *ec2.DeleteVpcPeeringConnectionOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteVpcPeeringConnectionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteVpcPeeringConnectionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteVpcPeeringConnectionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpcPeeringConnectionRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteVpnConnection(_param0 *ec2.DeleteVpnConnectionInput) (*ec2.DeleteVpnConnectionOutput, error) {
@@ -1812,15 +3082,31 @@ func (_mr *_MockEC2APIRecorder) DeleteVpnConnection(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpnConnection", arg0)
 }
 
-func (_m *MockEC2API) DeleteVpnConnectionRouteRequest(_param0 *ec2.DeleteVpnConnectionRouteInput) (*request.Request, *ec2.DeleteVpnConnectionRouteOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteVpnConnectionRouteRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteVpnConnectionRouteOutput)
+func (_m *MockEC2API) DeleteVpnConnectionWithContext(_param0 aws.Context, _param1 *ec2.DeleteVpnConnectionInput, _param2 ...request.Option) (*ec2.DeleteVpnConnectionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteVpnConnectionWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteVpnConnectionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteVpnConnectionRouteRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpnConnectionRouteRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteVpnConnectionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpnConnectionWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteVpnConnectionRequest(_param0 *ec2.DeleteVpnConnectionInput) (*request.Request, *ec2.DeleteVpnConnectionOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteVpnConnectionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteVpnConnectionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteVpnConnectionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpnConnectionRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteVpnConnectionRoute(_param0 *ec2.DeleteVpnConnectionRouteInput) (*ec2.DeleteVpnConnectionRouteOutput, error) {
@@ -1834,15 +3120,31 @@ func (_mr *_MockEC2APIRecorder) DeleteVpnConnectionRoute(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpnConnectionRoute", arg0)
 }
 
-func (_m *MockEC2API) DeleteVpnGatewayRequest(_param0 *ec2.DeleteVpnGatewayInput) (*request.Request, *ec2.DeleteVpnGatewayOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteVpnGatewayRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeleteVpnGatewayOutput)
+func (_m *MockEC2API) DeleteVpnConnectionRouteWithContext(_param0 aws.Context, _param1 *ec2.DeleteVpnConnectionRouteInput, _param2 ...request.Option) (*ec2.DeleteVpnConnectionRouteOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteVpnConnectionRouteWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteVpnConnectionRouteOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeleteVpnGatewayRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpnGatewayRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteVpnConnectionRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpnConnectionRouteWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteVpnConnectionRouteRequest(_param0 *ec2.DeleteVpnConnectionRouteInput) (*request.Request, *ec2.DeleteVpnConnectionRouteOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteVpnConnectionRouteRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteVpnConnectionRouteOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteVpnConnectionRouteRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpnConnectionRouteRequest", arg0)
 }
 
 func (_m *MockEC2API) DeleteVpnGateway(_param0 *ec2.DeleteVpnGatewayInput) (*ec2.DeleteVpnGatewayOutput, error) {
@@ -1856,15 +3158,31 @@ func (_mr *_MockEC2APIRecorder) DeleteVpnGateway(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpnGateway", arg0)
 }
 
-func (_m *MockEC2API) DeregisterImageRequest(_param0 *ec2.DeregisterImageInput) (*request.Request, *ec2.DeregisterImageOutput) {
-	ret := _m.ctrl.Call(_m, "DeregisterImageRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DeregisterImageOutput)
+func (_m *MockEC2API) DeleteVpnGatewayWithContext(_param0 aws.Context, _param1 *ec2.DeleteVpnGatewayInput, _param2 ...request.Option) (*ec2.DeleteVpnGatewayOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteVpnGatewayWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeleteVpnGatewayOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DeregisterImageRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeregisterImageRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeleteVpnGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpnGatewayWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeleteVpnGatewayRequest(_param0 *ec2.DeleteVpnGatewayInput) (*request.Request, *ec2.DeleteVpnGatewayOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteVpnGatewayRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteVpnGatewayOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeleteVpnGatewayRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVpnGatewayRequest", arg0)
 }
 
 func (_m *MockEC2API) DeregisterImage(_param0 *ec2.DeregisterImageInput) (*ec2.DeregisterImageOutput, error) {
@@ -1878,15 +3196,31 @@ func (_mr *_MockEC2APIRecorder) DeregisterImage(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeregisterImage", arg0)
 }
 
-func (_m *MockEC2API) DescribeAccountAttributesRequest(_param0 *ec2.DescribeAccountAttributesInput) (*request.Request, *ec2.DescribeAccountAttributesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeAccountAttributesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeAccountAttributesOutput)
+func (_m *MockEC2API) DeregisterImageWithContext(_param0 aws.Context, _param1 *ec2.DeregisterImageInput, _param2 ...request.Option) (*ec2.DeregisterImageOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeregisterImageWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DeregisterImageOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeAccountAttributesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeAccountAttributesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DeregisterImageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeregisterImageWithContext", _s...)
+}
+
+func (_m *MockEC2API) DeregisterImageRequest(_param0 *ec2.DeregisterImageInput) (*request.Request, *ec2.DeregisterImageOutput) {
+	ret := _m.ctrl.Call(_m, "DeregisterImageRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeregisterImageOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DeregisterImageRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeregisterImageRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeAccountAttributes(_param0 *ec2.DescribeAccountAttributesInput) (*ec2.DescribeAccountAttributesOutput, error) {
@@ -1900,15 +3234,31 @@ func (_mr *_MockEC2APIRecorder) DescribeAccountAttributes(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeAccountAttributes", arg0)
 }
 
-func (_m *MockEC2API) DescribeAddressesRequest(_param0 *ec2.DescribeAddressesInput) (*request.Request, *ec2.DescribeAddressesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeAddressesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeAddressesOutput)
+func (_m *MockEC2API) DescribeAccountAttributesWithContext(_param0 aws.Context, _param1 *ec2.DescribeAccountAttributesInput, _param2 ...request.Option) (*ec2.DescribeAccountAttributesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeAccountAttributesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeAccountAttributesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeAddressesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeAddressesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeAccountAttributesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeAccountAttributesWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeAccountAttributesRequest(_param0 *ec2.DescribeAccountAttributesInput) (*request.Request, *ec2.DescribeAccountAttributesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeAccountAttributesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeAccountAttributesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeAccountAttributesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeAccountAttributesRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeAddresses(_param0 *ec2.DescribeAddressesInput) (*ec2.DescribeAddressesOutput, error) {
@@ -1922,15 +3272,31 @@ func (_mr *_MockEC2APIRecorder) DescribeAddresses(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeAddresses", arg0)
 }
 
-func (_m *MockEC2API) DescribeAvailabilityZonesRequest(_param0 *ec2.DescribeAvailabilityZonesInput) (*request.Request, *ec2.DescribeAvailabilityZonesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeAvailabilityZonesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeAvailabilityZonesOutput)
+func (_m *MockEC2API) DescribeAddressesWithContext(_param0 aws.Context, _param1 *ec2.DescribeAddressesInput, _param2 ...request.Option) (*ec2.DescribeAddressesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeAddressesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeAddressesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeAvailabilityZonesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeAvailabilityZonesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeAddressesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeAddressesWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeAddressesRequest(_param0 *ec2.DescribeAddressesInput) (*request.Request, *ec2.DescribeAddressesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeAddressesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeAddressesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeAddressesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeAddressesRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeAvailabilityZones(_param0 *ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error) {
@@ -1944,15 +3310,31 @@ func (_mr *_MockEC2APIRecorder) DescribeAvailabilityZones(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeAvailabilityZones", arg0)
 }
 
-func (_m *MockEC2API) DescribeBundleTasksRequest(_param0 *ec2.DescribeBundleTasksInput) (*request.Request, *ec2.DescribeBundleTasksOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeBundleTasksRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeBundleTasksOutput)
+func (_m *MockEC2API) DescribeAvailabilityZonesWithContext(_param0 aws.Context, _param1 *ec2.DescribeAvailabilityZonesInput, _param2 ...request.Option) (*ec2.DescribeAvailabilityZonesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeAvailabilityZonesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeAvailabilityZonesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeBundleTasksRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeBundleTasksRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeAvailabilityZonesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeAvailabilityZonesWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeAvailabilityZonesRequest(_param0 *ec2.DescribeAvailabilityZonesInput) (*request.Request, *ec2.DescribeAvailabilityZonesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeAvailabilityZonesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeAvailabilityZonesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeAvailabilityZonesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeAvailabilityZonesRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeBundleTasks(_param0 *ec2.DescribeBundleTasksInput) (*ec2.DescribeBundleTasksOutput, error) {
@@ -1966,15 +3348,31 @@ func (_mr *_MockEC2APIRecorder) DescribeBundleTasks(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeBundleTasks", arg0)
 }
 
-func (_m *MockEC2API) DescribeClassicLinkInstancesRequest(_param0 *ec2.DescribeClassicLinkInstancesInput) (*request.Request, *ec2.DescribeClassicLinkInstancesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeClassicLinkInstancesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeClassicLinkInstancesOutput)
+func (_m *MockEC2API) DescribeBundleTasksWithContext(_param0 aws.Context, _param1 *ec2.DescribeBundleTasksInput, _param2 ...request.Option) (*ec2.DescribeBundleTasksOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeBundleTasksWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeBundleTasksOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeClassicLinkInstancesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeClassicLinkInstancesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeBundleTasksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeBundleTasksWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeBundleTasksRequest(_param0 *ec2.DescribeBundleTasksInput) (*request.Request, *ec2.DescribeBundleTasksOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeBundleTasksRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeBundleTasksOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeBundleTasksRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeBundleTasksRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeClassicLinkInstances(_param0 *ec2.DescribeClassicLinkInstancesInput) (*ec2.DescribeClassicLinkInstancesOutput, error) {
@@ -1988,15 +3386,31 @@ func (_mr *_MockEC2APIRecorder) DescribeClassicLinkInstances(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeClassicLinkInstances", arg0)
 }
 
-func (_m *MockEC2API) DescribeConversionTasksRequest(_param0 *ec2.DescribeConversionTasksInput) (*request.Request, *ec2.DescribeConversionTasksOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeConversionTasksRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeConversionTasksOutput)
+func (_m *MockEC2API) DescribeClassicLinkInstancesWithContext(_param0 aws.Context, _param1 *ec2.DescribeClassicLinkInstancesInput, _param2 ...request.Option) (*ec2.DescribeClassicLinkInstancesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeClassicLinkInstancesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeClassicLinkInstancesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeConversionTasksRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeConversionTasksRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeClassicLinkInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeClassicLinkInstancesWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeClassicLinkInstancesRequest(_param0 *ec2.DescribeClassicLinkInstancesInput) (*request.Request, *ec2.DescribeClassicLinkInstancesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeClassicLinkInstancesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeClassicLinkInstancesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeClassicLinkInstancesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeClassicLinkInstancesRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeConversionTasks(_param0 *ec2.DescribeConversionTasksInput) (*ec2.DescribeConversionTasksOutput, error) {
@@ -2010,15 +3424,31 @@ func (_mr *_MockEC2APIRecorder) DescribeConversionTasks(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeConversionTasks", arg0)
 }
 
-func (_m *MockEC2API) DescribeCustomerGatewaysRequest(_param0 *ec2.DescribeCustomerGatewaysInput) (*request.Request, *ec2.DescribeCustomerGatewaysOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeCustomerGatewaysRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeCustomerGatewaysOutput)
+func (_m *MockEC2API) DescribeConversionTasksWithContext(_param0 aws.Context, _param1 *ec2.DescribeConversionTasksInput, _param2 ...request.Option) (*ec2.DescribeConversionTasksOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeConversionTasksWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeConversionTasksOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeCustomerGatewaysRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCustomerGatewaysRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeConversionTasksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeConversionTasksWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeConversionTasksRequest(_param0 *ec2.DescribeConversionTasksInput) (*request.Request, *ec2.DescribeConversionTasksOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeConversionTasksRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeConversionTasksOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeConversionTasksRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeConversionTasksRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeCustomerGateways(_param0 *ec2.DescribeCustomerGatewaysInput) (*ec2.DescribeCustomerGatewaysOutput, error) {
@@ -2032,15 +3462,31 @@ func (_mr *_MockEC2APIRecorder) DescribeCustomerGateways(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCustomerGateways", arg0)
 }
 
-func (_m *MockEC2API) DescribeDhcpOptionsRequest(_param0 *ec2.DescribeDhcpOptionsInput) (*request.Request, *ec2.DescribeDhcpOptionsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeDhcpOptionsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeDhcpOptionsOutput)
+func (_m *MockEC2API) DescribeCustomerGatewaysWithContext(_param0 aws.Context, _param1 *ec2.DescribeCustomerGatewaysInput, _param2 ...request.Option) (*ec2.DescribeCustomerGatewaysOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeCustomerGatewaysWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeCustomerGatewaysOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeDhcpOptionsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDhcpOptionsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeCustomerGatewaysWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCustomerGatewaysWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeCustomerGatewaysRequest(_param0 *ec2.DescribeCustomerGatewaysInput) (*request.Request, *ec2.DescribeCustomerGatewaysOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeCustomerGatewaysRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeCustomerGatewaysOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeCustomerGatewaysRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCustomerGatewaysRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeDhcpOptions(_param0 *ec2.DescribeDhcpOptionsInput) (*ec2.DescribeDhcpOptionsOutput, error) {
@@ -2054,15 +3500,31 @@ func (_mr *_MockEC2APIRecorder) DescribeDhcpOptions(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDhcpOptions", arg0)
 }
 
-func (_m *MockEC2API) DescribeEgressOnlyInternetGatewaysRequest(_param0 *ec2.DescribeEgressOnlyInternetGatewaysInput) (*request.Request, *ec2.DescribeEgressOnlyInternetGatewaysOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeEgressOnlyInternetGatewaysRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeEgressOnlyInternetGatewaysOutput)
+func (_m *MockEC2API) DescribeDhcpOptionsWithContext(_param0 aws.Context, _param1 *ec2.DescribeDhcpOptionsInput, _param2 ...request.Option) (*ec2.DescribeDhcpOptionsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDhcpOptionsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeDhcpOptionsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeEgressOnlyInternetGatewaysRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEgressOnlyInternetGatewaysRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeDhcpOptionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDhcpOptionsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeDhcpOptionsRequest(_param0 *ec2.DescribeDhcpOptionsInput) (*request.Request, *ec2.DescribeDhcpOptionsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeDhcpOptionsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeDhcpOptionsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeDhcpOptionsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDhcpOptionsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeEgressOnlyInternetGateways(_param0 *ec2.DescribeEgressOnlyInternetGatewaysInput) (*ec2.DescribeEgressOnlyInternetGatewaysOutput, error) {
@@ -2076,15 +3538,31 @@ func (_mr *_MockEC2APIRecorder) DescribeEgressOnlyInternetGateways(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEgressOnlyInternetGateways", arg0)
 }
 
-func (_m *MockEC2API) DescribeExportTasksRequest(_param0 *ec2.DescribeExportTasksInput) (*request.Request, *ec2.DescribeExportTasksOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeExportTasksRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeExportTasksOutput)
+func (_m *MockEC2API) DescribeEgressOnlyInternetGatewaysWithContext(_param0 aws.Context, _param1 *ec2.DescribeEgressOnlyInternetGatewaysInput, _param2 ...request.Option) (*ec2.DescribeEgressOnlyInternetGatewaysOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeEgressOnlyInternetGatewaysWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeEgressOnlyInternetGatewaysOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeExportTasksRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeExportTasksRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeEgressOnlyInternetGatewaysWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEgressOnlyInternetGatewaysWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeEgressOnlyInternetGatewaysRequest(_param0 *ec2.DescribeEgressOnlyInternetGatewaysInput) (*request.Request, *ec2.DescribeEgressOnlyInternetGatewaysOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeEgressOnlyInternetGatewaysRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeEgressOnlyInternetGatewaysOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeEgressOnlyInternetGatewaysRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEgressOnlyInternetGatewaysRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeExportTasks(_param0 *ec2.DescribeExportTasksInput) (*ec2.DescribeExportTasksOutput, error) {
@@ -2098,15 +3576,31 @@ func (_mr *_MockEC2APIRecorder) DescribeExportTasks(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeExportTasks", arg0)
 }
 
-func (_m *MockEC2API) DescribeFlowLogsRequest(_param0 *ec2.DescribeFlowLogsInput) (*request.Request, *ec2.DescribeFlowLogsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeFlowLogsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeFlowLogsOutput)
+func (_m *MockEC2API) DescribeExportTasksWithContext(_param0 aws.Context, _param1 *ec2.DescribeExportTasksInput, _param2 ...request.Option) (*ec2.DescribeExportTasksOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeExportTasksWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeExportTasksOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeFlowLogsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeFlowLogsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeExportTasksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeExportTasksWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeExportTasksRequest(_param0 *ec2.DescribeExportTasksInput) (*request.Request, *ec2.DescribeExportTasksOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeExportTasksRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeExportTasksOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeExportTasksRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeExportTasksRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeFlowLogs(_param0 *ec2.DescribeFlowLogsInput) (*ec2.DescribeFlowLogsOutput, error) {
@@ -2120,15 +3614,31 @@ func (_mr *_MockEC2APIRecorder) DescribeFlowLogs(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeFlowLogs", arg0)
 }
 
-func (_m *MockEC2API) DescribeHostReservationOfferingsRequest(_param0 *ec2.DescribeHostReservationOfferingsInput) (*request.Request, *ec2.DescribeHostReservationOfferingsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeHostReservationOfferingsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeHostReservationOfferingsOutput)
+func (_m *MockEC2API) DescribeFlowLogsWithContext(_param0 aws.Context, _param1 *ec2.DescribeFlowLogsInput, _param2 ...request.Option) (*ec2.DescribeFlowLogsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeFlowLogsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeFlowLogsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeHostReservationOfferingsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeHostReservationOfferingsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeFlowLogsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeFlowLogsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeFlowLogsRequest(_param0 *ec2.DescribeFlowLogsInput) (*request.Request, *ec2.DescribeFlowLogsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeFlowLogsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeFlowLogsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeFlowLogsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeFlowLogsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeHostReservationOfferings(_param0 *ec2.DescribeHostReservationOfferingsInput) (*ec2.DescribeHostReservationOfferingsOutput, error) {
@@ -2142,15 +3652,31 @@ func (_mr *_MockEC2APIRecorder) DescribeHostReservationOfferings(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeHostReservationOfferings", arg0)
 }
 
-func (_m *MockEC2API) DescribeHostReservationsRequest(_param0 *ec2.DescribeHostReservationsInput) (*request.Request, *ec2.DescribeHostReservationsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeHostReservationsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeHostReservationsOutput)
+func (_m *MockEC2API) DescribeHostReservationOfferingsWithContext(_param0 aws.Context, _param1 *ec2.DescribeHostReservationOfferingsInput, _param2 ...request.Option) (*ec2.DescribeHostReservationOfferingsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeHostReservationOfferingsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeHostReservationOfferingsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeHostReservationsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeHostReservationsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeHostReservationOfferingsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeHostReservationOfferingsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeHostReservationOfferingsRequest(_param0 *ec2.DescribeHostReservationOfferingsInput) (*request.Request, *ec2.DescribeHostReservationOfferingsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeHostReservationOfferingsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeHostReservationOfferingsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeHostReservationOfferingsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeHostReservationOfferingsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeHostReservations(_param0 *ec2.DescribeHostReservationsInput) (*ec2.DescribeHostReservationsOutput, error) {
@@ -2164,15 +3690,31 @@ func (_mr *_MockEC2APIRecorder) DescribeHostReservations(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeHostReservations", arg0)
 }
 
-func (_m *MockEC2API) DescribeHostsRequest(_param0 *ec2.DescribeHostsInput) (*request.Request, *ec2.DescribeHostsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeHostsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeHostsOutput)
+func (_m *MockEC2API) DescribeHostReservationsWithContext(_param0 aws.Context, _param1 *ec2.DescribeHostReservationsInput, _param2 ...request.Option) (*ec2.DescribeHostReservationsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeHostReservationsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeHostReservationsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeHostsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeHostsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeHostReservationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeHostReservationsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeHostReservationsRequest(_param0 *ec2.DescribeHostReservationsInput) (*request.Request, *ec2.DescribeHostReservationsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeHostReservationsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeHostReservationsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeHostReservationsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeHostReservationsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeHosts(_param0 *ec2.DescribeHostsInput) (*ec2.DescribeHostsOutput, error) {
@@ -2186,15 +3728,31 @@ func (_mr *_MockEC2APIRecorder) DescribeHosts(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeHosts", arg0)
 }
 
-func (_m *MockEC2API) DescribeIamInstanceProfileAssociationsRequest(_param0 *ec2.DescribeIamInstanceProfileAssociationsInput) (*request.Request, *ec2.DescribeIamInstanceProfileAssociationsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeIamInstanceProfileAssociationsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeIamInstanceProfileAssociationsOutput)
+func (_m *MockEC2API) DescribeHostsWithContext(_param0 aws.Context, _param1 *ec2.DescribeHostsInput, _param2 ...request.Option) (*ec2.DescribeHostsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeHostsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeHostsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeIamInstanceProfileAssociationsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeIamInstanceProfileAssociationsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeHostsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeHostsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeHostsRequest(_param0 *ec2.DescribeHostsInput) (*request.Request, *ec2.DescribeHostsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeHostsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeHostsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeHostsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeHostsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeIamInstanceProfileAssociations(_param0 *ec2.DescribeIamInstanceProfileAssociationsInput) (*ec2.DescribeIamInstanceProfileAssociationsOutput, error) {
@@ -2208,15 +3766,31 @@ func (_mr *_MockEC2APIRecorder) DescribeIamInstanceProfileAssociations(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeIamInstanceProfileAssociations", arg0)
 }
 
-func (_m *MockEC2API) DescribeIdFormatRequest(_param0 *ec2.DescribeIdFormatInput) (*request.Request, *ec2.DescribeIdFormatOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeIdFormatRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeIdFormatOutput)
+func (_m *MockEC2API) DescribeIamInstanceProfileAssociationsWithContext(_param0 aws.Context, _param1 *ec2.DescribeIamInstanceProfileAssociationsInput, _param2 ...request.Option) (*ec2.DescribeIamInstanceProfileAssociationsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeIamInstanceProfileAssociationsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeIamInstanceProfileAssociationsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeIdFormatRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeIdFormatRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeIamInstanceProfileAssociationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeIamInstanceProfileAssociationsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeIamInstanceProfileAssociationsRequest(_param0 *ec2.DescribeIamInstanceProfileAssociationsInput) (*request.Request, *ec2.DescribeIamInstanceProfileAssociationsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeIamInstanceProfileAssociationsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeIamInstanceProfileAssociationsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeIamInstanceProfileAssociationsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeIamInstanceProfileAssociationsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeIdFormat(_param0 *ec2.DescribeIdFormatInput) (*ec2.DescribeIdFormatOutput, error) {
@@ -2230,15 +3804,31 @@ func (_mr *_MockEC2APIRecorder) DescribeIdFormat(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeIdFormat", arg0)
 }
 
-func (_m *MockEC2API) DescribeIdentityIdFormatRequest(_param0 *ec2.DescribeIdentityIdFormatInput) (*request.Request, *ec2.DescribeIdentityIdFormatOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeIdentityIdFormatRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeIdentityIdFormatOutput)
+func (_m *MockEC2API) DescribeIdFormatWithContext(_param0 aws.Context, _param1 *ec2.DescribeIdFormatInput, _param2 ...request.Option) (*ec2.DescribeIdFormatOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeIdFormatWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeIdFormatOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeIdentityIdFormatRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeIdentityIdFormatRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeIdFormatWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeIdFormatWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeIdFormatRequest(_param0 *ec2.DescribeIdFormatInput) (*request.Request, *ec2.DescribeIdFormatOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeIdFormatRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeIdFormatOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeIdFormatRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeIdFormatRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeIdentityIdFormat(_param0 *ec2.DescribeIdentityIdFormatInput) (*ec2.DescribeIdentityIdFormatOutput, error) {
@@ -2252,15 +3842,31 @@ func (_mr *_MockEC2APIRecorder) DescribeIdentityIdFormat(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeIdentityIdFormat", arg0)
 }
 
-func (_m *MockEC2API) DescribeImageAttributeRequest(_param0 *ec2.DescribeImageAttributeInput) (*request.Request, *ec2.DescribeImageAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeImageAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeImageAttributeOutput)
+func (_m *MockEC2API) DescribeIdentityIdFormatWithContext(_param0 aws.Context, _param1 *ec2.DescribeIdentityIdFormatInput, _param2 ...request.Option) (*ec2.DescribeIdentityIdFormatOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeIdentityIdFormatWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeIdentityIdFormatOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeImageAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeImageAttributeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeIdentityIdFormatWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeIdentityIdFormatWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeIdentityIdFormatRequest(_param0 *ec2.DescribeIdentityIdFormatInput) (*request.Request, *ec2.DescribeIdentityIdFormatOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeIdentityIdFormatRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeIdentityIdFormatOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeIdentityIdFormatRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeIdentityIdFormatRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeImageAttribute(_param0 *ec2.DescribeImageAttributeInput) (*ec2.DescribeImageAttributeOutput, error) {
@@ -2274,15 +3880,31 @@ func (_mr *_MockEC2APIRecorder) DescribeImageAttribute(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeImageAttribute", arg0)
 }
 
-func (_m *MockEC2API) DescribeImagesRequest(_param0 *ec2.DescribeImagesInput) (*request.Request, *ec2.DescribeImagesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeImagesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeImagesOutput)
+func (_m *MockEC2API) DescribeImageAttributeWithContext(_param0 aws.Context, _param1 *ec2.DescribeImageAttributeInput, _param2 ...request.Option) (*ec2.DescribeImageAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeImageAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeImageAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeImagesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeImagesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeImageAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeImageAttributeWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeImageAttributeRequest(_param0 *ec2.DescribeImageAttributeInput) (*request.Request, *ec2.DescribeImageAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeImageAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeImageAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeImageAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeImageAttributeRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeImages(_param0 *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
@@ -2296,15 +3918,31 @@ func (_mr *_MockEC2APIRecorder) DescribeImages(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeImages", arg0)
 }
 
-func (_m *MockEC2API) DescribeImportImageTasksRequest(_param0 *ec2.DescribeImportImageTasksInput) (*request.Request, *ec2.DescribeImportImageTasksOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeImportImageTasksRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeImportImageTasksOutput)
+func (_m *MockEC2API) DescribeImagesWithContext(_param0 aws.Context, _param1 *ec2.DescribeImagesInput, _param2 ...request.Option) (*ec2.DescribeImagesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeImagesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeImagesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeImportImageTasksRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeImportImageTasksRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeImagesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeImagesWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeImagesRequest(_param0 *ec2.DescribeImagesInput) (*request.Request, *ec2.DescribeImagesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeImagesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeImagesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeImagesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeImagesRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeImportImageTasks(_param0 *ec2.DescribeImportImageTasksInput) (*ec2.DescribeImportImageTasksOutput, error) {
@@ -2318,15 +3956,31 @@ func (_mr *_MockEC2APIRecorder) DescribeImportImageTasks(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeImportImageTasks", arg0)
 }
 
-func (_m *MockEC2API) DescribeImportSnapshotTasksRequest(_param0 *ec2.DescribeImportSnapshotTasksInput) (*request.Request, *ec2.DescribeImportSnapshotTasksOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeImportSnapshotTasksRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeImportSnapshotTasksOutput)
+func (_m *MockEC2API) DescribeImportImageTasksWithContext(_param0 aws.Context, _param1 *ec2.DescribeImportImageTasksInput, _param2 ...request.Option) (*ec2.DescribeImportImageTasksOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeImportImageTasksWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeImportImageTasksOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeImportSnapshotTasksRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeImportSnapshotTasksRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeImportImageTasksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeImportImageTasksWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeImportImageTasksRequest(_param0 *ec2.DescribeImportImageTasksInput) (*request.Request, *ec2.DescribeImportImageTasksOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeImportImageTasksRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeImportImageTasksOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeImportImageTasksRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeImportImageTasksRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeImportSnapshotTasks(_param0 *ec2.DescribeImportSnapshotTasksInput) (*ec2.DescribeImportSnapshotTasksOutput, error) {
@@ -2340,15 +3994,31 @@ func (_mr *_MockEC2APIRecorder) DescribeImportSnapshotTasks(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeImportSnapshotTasks", arg0)
 }
 
-func (_m *MockEC2API) DescribeInstanceAttributeRequest(_param0 *ec2.DescribeInstanceAttributeInput) (*request.Request, *ec2.DescribeInstanceAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeInstanceAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeInstanceAttributeOutput)
+func (_m *MockEC2API) DescribeImportSnapshotTasksWithContext(_param0 aws.Context, _param1 *ec2.DescribeImportSnapshotTasksInput, _param2 ...request.Option) (*ec2.DescribeImportSnapshotTasksOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeImportSnapshotTasksWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeImportSnapshotTasksOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeInstanceAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstanceAttributeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeImportSnapshotTasksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeImportSnapshotTasksWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeImportSnapshotTasksRequest(_param0 *ec2.DescribeImportSnapshotTasksInput) (*request.Request, *ec2.DescribeImportSnapshotTasksOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeImportSnapshotTasksRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeImportSnapshotTasksOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeImportSnapshotTasksRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeImportSnapshotTasksRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeInstanceAttribute(_param0 *ec2.DescribeInstanceAttributeInput) (*ec2.DescribeInstanceAttributeOutput, error) {
@@ -2362,15 +4032,31 @@ func (_mr *_MockEC2APIRecorder) DescribeInstanceAttribute(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstanceAttribute", arg0)
 }
 
-func (_m *MockEC2API) DescribeInstanceStatusRequest(_param0 *ec2.DescribeInstanceStatusInput) (*request.Request, *ec2.DescribeInstanceStatusOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeInstanceStatusRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeInstanceStatusOutput)
+func (_m *MockEC2API) DescribeInstanceAttributeWithContext(_param0 aws.Context, _param1 *ec2.DescribeInstanceAttributeInput, _param2 ...request.Option) (*ec2.DescribeInstanceAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeInstanceAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeInstanceAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeInstanceStatusRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstanceStatusRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeInstanceAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstanceAttributeWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeInstanceAttributeRequest(_param0 *ec2.DescribeInstanceAttributeInput) (*request.Request, *ec2.DescribeInstanceAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeInstanceAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeInstanceAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeInstanceAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstanceAttributeRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeInstanceStatus(_param0 *ec2.DescribeInstanceStatusInput) (*ec2.DescribeInstanceStatusOutput, error) {
@@ -2384,6 +4070,33 @@ func (_mr *_MockEC2APIRecorder) DescribeInstanceStatus(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstanceStatus", arg0)
 }
 
+func (_m *MockEC2API) DescribeInstanceStatusWithContext(_param0 aws.Context, _param1 *ec2.DescribeInstanceStatusInput, _param2 ...request.Option) (*ec2.DescribeInstanceStatusOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeInstanceStatusWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeInstanceStatusOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeInstanceStatusWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstanceStatusWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeInstanceStatusRequest(_param0 *ec2.DescribeInstanceStatusInput) (*request.Request, *ec2.DescribeInstanceStatusOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeInstanceStatusRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeInstanceStatusOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeInstanceStatusRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstanceStatusRequest", arg0)
+}
+
 func (_m *MockEC2API) DescribeInstanceStatusPages(_param0 *ec2.DescribeInstanceStatusInput, _param1 func(*ec2.DescribeInstanceStatusOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeInstanceStatusPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -2394,15 +4107,19 @@ func (_mr *_MockEC2APIRecorder) DescribeInstanceStatusPages(arg0, arg1 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstanceStatusPages", arg0, arg1)
 }
 
-func (_m *MockEC2API) DescribeInstancesRequest(_param0 *ec2.DescribeInstancesInput) (*request.Request, *ec2.DescribeInstancesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeInstancesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeInstancesOutput)
-	return ret0, ret1
+func (_m *MockEC2API) DescribeInstanceStatusPagesWithContext(_param0 aws.Context, _param1 *ec2.DescribeInstanceStatusInput, _param2 func(*ec2.DescribeInstanceStatusOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeInstanceStatusPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeInstancesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstancesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeInstanceStatusPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstanceStatusPagesWithContext", _s...)
 }
 
 func (_m *MockEC2API) DescribeInstances(_param0 *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
@@ -2416,6 +4133,33 @@ func (_mr *_MockEC2APIRecorder) DescribeInstances(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstances", arg0)
 }
 
+func (_m *MockEC2API) DescribeInstancesWithContext(_param0 aws.Context, _param1 *ec2.DescribeInstancesInput, _param2 ...request.Option) (*ec2.DescribeInstancesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeInstancesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeInstancesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstancesWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeInstancesRequest(_param0 *ec2.DescribeInstancesInput) (*request.Request, *ec2.DescribeInstancesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeInstancesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeInstancesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeInstancesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstancesRequest", arg0)
+}
+
 func (_m *MockEC2API) DescribeInstancesPages(_param0 *ec2.DescribeInstancesInput, _param1 func(*ec2.DescribeInstancesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeInstancesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -2426,15 +4170,19 @@ func (_mr *_MockEC2APIRecorder) DescribeInstancesPages(arg0, arg1 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstancesPages", arg0, arg1)
 }
 
-func (_m *MockEC2API) DescribeInternetGatewaysRequest(_param0 *ec2.DescribeInternetGatewaysInput) (*request.Request, *ec2.DescribeInternetGatewaysOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeInternetGatewaysRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeInternetGatewaysOutput)
-	return ret0, ret1
+func (_m *MockEC2API) DescribeInstancesPagesWithContext(_param0 aws.Context, _param1 *ec2.DescribeInstancesInput, _param2 func(*ec2.DescribeInstancesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeInstancesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeInternetGatewaysRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInternetGatewaysRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeInstancesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstancesPagesWithContext", _s...)
 }
 
 func (_m *MockEC2API) DescribeInternetGateways(_param0 *ec2.DescribeInternetGatewaysInput) (*ec2.DescribeInternetGatewaysOutput, error) {
@@ -2448,15 +4196,31 @@ func (_mr *_MockEC2APIRecorder) DescribeInternetGateways(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInternetGateways", arg0)
 }
 
-func (_m *MockEC2API) DescribeKeyPairsRequest(_param0 *ec2.DescribeKeyPairsInput) (*request.Request, *ec2.DescribeKeyPairsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeKeyPairsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeKeyPairsOutput)
+func (_m *MockEC2API) DescribeInternetGatewaysWithContext(_param0 aws.Context, _param1 *ec2.DescribeInternetGatewaysInput, _param2 ...request.Option) (*ec2.DescribeInternetGatewaysOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeInternetGatewaysWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeInternetGatewaysOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeKeyPairsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeKeyPairsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeInternetGatewaysWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInternetGatewaysWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeInternetGatewaysRequest(_param0 *ec2.DescribeInternetGatewaysInput) (*request.Request, *ec2.DescribeInternetGatewaysOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeInternetGatewaysRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeInternetGatewaysOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeInternetGatewaysRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInternetGatewaysRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeKeyPairs(_param0 *ec2.DescribeKeyPairsInput) (*ec2.DescribeKeyPairsOutput, error) {
@@ -2470,15 +4234,31 @@ func (_mr *_MockEC2APIRecorder) DescribeKeyPairs(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeKeyPairs", arg0)
 }
 
-func (_m *MockEC2API) DescribeMovingAddressesRequest(_param0 *ec2.DescribeMovingAddressesInput) (*request.Request, *ec2.DescribeMovingAddressesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeMovingAddressesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeMovingAddressesOutput)
+func (_m *MockEC2API) DescribeKeyPairsWithContext(_param0 aws.Context, _param1 *ec2.DescribeKeyPairsInput, _param2 ...request.Option) (*ec2.DescribeKeyPairsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeKeyPairsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeKeyPairsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeMovingAddressesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeMovingAddressesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeKeyPairsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeKeyPairsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeKeyPairsRequest(_param0 *ec2.DescribeKeyPairsInput) (*request.Request, *ec2.DescribeKeyPairsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeKeyPairsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeKeyPairsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeKeyPairsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeKeyPairsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeMovingAddresses(_param0 *ec2.DescribeMovingAddressesInput) (*ec2.DescribeMovingAddressesOutput, error) {
@@ -2492,15 +4272,31 @@ func (_mr *_MockEC2APIRecorder) DescribeMovingAddresses(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeMovingAddresses", arg0)
 }
 
-func (_m *MockEC2API) DescribeNatGatewaysRequest(_param0 *ec2.DescribeNatGatewaysInput) (*request.Request, *ec2.DescribeNatGatewaysOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeNatGatewaysRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeNatGatewaysOutput)
+func (_m *MockEC2API) DescribeMovingAddressesWithContext(_param0 aws.Context, _param1 *ec2.DescribeMovingAddressesInput, _param2 ...request.Option) (*ec2.DescribeMovingAddressesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeMovingAddressesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeMovingAddressesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeNatGatewaysRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNatGatewaysRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeMovingAddressesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeMovingAddressesWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeMovingAddressesRequest(_param0 *ec2.DescribeMovingAddressesInput) (*request.Request, *ec2.DescribeMovingAddressesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeMovingAddressesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeMovingAddressesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeMovingAddressesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeMovingAddressesRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeNatGateways(_param0 *ec2.DescribeNatGatewaysInput) (*ec2.DescribeNatGatewaysOutput, error) {
@@ -2514,6 +4310,33 @@ func (_mr *_MockEC2APIRecorder) DescribeNatGateways(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNatGateways", arg0)
 }
 
+func (_m *MockEC2API) DescribeNatGatewaysWithContext(_param0 aws.Context, _param1 *ec2.DescribeNatGatewaysInput, _param2 ...request.Option) (*ec2.DescribeNatGatewaysOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeNatGatewaysWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeNatGatewaysOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeNatGatewaysWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNatGatewaysWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeNatGatewaysRequest(_param0 *ec2.DescribeNatGatewaysInput) (*request.Request, *ec2.DescribeNatGatewaysOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeNatGatewaysRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeNatGatewaysOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeNatGatewaysRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNatGatewaysRequest", arg0)
+}
+
 func (_m *MockEC2API) DescribeNatGatewaysPages(_param0 *ec2.DescribeNatGatewaysInput, _param1 func(*ec2.DescribeNatGatewaysOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeNatGatewaysPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -2524,15 +4347,19 @@ func (_mr *_MockEC2APIRecorder) DescribeNatGatewaysPages(arg0, arg1 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNatGatewaysPages", arg0, arg1)
 }
 
-func (_m *MockEC2API) DescribeNetworkAclsRequest(_param0 *ec2.DescribeNetworkAclsInput) (*request.Request, *ec2.DescribeNetworkAclsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeNetworkAclsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeNetworkAclsOutput)
-	return ret0, ret1
+func (_m *MockEC2API) DescribeNatGatewaysPagesWithContext(_param0 aws.Context, _param1 *ec2.DescribeNatGatewaysInput, _param2 func(*ec2.DescribeNatGatewaysOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeNatGatewaysPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeNetworkAclsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNetworkAclsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeNatGatewaysPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNatGatewaysPagesWithContext", _s...)
 }
 
 func (_m *MockEC2API) DescribeNetworkAcls(_param0 *ec2.DescribeNetworkAclsInput) (*ec2.DescribeNetworkAclsOutput, error) {
@@ -2546,15 +4373,31 @@ func (_mr *_MockEC2APIRecorder) DescribeNetworkAcls(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNetworkAcls", arg0)
 }
 
-func (_m *MockEC2API) DescribeNetworkInterfaceAttributeRequest(_param0 *ec2.DescribeNetworkInterfaceAttributeInput) (*request.Request, *ec2.DescribeNetworkInterfaceAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeNetworkInterfaceAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeNetworkInterfaceAttributeOutput)
+func (_m *MockEC2API) DescribeNetworkAclsWithContext(_param0 aws.Context, _param1 *ec2.DescribeNetworkAclsInput, _param2 ...request.Option) (*ec2.DescribeNetworkAclsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeNetworkAclsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeNetworkAclsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeNetworkInterfaceAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNetworkInterfaceAttributeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeNetworkAclsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNetworkAclsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeNetworkAclsRequest(_param0 *ec2.DescribeNetworkAclsInput) (*request.Request, *ec2.DescribeNetworkAclsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeNetworkAclsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeNetworkAclsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeNetworkAclsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNetworkAclsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeNetworkInterfaceAttribute(_param0 *ec2.DescribeNetworkInterfaceAttributeInput) (*ec2.DescribeNetworkInterfaceAttributeOutput, error) {
@@ -2568,15 +4411,31 @@ func (_mr *_MockEC2APIRecorder) DescribeNetworkInterfaceAttribute(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNetworkInterfaceAttribute", arg0)
 }
 
-func (_m *MockEC2API) DescribeNetworkInterfacesRequest(_param0 *ec2.DescribeNetworkInterfacesInput) (*request.Request, *ec2.DescribeNetworkInterfacesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeNetworkInterfacesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeNetworkInterfacesOutput)
+func (_m *MockEC2API) DescribeNetworkInterfaceAttributeWithContext(_param0 aws.Context, _param1 *ec2.DescribeNetworkInterfaceAttributeInput, _param2 ...request.Option) (*ec2.DescribeNetworkInterfaceAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeNetworkInterfaceAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeNetworkInterfaceAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeNetworkInterfacesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNetworkInterfacesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeNetworkInterfaceAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNetworkInterfaceAttributeWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeNetworkInterfaceAttributeRequest(_param0 *ec2.DescribeNetworkInterfaceAttributeInput) (*request.Request, *ec2.DescribeNetworkInterfaceAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeNetworkInterfaceAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeNetworkInterfaceAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeNetworkInterfaceAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNetworkInterfaceAttributeRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeNetworkInterfaces(_param0 *ec2.DescribeNetworkInterfacesInput) (*ec2.DescribeNetworkInterfacesOutput, error) {
@@ -2590,15 +4449,31 @@ func (_mr *_MockEC2APIRecorder) DescribeNetworkInterfaces(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNetworkInterfaces", arg0)
 }
 
-func (_m *MockEC2API) DescribePlacementGroupsRequest(_param0 *ec2.DescribePlacementGroupsInput) (*request.Request, *ec2.DescribePlacementGroupsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribePlacementGroupsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribePlacementGroupsOutput)
+func (_m *MockEC2API) DescribeNetworkInterfacesWithContext(_param0 aws.Context, _param1 *ec2.DescribeNetworkInterfacesInput, _param2 ...request.Option) (*ec2.DescribeNetworkInterfacesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeNetworkInterfacesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeNetworkInterfacesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribePlacementGroupsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribePlacementGroupsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeNetworkInterfacesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNetworkInterfacesWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeNetworkInterfacesRequest(_param0 *ec2.DescribeNetworkInterfacesInput) (*request.Request, *ec2.DescribeNetworkInterfacesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeNetworkInterfacesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeNetworkInterfacesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeNetworkInterfacesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNetworkInterfacesRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribePlacementGroups(_param0 *ec2.DescribePlacementGroupsInput) (*ec2.DescribePlacementGroupsOutput, error) {
@@ -2612,15 +4487,31 @@ func (_mr *_MockEC2APIRecorder) DescribePlacementGroups(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribePlacementGroups", arg0)
 }
 
-func (_m *MockEC2API) DescribePrefixListsRequest(_param0 *ec2.DescribePrefixListsInput) (*request.Request, *ec2.DescribePrefixListsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribePrefixListsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribePrefixListsOutput)
+func (_m *MockEC2API) DescribePlacementGroupsWithContext(_param0 aws.Context, _param1 *ec2.DescribePlacementGroupsInput, _param2 ...request.Option) (*ec2.DescribePlacementGroupsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribePlacementGroupsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribePlacementGroupsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribePrefixListsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribePrefixListsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribePlacementGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribePlacementGroupsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribePlacementGroupsRequest(_param0 *ec2.DescribePlacementGroupsInput) (*request.Request, *ec2.DescribePlacementGroupsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribePlacementGroupsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribePlacementGroupsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribePlacementGroupsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribePlacementGroupsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribePrefixLists(_param0 *ec2.DescribePrefixListsInput) (*ec2.DescribePrefixListsOutput, error) {
@@ -2634,15 +4525,31 @@ func (_mr *_MockEC2APIRecorder) DescribePrefixLists(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribePrefixLists", arg0)
 }
 
-func (_m *MockEC2API) DescribeRegionsRequest(_param0 *ec2.DescribeRegionsInput) (*request.Request, *ec2.DescribeRegionsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeRegionsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeRegionsOutput)
+func (_m *MockEC2API) DescribePrefixListsWithContext(_param0 aws.Context, _param1 *ec2.DescribePrefixListsInput, _param2 ...request.Option) (*ec2.DescribePrefixListsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribePrefixListsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribePrefixListsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeRegionsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeRegionsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribePrefixListsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribePrefixListsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribePrefixListsRequest(_param0 *ec2.DescribePrefixListsInput) (*request.Request, *ec2.DescribePrefixListsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribePrefixListsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribePrefixListsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribePrefixListsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribePrefixListsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeRegions(_param0 *ec2.DescribeRegionsInput) (*ec2.DescribeRegionsOutput, error) {
@@ -2656,15 +4563,31 @@ func (_mr *_MockEC2APIRecorder) DescribeRegions(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeRegions", arg0)
 }
 
-func (_m *MockEC2API) DescribeReservedInstancesRequest(_param0 *ec2.DescribeReservedInstancesInput) (*request.Request, *ec2.DescribeReservedInstancesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeReservedInstancesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeReservedInstancesOutput)
+func (_m *MockEC2API) DescribeRegionsWithContext(_param0 aws.Context, _param1 *ec2.DescribeRegionsInput, _param2 ...request.Option) (*ec2.DescribeRegionsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeRegionsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeRegionsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeRegionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeRegionsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeRegionsRequest(_param0 *ec2.DescribeRegionsInput) (*request.Request, *ec2.DescribeRegionsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeRegionsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeRegionsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeRegionsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeRegionsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeReservedInstances(_param0 *ec2.DescribeReservedInstancesInput) (*ec2.DescribeReservedInstancesOutput, error) {
@@ -2678,15 +4601,31 @@ func (_mr *_MockEC2APIRecorder) DescribeReservedInstances(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstances", arg0)
 }
 
-func (_m *MockEC2API) DescribeReservedInstancesListingsRequest(_param0 *ec2.DescribeReservedInstancesListingsInput) (*request.Request, *ec2.DescribeReservedInstancesListingsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeReservedInstancesListingsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeReservedInstancesListingsOutput)
+func (_m *MockEC2API) DescribeReservedInstancesWithContext(_param0 aws.Context, _param1 *ec2.DescribeReservedInstancesInput, _param2 ...request.Option) (*ec2.DescribeReservedInstancesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeReservedInstancesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeReservedInstancesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesListingsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesListingsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeReservedInstancesRequest(_param0 *ec2.DescribeReservedInstancesInput) (*request.Request, *ec2.DescribeReservedInstancesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeReservedInstancesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeReservedInstancesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeReservedInstancesListings(_param0 *ec2.DescribeReservedInstancesListingsInput) (*ec2.DescribeReservedInstancesListingsOutput, error) {
@@ -2700,15 +4639,31 @@ func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesListings(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesListings", arg0)
 }
 
-func (_m *MockEC2API) DescribeReservedInstancesModificationsRequest(_param0 *ec2.DescribeReservedInstancesModificationsInput) (*request.Request, *ec2.DescribeReservedInstancesModificationsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeReservedInstancesModificationsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeReservedInstancesModificationsOutput)
+func (_m *MockEC2API) DescribeReservedInstancesListingsWithContext(_param0 aws.Context, _param1 *ec2.DescribeReservedInstancesListingsInput, _param2 ...request.Option) (*ec2.DescribeReservedInstancesListingsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeReservedInstancesListingsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeReservedInstancesListingsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesModificationsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesModificationsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesListingsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesListingsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeReservedInstancesListingsRequest(_param0 *ec2.DescribeReservedInstancesListingsInput) (*request.Request, *ec2.DescribeReservedInstancesListingsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeReservedInstancesListingsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeReservedInstancesListingsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesListingsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesListingsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeReservedInstancesModifications(_param0 *ec2.DescribeReservedInstancesModificationsInput) (*ec2.DescribeReservedInstancesModificationsOutput, error) {
@@ -2722,6 +4677,33 @@ func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesModifications(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesModifications", arg0)
 }
 
+func (_m *MockEC2API) DescribeReservedInstancesModificationsWithContext(_param0 aws.Context, _param1 *ec2.DescribeReservedInstancesModificationsInput, _param2 ...request.Option) (*ec2.DescribeReservedInstancesModificationsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeReservedInstancesModificationsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeReservedInstancesModificationsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesModificationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesModificationsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeReservedInstancesModificationsRequest(_param0 *ec2.DescribeReservedInstancesModificationsInput) (*request.Request, *ec2.DescribeReservedInstancesModificationsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeReservedInstancesModificationsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeReservedInstancesModificationsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesModificationsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesModificationsRequest", arg0)
+}
+
 func (_m *MockEC2API) DescribeReservedInstancesModificationsPages(_param0 *ec2.DescribeReservedInstancesModificationsInput, _param1 func(*ec2.DescribeReservedInstancesModificationsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeReservedInstancesModificationsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -2732,15 +4714,19 @@ func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesModificationsPages(arg0
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesModificationsPages", arg0, arg1)
 }
 
-func (_m *MockEC2API) DescribeReservedInstancesOfferingsRequest(_param0 *ec2.DescribeReservedInstancesOfferingsInput) (*request.Request, *ec2.DescribeReservedInstancesOfferingsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeReservedInstancesOfferingsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeReservedInstancesOfferingsOutput)
-	return ret0, ret1
+func (_m *MockEC2API) DescribeReservedInstancesModificationsPagesWithContext(_param0 aws.Context, _param1 *ec2.DescribeReservedInstancesModificationsInput, _param2 func(*ec2.DescribeReservedInstancesModificationsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeReservedInstancesModificationsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesOfferingsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesOfferingsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesModificationsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesModificationsPagesWithContext", _s...)
 }
 
 func (_m *MockEC2API) DescribeReservedInstancesOfferings(_param0 *ec2.DescribeReservedInstancesOfferingsInput) (*ec2.DescribeReservedInstancesOfferingsOutput, error) {
@@ -2754,6 +4740,33 @@ func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesOfferings(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesOfferings", arg0)
 }
 
+func (_m *MockEC2API) DescribeReservedInstancesOfferingsWithContext(_param0 aws.Context, _param1 *ec2.DescribeReservedInstancesOfferingsInput, _param2 ...request.Option) (*ec2.DescribeReservedInstancesOfferingsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeReservedInstancesOfferingsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeReservedInstancesOfferingsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesOfferingsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesOfferingsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeReservedInstancesOfferingsRequest(_param0 *ec2.DescribeReservedInstancesOfferingsInput) (*request.Request, *ec2.DescribeReservedInstancesOfferingsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeReservedInstancesOfferingsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeReservedInstancesOfferingsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesOfferingsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesOfferingsRequest", arg0)
+}
+
 func (_m *MockEC2API) DescribeReservedInstancesOfferingsPages(_param0 *ec2.DescribeReservedInstancesOfferingsInput, _param1 func(*ec2.DescribeReservedInstancesOfferingsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeReservedInstancesOfferingsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -2764,15 +4777,19 @@ func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesOfferingsPages(arg0, ar
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesOfferingsPages", arg0, arg1)
 }
 
-func (_m *MockEC2API) DescribeRouteTablesRequest(_param0 *ec2.DescribeRouteTablesInput) (*request.Request, *ec2.DescribeRouteTablesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeRouteTablesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeRouteTablesOutput)
-	return ret0, ret1
+func (_m *MockEC2API) DescribeReservedInstancesOfferingsPagesWithContext(_param0 aws.Context, _param1 *ec2.DescribeReservedInstancesOfferingsInput, _param2 func(*ec2.DescribeReservedInstancesOfferingsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeReservedInstancesOfferingsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeRouteTablesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeRouteTablesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeReservedInstancesOfferingsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedInstancesOfferingsPagesWithContext", _s...)
 }
 
 func (_m *MockEC2API) DescribeRouteTables(_param0 *ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error) {
@@ -2786,15 +4803,31 @@ func (_mr *_MockEC2APIRecorder) DescribeRouteTables(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeRouteTables", arg0)
 }
 
-func (_m *MockEC2API) DescribeScheduledInstanceAvailabilityRequest(_param0 *ec2.DescribeScheduledInstanceAvailabilityInput) (*request.Request, *ec2.DescribeScheduledInstanceAvailabilityOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeScheduledInstanceAvailabilityRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeScheduledInstanceAvailabilityOutput)
+func (_m *MockEC2API) DescribeRouteTablesWithContext(_param0 aws.Context, _param1 *ec2.DescribeRouteTablesInput, _param2 ...request.Option) (*ec2.DescribeRouteTablesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeRouteTablesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeRouteTablesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeScheduledInstanceAvailabilityRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeScheduledInstanceAvailabilityRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeRouteTablesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeRouteTablesWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeRouteTablesRequest(_param0 *ec2.DescribeRouteTablesInput) (*request.Request, *ec2.DescribeRouteTablesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeRouteTablesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeRouteTablesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeRouteTablesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeRouteTablesRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeScheduledInstanceAvailability(_param0 *ec2.DescribeScheduledInstanceAvailabilityInput) (*ec2.DescribeScheduledInstanceAvailabilityOutput, error) {
@@ -2808,15 +4841,31 @@ func (_mr *_MockEC2APIRecorder) DescribeScheduledInstanceAvailability(arg0 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeScheduledInstanceAvailability", arg0)
 }
 
-func (_m *MockEC2API) DescribeScheduledInstancesRequest(_param0 *ec2.DescribeScheduledInstancesInput) (*request.Request, *ec2.DescribeScheduledInstancesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeScheduledInstancesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeScheduledInstancesOutput)
+func (_m *MockEC2API) DescribeScheduledInstanceAvailabilityWithContext(_param0 aws.Context, _param1 *ec2.DescribeScheduledInstanceAvailabilityInput, _param2 ...request.Option) (*ec2.DescribeScheduledInstanceAvailabilityOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeScheduledInstanceAvailabilityWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeScheduledInstanceAvailabilityOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeScheduledInstancesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeScheduledInstancesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeScheduledInstanceAvailabilityWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeScheduledInstanceAvailabilityWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeScheduledInstanceAvailabilityRequest(_param0 *ec2.DescribeScheduledInstanceAvailabilityInput) (*request.Request, *ec2.DescribeScheduledInstanceAvailabilityOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeScheduledInstanceAvailabilityRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeScheduledInstanceAvailabilityOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeScheduledInstanceAvailabilityRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeScheduledInstanceAvailabilityRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeScheduledInstances(_param0 *ec2.DescribeScheduledInstancesInput) (*ec2.DescribeScheduledInstancesOutput, error) {
@@ -2830,15 +4879,31 @@ func (_mr *_MockEC2APIRecorder) DescribeScheduledInstances(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeScheduledInstances", arg0)
 }
 
-func (_m *MockEC2API) DescribeSecurityGroupReferencesRequest(_param0 *ec2.DescribeSecurityGroupReferencesInput) (*request.Request, *ec2.DescribeSecurityGroupReferencesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeSecurityGroupReferencesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeSecurityGroupReferencesOutput)
+func (_m *MockEC2API) DescribeScheduledInstancesWithContext(_param0 aws.Context, _param1 *ec2.DescribeScheduledInstancesInput, _param2 ...request.Option) (*ec2.DescribeScheduledInstancesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeScheduledInstancesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeScheduledInstancesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeSecurityGroupReferencesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSecurityGroupReferencesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeScheduledInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeScheduledInstancesWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeScheduledInstancesRequest(_param0 *ec2.DescribeScheduledInstancesInput) (*request.Request, *ec2.DescribeScheduledInstancesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeScheduledInstancesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeScheduledInstancesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeScheduledInstancesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeScheduledInstancesRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeSecurityGroupReferences(_param0 *ec2.DescribeSecurityGroupReferencesInput) (*ec2.DescribeSecurityGroupReferencesOutput, error) {
@@ -2852,15 +4917,31 @@ func (_mr *_MockEC2APIRecorder) DescribeSecurityGroupReferences(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSecurityGroupReferences", arg0)
 }
 
-func (_m *MockEC2API) DescribeSecurityGroupsRequest(_param0 *ec2.DescribeSecurityGroupsInput) (*request.Request, *ec2.DescribeSecurityGroupsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeSecurityGroupsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeSecurityGroupsOutput)
+func (_m *MockEC2API) DescribeSecurityGroupReferencesWithContext(_param0 aws.Context, _param1 *ec2.DescribeSecurityGroupReferencesInput, _param2 ...request.Option) (*ec2.DescribeSecurityGroupReferencesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeSecurityGroupReferencesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeSecurityGroupReferencesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeSecurityGroupsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSecurityGroupsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeSecurityGroupReferencesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSecurityGroupReferencesWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeSecurityGroupReferencesRequest(_param0 *ec2.DescribeSecurityGroupReferencesInput) (*request.Request, *ec2.DescribeSecurityGroupReferencesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeSecurityGroupReferencesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeSecurityGroupReferencesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeSecurityGroupReferencesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSecurityGroupReferencesRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeSecurityGroups(_param0 *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
@@ -2874,15 +4955,31 @@ func (_mr *_MockEC2APIRecorder) DescribeSecurityGroups(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSecurityGroups", arg0)
 }
 
-func (_m *MockEC2API) DescribeSnapshotAttributeRequest(_param0 *ec2.DescribeSnapshotAttributeInput) (*request.Request, *ec2.DescribeSnapshotAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeSnapshotAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeSnapshotAttributeOutput)
+func (_m *MockEC2API) DescribeSecurityGroupsWithContext(_param0 aws.Context, _param1 *ec2.DescribeSecurityGroupsInput, _param2 ...request.Option) (*ec2.DescribeSecurityGroupsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeSecurityGroupsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeSecurityGroupsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeSnapshotAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSnapshotAttributeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeSecurityGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSecurityGroupsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeSecurityGroupsRequest(_param0 *ec2.DescribeSecurityGroupsInput) (*request.Request, *ec2.DescribeSecurityGroupsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeSecurityGroupsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeSecurityGroupsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeSecurityGroupsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSecurityGroupsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeSnapshotAttribute(_param0 *ec2.DescribeSnapshotAttributeInput) (*ec2.DescribeSnapshotAttributeOutput, error) {
@@ -2896,15 +4993,31 @@ func (_mr *_MockEC2APIRecorder) DescribeSnapshotAttribute(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSnapshotAttribute", arg0)
 }
 
-func (_m *MockEC2API) DescribeSnapshotsRequest(_param0 *ec2.DescribeSnapshotsInput) (*request.Request, *ec2.DescribeSnapshotsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeSnapshotsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeSnapshotsOutput)
+func (_m *MockEC2API) DescribeSnapshotAttributeWithContext(_param0 aws.Context, _param1 *ec2.DescribeSnapshotAttributeInput, _param2 ...request.Option) (*ec2.DescribeSnapshotAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeSnapshotAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeSnapshotAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeSnapshotsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSnapshotsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeSnapshotAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSnapshotAttributeWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeSnapshotAttributeRequest(_param0 *ec2.DescribeSnapshotAttributeInput) (*request.Request, *ec2.DescribeSnapshotAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeSnapshotAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeSnapshotAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeSnapshotAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSnapshotAttributeRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeSnapshots(_param0 *ec2.DescribeSnapshotsInput) (*ec2.DescribeSnapshotsOutput, error) {
@@ -2918,6 +5031,33 @@ func (_mr *_MockEC2APIRecorder) DescribeSnapshots(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSnapshots", arg0)
 }
 
+func (_m *MockEC2API) DescribeSnapshotsWithContext(_param0 aws.Context, _param1 *ec2.DescribeSnapshotsInput, _param2 ...request.Option) (*ec2.DescribeSnapshotsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeSnapshotsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeSnapshotsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeSnapshotsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSnapshotsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeSnapshotsRequest(_param0 *ec2.DescribeSnapshotsInput) (*request.Request, *ec2.DescribeSnapshotsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeSnapshotsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeSnapshotsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeSnapshotsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSnapshotsRequest", arg0)
+}
+
 func (_m *MockEC2API) DescribeSnapshotsPages(_param0 *ec2.DescribeSnapshotsInput, _param1 func(*ec2.DescribeSnapshotsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeSnapshotsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -2928,15 +5068,19 @@ func (_mr *_MockEC2APIRecorder) DescribeSnapshotsPages(arg0, arg1 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSnapshotsPages", arg0, arg1)
 }
 
-func (_m *MockEC2API) DescribeSpotDatafeedSubscriptionRequest(_param0 *ec2.DescribeSpotDatafeedSubscriptionInput) (*request.Request, *ec2.DescribeSpotDatafeedSubscriptionOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeSpotDatafeedSubscriptionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeSpotDatafeedSubscriptionOutput)
-	return ret0, ret1
+func (_m *MockEC2API) DescribeSnapshotsPagesWithContext(_param0 aws.Context, _param1 *ec2.DescribeSnapshotsInput, _param2 func(*ec2.DescribeSnapshotsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeSnapshotsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeSpotDatafeedSubscriptionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotDatafeedSubscriptionRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeSnapshotsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSnapshotsPagesWithContext", _s...)
 }
 
 func (_m *MockEC2API) DescribeSpotDatafeedSubscription(_param0 *ec2.DescribeSpotDatafeedSubscriptionInput) (*ec2.DescribeSpotDatafeedSubscriptionOutput, error) {
@@ -2950,15 +5094,31 @@ func (_mr *_MockEC2APIRecorder) DescribeSpotDatafeedSubscription(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotDatafeedSubscription", arg0)
 }
 
-func (_m *MockEC2API) DescribeSpotFleetInstancesRequest(_param0 *ec2.DescribeSpotFleetInstancesInput) (*request.Request, *ec2.DescribeSpotFleetInstancesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeSpotFleetInstancesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeSpotFleetInstancesOutput)
+func (_m *MockEC2API) DescribeSpotDatafeedSubscriptionWithContext(_param0 aws.Context, _param1 *ec2.DescribeSpotDatafeedSubscriptionInput, _param2 ...request.Option) (*ec2.DescribeSpotDatafeedSubscriptionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeSpotDatafeedSubscriptionWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeSpotDatafeedSubscriptionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeSpotFleetInstancesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotFleetInstancesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeSpotDatafeedSubscriptionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotDatafeedSubscriptionWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeSpotDatafeedSubscriptionRequest(_param0 *ec2.DescribeSpotDatafeedSubscriptionInput) (*request.Request, *ec2.DescribeSpotDatafeedSubscriptionOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeSpotDatafeedSubscriptionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeSpotDatafeedSubscriptionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeSpotDatafeedSubscriptionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotDatafeedSubscriptionRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeSpotFleetInstances(_param0 *ec2.DescribeSpotFleetInstancesInput) (*ec2.DescribeSpotFleetInstancesOutput, error) {
@@ -2972,15 +5132,31 @@ func (_mr *_MockEC2APIRecorder) DescribeSpotFleetInstances(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotFleetInstances", arg0)
 }
 
-func (_m *MockEC2API) DescribeSpotFleetRequestHistoryRequest(_param0 *ec2.DescribeSpotFleetRequestHistoryInput) (*request.Request, *ec2.DescribeSpotFleetRequestHistoryOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeSpotFleetRequestHistoryRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeSpotFleetRequestHistoryOutput)
+func (_m *MockEC2API) DescribeSpotFleetInstancesWithContext(_param0 aws.Context, _param1 *ec2.DescribeSpotFleetInstancesInput, _param2 ...request.Option) (*ec2.DescribeSpotFleetInstancesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeSpotFleetInstancesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeSpotFleetInstancesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeSpotFleetRequestHistoryRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotFleetRequestHistoryRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeSpotFleetInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotFleetInstancesWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeSpotFleetInstancesRequest(_param0 *ec2.DescribeSpotFleetInstancesInput) (*request.Request, *ec2.DescribeSpotFleetInstancesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeSpotFleetInstancesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeSpotFleetInstancesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeSpotFleetInstancesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotFleetInstancesRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeSpotFleetRequestHistory(_param0 *ec2.DescribeSpotFleetRequestHistoryInput) (*ec2.DescribeSpotFleetRequestHistoryOutput, error) {
@@ -2994,15 +5170,31 @@ func (_mr *_MockEC2APIRecorder) DescribeSpotFleetRequestHistory(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotFleetRequestHistory", arg0)
 }
 
-func (_m *MockEC2API) DescribeSpotFleetRequestsRequest(_param0 *ec2.DescribeSpotFleetRequestsInput) (*request.Request, *ec2.DescribeSpotFleetRequestsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeSpotFleetRequestsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeSpotFleetRequestsOutput)
+func (_m *MockEC2API) DescribeSpotFleetRequestHistoryWithContext(_param0 aws.Context, _param1 *ec2.DescribeSpotFleetRequestHistoryInput, _param2 ...request.Option) (*ec2.DescribeSpotFleetRequestHistoryOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeSpotFleetRequestHistoryWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeSpotFleetRequestHistoryOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeSpotFleetRequestsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotFleetRequestsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeSpotFleetRequestHistoryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotFleetRequestHistoryWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeSpotFleetRequestHistoryRequest(_param0 *ec2.DescribeSpotFleetRequestHistoryInput) (*request.Request, *ec2.DescribeSpotFleetRequestHistoryOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeSpotFleetRequestHistoryRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeSpotFleetRequestHistoryOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeSpotFleetRequestHistoryRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotFleetRequestHistoryRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeSpotFleetRequests(_param0 *ec2.DescribeSpotFleetRequestsInput) (*ec2.DescribeSpotFleetRequestsOutput, error) {
@@ -3016,6 +5208,33 @@ func (_mr *_MockEC2APIRecorder) DescribeSpotFleetRequests(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotFleetRequests", arg0)
 }
 
+func (_m *MockEC2API) DescribeSpotFleetRequestsWithContext(_param0 aws.Context, _param1 *ec2.DescribeSpotFleetRequestsInput, _param2 ...request.Option) (*ec2.DescribeSpotFleetRequestsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeSpotFleetRequestsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeSpotFleetRequestsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeSpotFleetRequestsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotFleetRequestsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeSpotFleetRequestsRequest(_param0 *ec2.DescribeSpotFleetRequestsInput) (*request.Request, *ec2.DescribeSpotFleetRequestsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeSpotFleetRequestsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeSpotFleetRequestsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeSpotFleetRequestsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotFleetRequestsRequest", arg0)
+}
+
 func (_m *MockEC2API) DescribeSpotFleetRequestsPages(_param0 *ec2.DescribeSpotFleetRequestsInput, _param1 func(*ec2.DescribeSpotFleetRequestsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeSpotFleetRequestsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -3026,15 +5245,19 @@ func (_mr *_MockEC2APIRecorder) DescribeSpotFleetRequestsPages(arg0, arg1 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotFleetRequestsPages", arg0, arg1)
 }
 
-func (_m *MockEC2API) DescribeSpotInstanceRequestsRequest(_param0 *ec2.DescribeSpotInstanceRequestsInput) (*request.Request, *ec2.DescribeSpotInstanceRequestsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeSpotInstanceRequestsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeSpotInstanceRequestsOutput)
-	return ret0, ret1
+func (_m *MockEC2API) DescribeSpotFleetRequestsPagesWithContext(_param0 aws.Context, _param1 *ec2.DescribeSpotFleetRequestsInput, _param2 func(*ec2.DescribeSpotFleetRequestsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeSpotFleetRequestsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeSpotInstanceRequestsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotInstanceRequestsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeSpotFleetRequestsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotFleetRequestsPagesWithContext", _s...)
 }
 
 func (_m *MockEC2API) DescribeSpotInstanceRequests(_param0 *ec2.DescribeSpotInstanceRequestsInput) (*ec2.DescribeSpotInstanceRequestsOutput, error) {
@@ -3048,15 +5271,31 @@ func (_mr *_MockEC2APIRecorder) DescribeSpotInstanceRequests(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotInstanceRequests", arg0)
 }
 
-func (_m *MockEC2API) DescribeSpotPriceHistoryRequest(_param0 *ec2.DescribeSpotPriceHistoryInput) (*request.Request, *ec2.DescribeSpotPriceHistoryOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeSpotPriceHistoryRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeSpotPriceHistoryOutput)
+func (_m *MockEC2API) DescribeSpotInstanceRequestsWithContext(_param0 aws.Context, _param1 *ec2.DescribeSpotInstanceRequestsInput, _param2 ...request.Option) (*ec2.DescribeSpotInstanceRequestsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeSpotInstanceRequestsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeSpotInstanceRequestsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeSpotPriceHistoryRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotPriceHistoryRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeSpotInstanceRequestsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotInstanceRequestsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeSpotInstanceRequestsRequest(_param0 *ec2.DescribeSpotInstanceRequestsInput) (*request.Request, *ec2.DescribeSpotInstanceRequestsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeSpotInstanceRequestsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeSpotInstanceRequestsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeSpotInstanceRequestsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotInstanceRequestsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeSpotPriceHistory(_param0 *ec2.DescribeSpotPriceHistoryInput) (*ec2.DescribeSpotPriceHistoryOutput, error) {
@@ -3070,6 +5309,33 @@ func (_mr *_MockEC2APIRecorder) DescribeSpotPriceHistory(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotPriceHistory", arg0)
 }
 
+func (_m *MockEC2API) DescribeSpotPriceHistoryWithContext(_param0 aws.Context, _param1 *ec2.DescribeSpotPriceHistoryInput, _param2 ...request.Option) (*ec2.DescribeSpotPriceHistoryOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeSpotPriceHistoryWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeSpotPriceHistoryOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeSpotPriceHistoryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotPriceHistoryWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeSpotPriceHistoryRequest(_param0 *ec2.DescribeSpotPriceHistoryInput) (*request.Request, *ec2.DescribeSpotPriceHistoryOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeSpotPriceHistoryRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeSpotPriceHistoryOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeSpotPriceHistoryRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotPriceHistoryRequest", arg0)
+}
+
 func (_m *MockEC2API) DescribeSpotPriceHistoryPages(_param0 *ec2.DescribeSpotPriceHistoryInput, _param1 func(*ec2.DescribeSpotPriceHistoryOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeSpotPriceHistoryPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -3080,15 +5346,19 @@ func (_mr *_MockEC2APIRecorder) DescribeSpotPriceHistoryPages(arg0, arg1 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotPriceHistoryPages", arg0, arg1)
 }
 
-func (_m *MockEC2API) DescribeStaleSecurityGroupsRequest(_param0 *ec2.DescribeStaleSecurityGroupsInput) (*request.Request, *ec2.DescribeStaleSecurityGroupsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeStaleSecurityGroupsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeStaleSecurityGroupsOutput)
-	return ret0, ret1
+func (_m *MockEC2API) DescribeSpotPriceHistoryPagesWithContext(_param0 aws.Context, _param1 *ec2.DescribeSpotPriceHistoryInput, _param2 func(*ec2.DescribeSpotPriceHistoryOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeSpotPriceHistoryPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeStaleSecurityGroupsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeStaleSecurityGroupsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeSpotPriceHistoryPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSpotPriceHistoryPagesWithContext", _s...)
 }
 
 func (_m *MockEC2API) DescribeStaleSecurityGroups(_param0 *ec2.DescribeStaleSecurityGroupsInput) (*ec2.DescribeStaleSecurityGroupsOutput, error) {
@@ -3102,15 +5372,31 @@ func (_mr *_MockEC2APIRecorder) DescribeStaleSecurityGroups(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeStaleSecurityGroups", arg0)
 }
 
-func (_m *MockEC2API) DescribeSubnetsRequest(_param0 *ec2.DescribeSubnetsInput) (*request.Request, *ec2.DescribeSubnetsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeSubnetsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeSubnetsOutput)
+func (_m *MockEC2API) DescribeStaleSecurityGroupsWithContext(_param0 aws.Context, _param1 *ec2.DescribeStaleSecurityGroupsInput, _param2 ...request.Option) (*ec2.DescribeStaleSecurityGroupsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeStaleSecurityGroupsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeStaleSecurityGroupsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeSubnetsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSubnetsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeStaleSecurityGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeStaleSecurityGroupsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeStaleSecurityGroupsRequest(_param0 *ec2.DescribeStaleSecurityGroupsInput) (*request.Request, *ec2.DescribeStaleSecurityGroupsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeStaleSecurityGroupsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeStaleSecurityGroupsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeStaleSecurityGroupsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeStaleSecurityGroupsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeSubnets(_param0 *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
@@ -3124,15 +5410,31 @@ func (_mr *_MockEC2APIRecorder) DescribeSubnets(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSubnets", arg0)
 }
 
-func (_m *MockEC2API) DescribeTagsRequest(_param0 *ec2.DescribeTagsInput) (*request.Request, *ec2.DescribeTagsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeTagsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeTagsOutput)
+func (_m *MockEC2API) DescribeSubnetsWithContext(_param0 aws.Context, _param1 *ec2.DescribeSubnetsInput, _param2 ...request.Option) (*ec2.DescribeSubnetsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeSubnetsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeSubnetsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeTagsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTagsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeSubnetsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSubnetsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeSubnetsRequest(_param0 *ec2.DescribeSubnetsInput) (*request.Request, *ec2.DescribeSubnetsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeSubnetsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeSubnetsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeSubnetsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSubnetsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeTags(_param0 *ec2.DescribeTagsInput) (*ec2.DescribeTagsOutput, error) {
@@ -3146,6 +5448,33 @@ func (_mr *_MockEC2APIRecorder) DescribeTags(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTags", arg0)
 }
 
+func (_m *MockEC2API) DescribeTagsWithContext(_param0 aws.Context, _param1 *ec2.DescribeTagsInput, _param2 ...request.Option) (*ec2.DescribeTagsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeTagsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeTagsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeTagsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTagsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeTagsRequest(_param0 *ec2.DescribeTagsInput) (*request.Request, *ec2.DescribeTagsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeTagsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeTagsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeTagsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTagsRequest", arg0)
+}
+
 func (_m *MockEC2API) DescribeTagsPages(_param0 *ec2.DescribeTagsInput, _param1 func(*ec2.DescribeTagsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeTagsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -3156,15 +5485,19 @@ func (_mr *_MockEC2APIRecorder) DescribeTagsPages(arg0, arg1 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTagsPages", arg0, arg1)
 }
 
-func (_m *MockEC2API) DescribeVolumeAttributeRequest(_param0 *ec2.DescribeVolumeAttributeInput) (*request.Request, *ec2.DescribeVolumeAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeVolumeAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeVolumeAttributeOutput)
-	return ret0, ret1
+func (_m *MockEC2API) DescribeTagsPagesWithContext(_param0 aws.Context, _param1 *ec2.DescribeTagsInput, _param2 func(*ec2.DescribeTagsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeTagsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeVolumeAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumeAttributeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeTagsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTagsPagesWithContext", _s...)
 }
 
 func (_m *MockEC2API) DescribeVolumeAttribute(_param0 *ec2.DescribeVolumeAttributeInput) (*ec2.DescribeVolumeAttributeOutput, error) {
@@ -3178,15 +5511,31 @@ func (_mr *_MockEC2APIRecorder) DescribeVolumeAttribute(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumeAttribute", arg0)
 }
 
-func (_m *MockEC2API) DescribeVolumeStatusRequest(_param0 *ec2.DescribeVolumeStatusInput) (*request.Request, *ec2.DescribeVolumeStatusOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeVolumeStatusRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeVolumeStatusOutput)
+func (_m *MockEC2API) DescribeVolumeAttributeWithContext(_param0 aws.Context, _param1 *ec2.DescribeVolumeAttributeInput, _param2 ...request.Option) (*ec2.DescribeVolumeAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeVolumeAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeVolumeAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeVolumeStatusRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumeStatusRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeVolumeAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumeAttributeWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeVolumeAttributeRequest(_param0 *ec2.DescribeVolumeAttributeInput) (*request.Request, *ec2.DescribeVolumeAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeVolumeAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeVolumeAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeVolumeAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumeAttributeRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeVolumeStatus(_param0 *ec2.DescribeVolumeStatusInput) (*ec2.DescribeVolumeStatusOutput, error) {
@@ -3200,6 +5549,33 @@ func (_mr *_MockEC2APIRecorder) DescribeVolumeStatus(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumeStatus", arg0)
 }
 
+func (_m *MockEC2API) DescribeVolumeStatusWithContext(_param0 aws.Context, _param1 *ec2.DescribeVolumeStatusInput, _param2 ...request.Option) (*ec2.DescribeVolumeStatusOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeVolumeStatusWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeVolumeStatusOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeVolumeStatusWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumeStatusWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeVolumeStatusRequest(_param0 *ec2.DescribeVolumeStatusInput) (*request.Request, *ec2.DescribeVolumeStatusOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeVolumeStatusRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeVolumeStatusOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeVolumeStatusRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumeStatusRequest", arg0)
+}
+
 func (_m *MockEC2API) DescribeVolumeStatusPages(_param0 *ec2.DescribeVolumeStatusInput, _param1 func(*ec2.DescribeVolumeStatusOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeVolumeStatusPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -3210,15 +5586,19 @@ func (_mr *_MockEC2APIRecorder) DescribeVolumeStatusPages(arg0, arg1 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumeStatusPages", arg0, arg1)
 }
 
-func (_m *MockEC2API) DescribeVolumesRequest(_param0 *ec2.DescribeVolumesInput) (*request.Request, *ec2.DescribeVolumesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeVolumesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeVolumesOutput)
-	return ret0, ret1
+func (_m *MockEC2API) DescribeVolumeStatusPagesWithContext(_param0 aws.Context, _param1 *ec2.DescribeVolumeStatusInput, _param2 func(*ec2.DescribeVolumeStatusOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeVolumeStatusPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeVolumesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeVolumeStatusPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumeStatusPagesWithContext", _s...)
 }
 
 func (_m *MockEC2API) DescribeVolumes(_param0 *ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error) {
@@ -3232,6 +5612,33 @@ func (_mr *_MockEC2APIRecorder) DescribeVolumes(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumes", arg0)
 }
 
+func (_m *MockEC2API) DescribeVolumesWithContext(_param0 aws.Context, _param1 *ec2.DescribeVolumesInput, _param2 ...request.Option) (*ec2.DescribeVolumesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeVolumesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeVolumesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeVolumesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumesWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeVolumesRequest(_param0 *ec2.DescribeVolumesInput) (*request.Request, *ec2.DescribeVolumesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeVolumesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeVolumesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeVolumesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumesRequest", arg0)
+}
+
 func (_m *MockEC2API) DescribeVolumesPages(_param0 *ec2.DescribeVolumesInput, _param1 func(*ec2.DescribeVolumesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeVolumesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -3242,15 +5649,19 @@ func (_mr *_MockEC2APIRecorder) DescribeVolumesPages(arg0, arg1 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumesPages", arg0, arg1)
 }
 
-func (_m *MockEC2API) DescribeVolumesModificationsRequest(_param0 *ec2.DescribeVolumesModificationsInput) (*request.Request, *ec2.DescribeVolumesModificationsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeVolumesModificationsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeVolumesModificationsOutput)
-	return ret0, ret1
+func (_m *MockEC2API) DescribeVolumesPagesWithContext(_param0 aws.Context, _param1 *ec2.DescribeVolumesInput, _param2 func(*ec2.DescribeVolumesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeVolumesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeVolumesModificationsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumesModificationsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeVolumesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumesPagesWithContext", _s...)
 }
 
 func (_m *MockEC2API) DescribeVolumesModifications(_param0 *ec2.DescribeVolumesModificationsInput) (*ec2.DescribeVolumesModificationsOutput, error) {
@@ -3264,15 +5675,31 @@ func (_mr *_MockEC2APIRecorder) DescribeVolumesModifications(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumesModifications", arg0)
 }
 
-func (_m *MockEC2API) DescribeVpcAttributeRequest(_param0 *ec2.DescribeVpcAttributeInput) (*request.Request, *ec2.DescribeVpcAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeVpcAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeVpcAttributeOutput)
+func (_m *MockEC2API) DescribeVolumesModificationsWithContext(_param0 aws.Context, _param1 *ec2.DescribeVolumesModificationsInput, _param2 ...request.Option) (*ec2.DescribeVolumesModificationsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeVolumesModificationsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeVolumesModificationsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeVpcAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcAttributeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeVolumesModificationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumesModificationsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeVolumesModificationsRequest(_param0 *ec2.DescribeVolumesModificationsInput) (*request.Request, *ec2.DescribeVolumesModificationsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeVolumesModificationsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeVolumesModificationsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeVolumesModificationsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVolumesModificationsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeVpcAttribute(_param0 *ec2.DescribeVpcAttributeInput) (*ec2.DescribeVpcAttributeOutput, error) {
@@ -3286,15 +5713,31 @@ func (_mr *_MockEC2APIRecorder) DescribeVpcAttribute(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcAttribute", arg0)
 }
 
-func (_m *MockEC2API) DescribeVpcClassicLinkRequest(_param0 *ec2.DescribeVpcClassicLinkInput) (*request.Request, *ec2.DescribeVpcClassicLinkOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeVpcClassicLinkRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeVpcClassicLinkOutput)
+func (_m *MockEC2API) DescribeVpcAttributeWithContext(_param0 aws.Context, _param1 *ec2.DescribeVpcAttributeInput, _param2 ...request.Option) (*ec2.DescribeVpcAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeVpcAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeVpcAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeVpcClassicLinkRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcClassicLinkRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeVpcAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcAttributeWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeVpcAttributeRequest(_param0 *ec2.DescribeVpcAttributeInput) (*request.Request, *ec2.DescribeVpcAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeVpcAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeVpcAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeVpcAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcAttributeRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeVpcClassicLink(_param0 *ec2.DescribeVpcClassicLinkInput) (*ec2.DescribeVpcClassicLinkOutput, error) {
@@ -3308,15 +5751,31 @@ func (_mr *_MockEC2APIRecorder) DescribeVpcClassicLink(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcClassicLink", arg0)
 }
 
-func (_m *MockEC2API) DescribeVpcClassicLinkDnsSupportRequest(_param0 *ec2.DescribeVpcClassicLinkDnsSupportInput) (*request.Request, *ec2.DescribeVpcClassicLinkDnsSupportOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeVpcClassicLinkDnsSupportRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeVpcClassicLinkDnsSupportOutput)
+func (_m *MockEC2API) DescribeVpcClassicLinkWithContext(_param0 aws.Context, _param1 *ec2.DescribeVpcClassicLinkInput, _param2 ...request.Option) (*ec2.DescribeVpcClassicLinkOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeVpcClassicLinkWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeVpcClassicLinkOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeVpcClassicLinkDnsSupportRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcClassicLinkDnsSupportRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeVpcClassicLinkWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcClassicLinkWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeVpcClassicLinkRequest(_param0 *ec2.DescribeVpcClassicLinkInput) (*request.Request, *ec2.DescribeVpcClassicLinkOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeVpcClassicLinkRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeVpcClassicLinkOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeVpcClassicLinkRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcClassicLinkRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeVpcClassicLinkDnsSupport(_param0 *ec2.DescribeVpcClassicLinkDnsSupportInput) (*ec2.DescribeVpcClassicLinkDnsSupportOutput, error) {
@@ -3330,15 +5789,31 @@ func (_mr *_MockEC2APIRecorder) DescribeVpcClassicLinkDnsSupport(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcClassicLinkDnsSupport", arg0)
 }
 
-func (_m *MockEC2API) DescribeVpcEndpointServicesRequest(_param0 *ec2.DescribeVpcEndpointServicesInput) (*request.Request, *ec2.DescribeVpcEndpointServicesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeVpcEndpointServicesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeVpcEndpointServicesOutput)
+func (_m *MockEC2API) DescribeVpcClassicLinkDnsSupportWithContext(_param0 aws.Context, _param1 *ec2.DescribeVpcClassicLinkDnsSupportInput, _param2 ...request.Option) (*ec2.DescribeVpcClassicLinkDnsSupportOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeVpcClassicLinkDnsSupportWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeVpcClassicLinkDnsSupportOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeVpcEndpointServicesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcEndpointServicesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeVpcClassicLinkDnsSupportWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcClassicLinkDnsSupportWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeVpcClassicLinkDnsSupportRequest(_param0 *ec2.DescribeVpcClassicLinkDnsSupportInput) (*request.Request, *ec2.DescribeVpcClassicLinkDnsSupportOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeVpcClassicLinkDnsSupportRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeVpcClassicLinkDnsSupportOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeVpcClassicLinkDnsSupportRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcClassicLinkDnsSupportRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeVpcEndpointServices(_param0 *ec2.DescribeVpcEndpointServicesInput) (*ec2.DescribeVpcEndpointServicesOutput, error) {
@@ -3352,15 +5827,31 @@ func (_mr *_MockEC2APIRecorder) DescribeVpcEndpointServices(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcEndpointServices", arg0)
 }
 
-func (_m *MockEC2API) DescribeVpcEndpointsRequest(_param0 *ec2.DescribeVpcEndpointsInput) (*request.Request, *ec2.DescribeVpcEndpointsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeVpcEndpointsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeVpcEndpointsOutput)
+func (_m *MockEC2API) DescribeVpcEndpointServicesWithContext(_param0 aws.Context, _param1 *ec2.DescribeVpcEndpointServicesInput, _param2 ...request.Option) (*ec2.DescribeVpcEndpointServicesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeVpcEndpointServicesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeVpcEndpointServicesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeVpcEndpointsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcEndpointsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeVpcEndpointServicesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcEndpointServicesWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeVpcEndpointServicesRequest(_param0 *ec2.DescribeVpcEndpointServicesInput) (*request.Request, *ec2.DescribeVpcEndpointServicesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeVpcEndpointServicesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeVpcEndpointServicesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeVpcEndpointServicesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcEndpointServicesRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeVpcEndpoints(_param0 *ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error) {
@@ -3374,15 +5865,31 @@ func (_mr *_MockEC2APIRecorder) DescribeVpcEndpoints(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcEndpoints", arg0)
 }
 
-func (_m *MockEC2API) DescribeVpcPeeringConnectionsRequest(_param0 *ec2.DescribeVpcPeeringConnectionsInput) (*request.Request, *ec2.DescribeVpcPeeringConnectionsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeVpcPeeringConnectionsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeVpcPeeringConnectionsOutput)
+func (_m *MockEC2API) DescribeVpcEndpointsWithContext(_param0 aws.Context, _param1 *ec2.DescribeVpcEndpointsInput, _param2 ...request.Option) (*ec2.DescribeVpcEndpointsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeVpcEndpointsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeVpcEndpointsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeVpcPeeringConnectionsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcPeeringConnectionsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeVpcEndpointsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcEndpointsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeVpcEndpointsRequest(_param0 *ec2.DescribeVpcEndpointsInput) (*request.Request, *ec2.DescribeVpcEndpointsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeVpcEndpointsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeVpcEndpointsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeVpcEndpointsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcEndpointsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeVpcPeeringConnections(_param0 *ec2.DescribeVpcPeeringConnectionsInput) (*ec2.DescribeVpcPeeringConnectionsOutput, error) {
@@ -3396,15 +5903,31 @@ func (_mr *_MockEC2APIRecorder) DescribeVpcPeeringConnections(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcPeeringConnections", arg0)
 }
 
-func (_m *MockEC2API) DescribeVpcsRequest(_param0 *ec2.DescribeVpcsInput) (*request.Request, *ec2.DescribeVpcsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeVpcsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeVpcsOutput)
+func (_m *MockEC2API) DescribeVpcPeeringConnectionsWithContext(_param0 aws.Context, _param1 *ec2.DescribeVpcPeeringConnectionsInput, _param2 ...request.Option) (*ec2.DescribeVpcPeeringConnectionsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeVpcPeeringConnectionsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeVpcPeeringConnectionsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeVpcsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeVpcPeeringConnectionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcPeeringConnectionsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeVpcPeeringConnectionsRequest(_param0 *ec2.DescribeVpcPeeringConnectionsInput) (*request.Request, *ec2.DescribeVpcPeeringConnectionsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeVpcPeeringConnectionsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeVpcPeeringConnectionsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeVpcPeeringConnectionsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcPeeringConnectionsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeVpcs(_param0 *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
@@ -3418,15 +5941,31 @@ func (_mr *_MockEC2APIRecorder) DescribeVpcs(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcs", arg0)
 }
 
-func (_m *MockEC2API) DescribeVpnConnectionsRequest(_param0 *ec2.DescribeVpnConnectionsInput) (*request.Request, *ec2.DescribeVpnConnectionsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeVpnConnectionsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeVpnConnectionsOutput)
+func (_m *MockEC2API) DescribeVpcsWithContext(_param0 aws.Context, _param1 *ec2.DescribeVpcsInput, _param2 ...request.Option) (*ec2.DescribeVpcsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeVpcsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeVpcsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeVpnConnectionsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpnConnectionsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeVpcsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeVpcsRequest(_param0 *ec2.DescribeVpcsInput) (*request.Request, *ec2.DescribeVpcsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeVpcsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeVpcsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeVpcsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpcsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeVpnConnections(_param0 *ec2.DescribeVpnConnectionsInput) (*ec2.DescribeVpnConnectionsOutput, error) {
@@ -3440,15 +5979,31 @@ func (_mr *_MockEC2APIRecorder) DescribeVpnConnections(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpnConnections", arg0)
 }
 
-func (_m *MockEC2API) DescribeVpnGatewaysRequest(_param0 *ec2.DescribeVpnGatewaysInput) (*request.Request, *ec2.DescribeVpnGatewaysOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeVpnGatewaysRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DescribeVpnGatewaysOutput)
+func (_m *MockEC2API) DescribeVpnConnectionsWithContext(_param0 aws.Context, _param1 *ec2.DescribeVpnConnectionsInput, _param2 ...request.Option) (*ec2.DescribeVpnConnectionsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeVpnConnectionsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeVpnConnectionsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DescribeVpnGatewaysRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpnGatewaysRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeVpnConnectionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpnConnectionsWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeVpnConnectionsRequest(_param0 *ec2.DescribeVpnConnectionsInput) (*request.Request, *ec2.DescribeVpnConnectionsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeVpnConnectionsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeVpnConnectionsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeVpnConnectionsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpnConnectionsRequest", arg0)
 }
 
 func (_m *MockEC2API) DescribeVpnGateways(_param0 *ec2.DescribeVpnGatewaysInput) (*ec2.DescribeVpnGatewaysOutput, error) {
@@ -3462,15 +6017,31 @@ func (_mr *_MockEC2APIRecorder) DescribeVpnGateways(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpnGateways", arg0)
 }
 
-func (_m *MockEC2API) DetachClassicLinkVpcRequest(_param0 *ec2.DetachClassicLinkVpcInput) (*request.Request, *ec2.DetachClassicLinkVpcOutput) {
-	ret := _m.ctrl.Call(_m, "DetachClassicLinkVpcRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DetachClassicLinkVpcOutput)
+func (_m *MockEC2API) DescribeVpnGatewaysWithContext(_param0 aws.Context, _param1 *ec2.DescribeVpnGatewaysInput, _param2 ...request.Option) (*ec2.DescribeVpnGatewaysOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeVpnGatewaysWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DescribeVpnGatewaysOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DetachClassicLinkVpcRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachClassicLinkVpcRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DescribeVpnGatewaysWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpnGatewaysWithContext", _s...)
+}
+
+func (_m *MockEC2API) DescribeVpnGatewaysRequest(_param0 *ec2.DescribeVpnGatewaysInput) (*request.Request, *ec2.DescribeVpnGatewaysOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeVpnGatewaysRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeVpnGatewaysOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DescribeVpnGatewaysRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeVpnGatewaysRequest", arg0)
 }
 
 func (_m *MockEC2API) DetachClassicLinkVpc(_param0 *ec2.DetachClassicLinkVpcInput) (*ec2.DetachClassicLinkVpcOutput, error) {
@@ -3484,15 +6055,31 @@ func (_mr *_MockEC2APIRecorder) DetachClassicLinkVpc(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachClassicLinkVpc", arg0)
 }
 
-func (_m *MockEC2API) DetachInternetGatewayRequest(_param0 *ec2.DetachInternetGatewayInput) (*request.Request, *ec2.DetachInternetGatewayOutput) {
-	ret := _m.ctrl.Call(_m, "DetachInternetGatewayRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DetachInternetGatewayOutput)
+func (_m *MockEC2API) DetachClassicLinkVpcWithContext(_param0 aws.Context, _param1 *ec2.DetachClassicLinkVpcInput, _param2 ...request.Option) (*ec2.DetachClassicLinkVpcOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DetachClassicLinkVpcWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DetachClassicLinkVpcOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DetachInternetGatewayRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachInternetGatewayRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DetachClassicLinkVpcWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachClassicLinkVpcWithContext", _s...)
+}
+
+func (_m *MockEC2API) DetachClassicLinkVpcRequest(_param0 *ec2.DetachClassicLinkVpcInput) (*request.Request, *ec2.DetachClassicLinkVpcOutput) {
+	ret := _m.ctrl.Call(_m, "DetachClassicLinkVpcRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DetachClassicLinkVpcOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DetachClassicLinkVpcRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachClassicLinkVpcRequest", arg0)
 }
 
 func (_m *MockEC2API) DetachInternetGateway(_param0 *ec2.DetachInternetGatewayInput) (*ec2.DetachInternetGatewayOutput, error) {
@@ -3506,15 +6093,31 @@ func (_mr *_MockEC2APIRecorder) DetachInternetGateway(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachInternetGateway", arg0)
 }
 
-func (_m *MockEC2API) DetachNetworkInterfaceRequest(_param0 *ec2.DetachNetworkInterfaceInput) (*request.Request, *ec2.DetachNetworkInterfaceOutput) {
-	ret := _m.ctrl.Call(_m, "DetachNetworkInterfaceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DetachNetworkInterfaceOutput)
+func (_m *MockEC2API) DetachInternetGatewayWithContext(_param0 aws.Context, _param1 *ec2.DetachInternetGatewayInput, _param2 ...request.Option) (*ec2.DetachInternetGatewayOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DetachInternetGatewayWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DetachInternetGatewayOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DetachNetworkInterfaceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachNetworkInterfaceRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DetachInternetGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachInternetGatewayWithContext", _s...)
+}
+
+func (_m *MockEC2API) DetachInternetGatewayRequest(_param0 *ec2.DetachInternetGatewayInput) (*request.Request, *ec2.DetachInternetGatewayOutput) {
+	ret := _m.ctrl.Call(_m, "DetachInternetGatewayRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DetachInternetGatewayOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DetachInternetGatewayRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachInternetGatewayRequest", arg0)
 }
 
 func (_m *MockEC2API) DetachNetworkInterface(_param0 *ec2.DetachNetworkInterfaceInput) (*ec2.DetachNetworkInterfaceOutput, error) {
@@ -3528,15 +6131,31 @@ func (_mr *_MockEC2APIRecorder) DetachNetworkInterface(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachNetworkInterface", arg0)
 }
 
-func (_m *MockEC2API) DetachVolumeRequest(_param0 *ec2.DetachVolumeInput) (*request.Request, *ec2.VolumeAttachment) {
-	ret := _m.ctrl.Call(_m, "DetachVolumeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.VolumeAttachment)
+func (_m *MockEC2API) DetachNetworkInterfaceWithContext(_param0 aws.Context, _param1 *ec2.DetachNetworkInterfaceInput, _param2 ...request.Option) (*ec2.DetachNetworkInterfaceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DetachNetworkInterfaceWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DetachNetworkInterfaceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DetachVolumeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachVolumeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DetachNetworkInterfaceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachNetworkInterfaceWithContext", _s...)
+}
+
+func (_m *MockEC2API) DetachNetworkInterfaceRequest(_param0 *ec2.DetachNetworkInterfaceInput) (*request.Request, *ec2.DetachNetworkInterfaceOutput) {
+	ret := _m.ctrl.Call(_m, "DetachNetworkInterfaceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DetachNetworkInterfaceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DetachNetworkInterfaceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachNetworkInterfaceRequest", arg0)
 }
 
 func (_m *MockEC2API) DetachVolume(_param0 *ec2.DetachVolumeInput) (*ec2.VolumeAttachment, error) {
@@ -3550,15 +6169,31 @@ func (_mr *_MockEC2APIRecorder) DetachVolume(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachVolume", arg0)
 }
 
-func (_m *MockEC2API) DetachVpnGatewayRequest(_param0 *ec2.DetachVpnGatewayInput) (*request.Request, *ec2.DetachVpnGatewayOutput) {
-	ret := _m.ctrl.Call(_m, "DetachVpnGatewayRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DetachVpnGatewayOutput)
+func (_m *MockEC2API) DetachVolumeWithContext(_param0 aws.Context, _param1 *ec2.DetachVolumeInput, _param2 ...request.Option) (*ec2.VolumeAttachment, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DetachVolumeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.VolumeAttachment)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DetachVpnGatewayRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachVpnGatewayRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DetachVolumeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachVolumeWithContext", _s...)
+}
+
+func (_m *MockEC2API) DetachVolumeRequest(_param0 *ec2.DetachVolumeInput) (*request.Request, *ec2.VolumeAttachment) {
+	ret := _m.ctrl.Call(_m, "DetachVolumeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.VolumeAttachment)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DetachVolumeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachVolumeRequest", arg0)
 }
 
 func (_m *MockEC2API) DetachVpnGateway(_param0 *ec2.DetachVpnGatewayInput) (*ec2.DetachVpnGatewayOutput, error) {
@@ -3572,15 +6207,31 @@ func (_mr *_MockEC2APIRecorder) DetachVpnGateway(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachVpnGateway", arg0)
 }
 
-func (_m *MockEC2API) DisableVgwRoutePropagationRequest(_param0 *ec2.DisableVgwRoutePropagationInput) (*request.Request, *ec2.DisableVgwRoutePropagationOutput) {
-	ret := _m.ctrl.Call(_m, "DisableVgwRoutePropagationRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DisableVgwRoutePropagationOutput)
+func (_m *MockEC2API) DetachVpnGatewayWithContext(_param0 aws.Context, _param1 *ec2.DetachVpnGatewayInput, _param2 ...request.Option) (*ec2.DetachVpnGatewayOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DetachVpnGatewayWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DetachVpnGatewayOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DisableVgwRoutePropagationRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisableVgwRoutePropagationRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DetachVpnGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachVpnGatewayWithContext", _s...)
+}
+
+func (_m *MockEC2API) DetachVpnGatewayRequest(_param0 *ec2.DetachVpnGatewayInput) (*request.Request, *ec2.DetachVpnGatewayOutput) {
+	ret := _m.ctrl.Call(_m, "DetachVpnGatewayRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DetachVpnGatewayOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DetachVpnGatewayRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachVpnGatewayRequest", arg0)
 }
 
 func (_m *MockEC2API) DisableVgwRoutePropagation(_param0 *ec2.DisableVgwRoutePropagationInput) (*ec2.DisableVgwRoutePropagationOutput, error) {
@@ -3594,15 +6245,31 @@ func (_mr *_MockEC2APIRecorder) DisableVgwRoutePropagation(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisableVgwRoutePropagation", arg0)
 }
 
-func (_m *MockEC2API) DisableVpcClassicLinkRequest(_param0 *ec2.DisableVpcClassicLinkInput) (*request.Request, *ec2.DisableVpcClassicLinkOutput) {
-	ret := _m.ctrl.Call(_m, "DisableVpcClassicLinkRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DisableVpcClassicLinkOutput)
+func (_m *MockEC2API) DisableVgwRoutePropagationWithContext(_param0 aws.Context, _param1 *ec2.DisableVgwRoutePropagationInput, _param2 ...request.Option) (*ec2.DisableVgwRoutePropagationOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DisableVgwRoutePropagationWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DisableVgwRoutePropagationOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DisableVpcClassicLinkRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisableVpcClassicLinkRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DisableVgwRoutePropagationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisableVgwRoutePropagationWithContext", _s...)
+}
+
+func (_m *MockEC2API) DisableVgwRoutePropagationRequest(_param0 *ec2.DisableVgwRoutePropagationInput) (*request.Request, *ec2.DisableVgwRoutePropagationOutput) {
+	ret := _m.ctrl.Call(_m, "DisableVgwRoutePropagationRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DisableVgwRoutePropagationOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DisableVgwRoutePropagationRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisableVgwRoutePropagationRequest", arg0)
 }
 
 func (_m *MockEC2API) DisableVpcClassicLink(_param0 *ec2.DisableVpcClassicLinkInput) (*ec2.DisableVpcClassicLinkOutput, error) {
@@ -3616,15 +6283,31 @@ func (_mr *_MockEC2APIRecorder) DisableVpcClassicLink(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisableVpcClassicLink", arg0)
 }
 
-func (_m *MockEC2API) DisableVpcClassicLinkDnsSupportRequest(_param0 *ec2.DisableVpcClassicLinkDnsSupportInput) (*request.Request, *ec2.DisableVpcClassicLinkDnsSupportOutput) {
-	ret := _m.ctrl.Call(_m, "DisableVpcClassicLinkDnsSupportRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DisableVpcClassicLinkDnsSupportOutput)
+func (_m *MockEC2API) DisableVpcClassicLinkWithContext(_param0 aws.Context, _param1 *ec2.DisableVpcClassicLinkInput, _param2 ...request.Option) (*ec2.DisableVpcClassicLinkOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DisableVpcClassicLinkWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DisableVpcClassicLinkOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DisableVpcClassicLinkDnsSupportRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisableVpcClassicLinkDnsSupportRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DisableVpcClassicLinkWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisableVpcClassicLinkWithContext", _s...)
+}
+
+func (_m *MockEC2API) DisableVpcClassicLinkRequest(_param0 *ec2.DisableVpcClassicLinkInput) (*request.Request, *ec2.DisableVpcClassicLinkOutput) {
+	ret := _m.ctrl.Call(_m, "DisableVpcClassicLinkRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DisableVpcClassicLinkOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DisableVpcClassicLinkRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisableVpcClassicLinkRequest", arg0)
 }
 
 func (_m *MockEC2API) DisableVpcClassicLinkDnsSupport(_param0 *ec2.DisableVpcClassicLinkDnsSupportInput) (*ec2.DisableVpcClassicLinkDnsSupportOutput, error) {
@@ -3638,15 +6321,31 @@ func (_mr *_MockEC2APIRecorder) DisableVpcClassicLinkDnsSupport(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisableVpcClassicLinkDnsSupport", arg0)
 }
 
-func (_m *MockEC2API) DisassociateAddressRequest(_param0 *ec2.DisassociateAddressInput) (*request.Request, *ec2.DisassociateAddressOutput) {
-	ret := _m.ctrl.Call(_m, "DisassociateAddressRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DisassociateAddressOutput)
+func (_m *MockEC2API) DisableVpcClassicLinkDnsSupportWithContext(_param0 aws.Context, _param1 *ec2.DisableVpcClassicLinkDnsSupportInput, _param2 ...request.Option) (*ec2.DisableVpcClassicLinkDnsSupportOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DisableVpcClassicLinkDnsSupportWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DisableVpcClassicLinkDnsSupportOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DisassociateAddressRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateAddressRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DisableVpcClassicLinkDnsSupportWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisableVpcClassicLinkDnsSupportWithContext", _s...)
+}
+
+func (_m *MockEC2API) DisableVpcClassicLinkDnsSupportRequest(_param0 *ec2.DisableVpcClassicLinkDnsSupportInput) (*request.Request, *ec2.DisableVpcClassicLinkDnsSupportOutput) {
+	ret := _m.ctrl.Call(_m, "DisableVpcClassicLinkDnsSupportRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DisableVpcClassicLinkDnsSupportOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DisableVpcClassicLinkDnsSupportRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisableVpcClassicLinkDnsSupportRequest", arg0)
 }
 
 func (_m *MockEC2API) DisassociateAddress(_param0 *ec2.DisassociateAddressInput) (*ec2.DisassociateAddressOutput, error) {
@@ -3660,15 +6359,31 @@ func (_mr *_MockEC2APIRecorder) DisassociateAddress(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateAddress", arg0)
 }
 
-func (_m *MockEC2API) DisassociateIamInstanceProfileRequest(_param0 *ec2.DisassociateIamInstanceProfileInput) (*request.Request, *ec2.DisassociateIamInstanceProfileOutput) {
-	ret := _m.ctrl.Call(_m, "DisassociateIamInstanceProfileRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DisassociateIamInstanceProfileOutput)
+func (_m *MockEC2API) DisassociateAddressWithContext(_param0 aws.Context, _param1 *ec2.DisassociateAddressInput, _param2 ...request.Option) (*ec2.DisassociateAddressOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DisassociateAddressWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DisassociateAddressOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DisassociateIamInstanceProfileRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateIamInstanceProfileRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DisassociateAddressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateAddressWithContext", _s...)
+}
+
+func (_m *MockEC2API) DisassociateAddressRequest(_param0 *ec2.DisassociateAddressInput) (*request.Request, *ec2.DisassociateAddressOutput) {
+	ret := _m.ctrl.Call(_m, "DisassociateAddressRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DisassociateAddressOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DisassociateAddressRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateAddressRequest", arg0)
 }
 
 func (_m *MockEC2API) DisassociateIamInstanceProfile(_param0 *ec2.DisassociateIamInstanceProfileInput) (*ec2.DisassociateIamInstanceProfileOutput, error) {
@@ -3682,15 +6397,31 @@ func (_mr *_MockEC2APIRecorder) DisassociateIamInstanceProfile(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateIamInstanceProfile", arg0)
 }
 
-func (_m *MockEC2API) DisassociateRouteTableRequest(_param0 *ec2.DisassociateRouteTableInput) (*request.Request, *ec2.DisassociateRouteTableOutput) {
-	ret := _m.ctrl.Call(_m, "DisassociateRouteTableRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DisassociateRouteTableOutput)
+func (_m *MockEC2API) DisassociateIamInstanceProfileWithContext(_param0 aws.Context, _param1 *ec2.DisassociateIamInstanceProfileInput, _param2 ...request.Option) (*ec2.DisassociateIamInstanceProfileOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DisassociateIamInstanceProfileWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DisassociateIamInstanceProfileOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DisassociateRouteTableRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateRouteTableRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DisassociateIamInstanceProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateIamInstanceProfileWithContext", _s...)
+}
+
+func (_m *MockEC2API) DisassociateIamInstanceProfileRequest(_param0 *ec2.DisassociateIamInstanceProfileInput) (*request.Request, *ec2.DisassociateIamInstanceProfileOutput) {
+	ret := _m.ctrl.Call(_m, "DisassociateIamInstanceProfileRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DisassociateIamInstanceProfileOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DisassociateIamInstanceProfileRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateIamInstanceProfileRequest", arg0)
 }
 
 func (_m *MockEC2API) DisassociateRouteTable(_param0 *ec2.DisassociateRouteTableInput) (*ec2.DisassociateRouteTableOutput, error) {
@@ -3704,15 +6435,31 @@ func (_mr *_MockEC2APIRecorder) DisassociateRouteTable(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateRouteTable", arg0)
 }
 
-func (_m *MockEC2API) DisassociateSubnetCidrBlockRequest(_param0 *ec2.DisassociateSubnetCidrBlockInput) (*request.Request, *ec2.DisassociateSubnetCidrBlockOutput) {
-	ret := _m.ctrl.Call(_m, "DisassociateSubnetCidrBlockRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DisassociateSubnetCidrBlockOutput)
+func (_m *MockEC2API) DisassociateRouteTableWithContext(_param0 aws.Context, _param1 *ec2.DisassociateRouteTableInput, _param2 ...request.Option) (*ec2.DisassociateRouteTableOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DisassociateRouteTableWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DisassociateRouteTableOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DisassociateSubnetCidrBlockRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateSubnetCidrBlockRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DisassociateRouteTableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateRouteTableWithContext", _s...)
+}
+
+func (_m *MockEC2API) DisassociateRouteTableRequest(_param0 *ec2.DisassociateRouteTableInput) (*request.Request, *ec2.DisassociateRouteTableOutput) {
+	ret := _m.ctrl.Call(_m, "DisassociateRouteTableRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DisassociateRouteTableOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DisassociateRouteTableRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateRouteTableRequest", arg0)
 }
 
 func (_m *MockEC2API) DisassociateSubnetCidrBlock(_param0 *ec2.DisassociateSubnetCidrBlockInput) (*ec2.DisassociateSubnetCidrBlockOutput, error) {
@@ -3726,15 +6473,31 @@ func (_mr *_MockEC2APIRecorder) DisassociateSubnetCidrBlock(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateSubnetCidrBlock", arg0)
 }
 
-func (_m *MockEC2API) DisassociateVpcCidrBlockRequest(_param0 *ec2.DisassociateVpcCidrBlockInput) (*request.Request, *ec2.DisassociateVpcCidrBlockOutput) {
-	ret := _m.ctrl.Call(_m, "DisassociateVpcCidrBlockRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.DisassociateVpcCidrBlockOutput)
+func (_m *MockEC2API) DisassociateSubnetCidrBlockWithContext(_param0 aws.Context, _param1 *ec2.DisassociateSubnetCidrBlockInput, _param2 ...request.Option) (*ec2.DisassociateSubnetCidrBlockOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DisassociateSubnetCidrBlockWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DisassociateSubnetCidrBlockOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) DisassociateVpcCidrBlockRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateVpcCidrBlockRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DisassociateSubnetCidrBlockWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateSubnetCidrBlockWithContext", _s...)
+}
+
+func (_m *MockEC2API) DisassociateSubnetCidrBlockRequest(_param0 *ec2.DisassociateSubnetCidrBlockInput) (*request.Request, *ec2.DisassociateSubnetCidrBlockOutput) {
+	ret := _m.ctrl.Call(_m, "DisassociateSubnetCidrBlockRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DisassociateSubnetCidrBlockOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DisassociateSubnetCidrBlockRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateSubnetCidrBlockRequest", arg0)
 }
 
 func (_m *MockEC2API) DisassociateVpcCidrBlock(_param0 *ec2.DisassociateVpcCidrBlockInput) (*ec2.DisassociateVpcCidrBlockOutput, error) {
@@ -3748,15 +6511,31 @@ func (_mr *_MockEC2APIRecorder) DisassociateVpcCidrBlock(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateVpcCidrBlock", arg0)
 }
 
-func (_m *MockEC2API) EnableVgwRoutePropagationRequest(_param0 *ec2.EnableVgwRoutePropagationInput) (*request.Request, *ec2.EnableVgwRoutePropagationOutput) {
-	ret := _m.ctrl.Call(_m, "EnableVgwRoutePropagationRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.EnableVgwRoutePropagationOutput)
+func (_m *MockEC2API) DisassociateVpcCidrBlockWithContext(_param0 aws.Context, _param1 *ec2.DisassociateVpcCidrBlockInput, _param2 ...request.Option) (*ec2.DisassociateVpcCidrBlockOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DisassociateVpcCidrBlockWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.DisassociateVpcCidrBlockOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) EnableVgwRoutePropagationRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableVgwRoutePropagationRequest", arg0)
+func (_mr *_MockEC2APIRecorder) DisassociateVpcCidrBlockWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateVpcCidrBlockWithContext", _s...)
+}
+
+func (_m *MockEC2API) DisassociateVpcCidrBlockRequest(_param0 *ec2.DisassociateVpcCidrBlockInput) (*request.Request, *ec2.DisassociateVpcCidrBlockOutput) {
+	ret := _m.ctrl.Call(_m, "DisassociateVpcCidrBlockRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DisassociateVpcCidrBlockOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) DisassociateVpcCidrBlockRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisassociateVpcCidrBlockRequest", arg0)
 }
 
 func (_m *MockEC2API) EnableVgwRoutePropagation(_param0 *ec2.EnableVgwRoutePropagationInput) (*ec2.EnableVgwRoutePropagationOutput, error) {
@@ -3770,15 +6549,31 @@ func (_mr *_MockEC2APIRecorder) EnableVgwRoutePropagation(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableVgwRoutePropagation", arg0)
 }
 
-func (_m *MockEC2API) EnableVolumeIORequest(_param0 *ec2.EnableVolumeIOInput) (*request.Request, *ec2.EnableVolumeIOOutput) {
-	ret := _m.ctrl.Call(_m, "EnableVolumeIORequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.EnableVolumeIOOutput)
+func (_m *MockEC2API) EnableVgwRoutePropagationWithContext(_param0 aws.Context, _param1 *ec2.EnableVgwRoutePropagationInput, _param2 ...request.Option) (*ec2.EnableVgwRoutePropagationOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "EnableVgwRoutePropagationWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.EnableVgwRoutePropagationOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) EnableVolumeIORequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableVolumeIORequest", arg0)
+func (_mr *_MockEC2APIRecorder) EnableVgwRoutePropagationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableVgwRoutePropagationWithContext", _s...)
+}
+
+func (_m *MockEC2API) EnableVgwRoutePropagationRequest(_param0 *ec2.EnableVgwRoutePropagationInput) (*request.Request, *ec2.EnableVgwRoutePropagationOutput) {
+	ret := _m.ctrl.Call(_m, "EnableVgwRoutePropagationRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.EnableVgwRoutePropagationOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) EnableVgwRoutePropagationRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableVgwRoutePropagationRequest", arg0)
 }
 
 func (_m *MockEC2API) EnableVolumeIO(_param0 *ec2.EnableVolumeIOInput) (*ec2.EnableVolumeIOOutput, error) {
@@ -3792,15 +6587,31 @@ func (_mr *_MockEC2APIRecorder) EnableVolumeIO(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableVolumeIO", arg0)
 }
 
-func (_m *MockEC2API) EnableVpcClassicLinkRequest(_param0 *ec2.EnableVpcClassicLinkInput) (*request.Request, *ec2.EnableVpcClassicLinkOutput) {
-	ret := _m.ctrl.Call(_m, "EnableVpcClassicLinkRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.EnableVpcClassicLinkOutput)
+func (_m *MockEC2API) EnableVolumeIOWithContext(_param0 aws.Context, _param1 *ec2.EnableVolumeIOInput, _param2 ...request.Option) (*ec2.EnableVolumeIOOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "EnableVolumeIOWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.EnableVolumeIOOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) EnableVpcClassicLinkRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableVpcClassicLinkRequest", arg0)
+func (_mr *_MockEC2APIRecorder) EnableVolumeIOWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableVolumeIOWithContext", _s...)
+}
+
+func (_m *MockEC2API) EnableVolumeIORequest(_param0 *ec2.EnableVolumeIOInput) (*request.Request, *ec2.EnableVolumeIOOutput) {
+	ret := _m.ctrl.Call(_m, "EnableVolumeIORequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.EnableVolumeIOOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) EnableVolumeIORequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableVolumeIORequest", arg0)
 }
 
 func (_m *MockEC2API) EnableVpcClassicLink(_param0 *ec2.EnableVpcClassicLinkInput) (*ec2.EnableVpcClassicLinkOutput, error) {
@@ -3814,15 +6625,31 @@ func (_mr *_MockEC2APIRecorder) EnableVpcClassicLink(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableVpcClassicLink", arg0)
 }
 
-func (_m *MockEC2API) EnableVpcClassicLinkDnsSupportRequest(_param0 *ec2.EnableVpcClassicLinkDnsSupportInput) (*request.Request, *ec2.EnableVpcClassicLinkDnsSupportOutput) {
-	ret := _m.ctrl.Call(_m, "EnableVpcClassicLinkDnsSupportRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.EnableVpcClassicLinkDnsSupportOutput)
+func (_m *MockEC2API) EnableVpcClassicLinkWithContext(_param0 aws.Context, _param1 *ec2.EnableVpcClassicLinkInput, _param2 ...request.Option) (*ec2.EnableVpcClassicLinkOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "EnableVpcClassicLinkWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.EnableVpcClassicLinkOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) EnableVpcClassicLinkDnsSupportRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableVpcClassicLinkDnsSupportRequest", arg0)
+func (_mr *_MockEC2APIRecorder) EnableVpcClassicLinkWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableVpcClassicLinkWithContext", _s...)
+}
+
+func (_m *MockEC2API) EnableVpcClassicLinkRequest(_param0 *ec2.EnableVpcClassicLinkInput) (*request.Request, *ec2.EnableVpcClassicLinkOutput) {
+	ret := _m.ctrl.Call(_m, "EnableVpcClassicLinkRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.EnableVpcClassicLinkOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) EnableVpcClassicLinkRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableVpcClassicLinkRequest", arg0)
 }
 
 func (_m *MockEC2API) EnableVpcClassicLinkDnsSupport(_param0 *ec2.EnableVpcClassicLinkDnsSupportInput) (*ec2.EnableVpcClassicLinkDnsSupportOutput, error) {
@@ -3836,15 +6663,31 @@ func (_mr *_MockEC2APIRecorder) EnableVpcClassicLinkDnsSupport(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableVpcClassicLinkDnsSupport", arg0)
 }
 
-func (_m *MockEC2API) GetConsoleOutputRequest(_param0 *ec2.GetConsoleOutputInput) (*request.Request, *ec2.GetConsoleOutputOutput) {
-	ret := _m.ctrl.Call(_m, "GetConsoleOutputRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.GetConsoleOutputOutput)
+func (_m *MockEC2API) EnableVpcClassicLinkDnsSupportWithContext(_param0 aws.Context, _param1 *ec2.EnableVpcClassicLinkDnsSupportInput, _param2 ...request.Option) (*ec2.EnableVpcClassicLinkDnsSupportOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "EnableVpcClassicLinkDnsSupportWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.EnableVpcClassicLinkDnsSupportOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) GetConsoleOutputRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetConsoleOutputRequest", arg0)
+func (_mr *_MockEC2APIRecorder) EnableVpcClassicLinkDnsSupportWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableVpcClassicLinkDnsSupportWithContext", _s...)
+}
+
+func (_m *MockEC2API) EnableVpcClassicLinkDnsSupportRequest(_param0 *ec2.EnableVpcClassicLinkDnsSupportInput) (*request.Request, *ec2.EnableVpcClassicLinkDnsSupportOutput) {
+	ret := _m.ctrl.Call(_m, "EnableVpcClassicLinkDnsSupportRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.EnableVpcClassicLinkDnsSupportOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) EnableVpcClassicLinkDnsSupportRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableVpcClassicLinkDnsSupportRequest", arg0)
 }
 
 func (_m *MockEC2API) GetConsoleOutput(_param0 *ec2.GetConsoleOutputInput) (*ec2.GetConsoleOutputOutput, error) {
@@ -3858,15 +6701,31 @@ func (_mr *_MockEC2APIRecorder) GetConsoleOutput(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetConsoleOutput", arg0)
 }
 
-func (_m *MockEC2API) GetConsoleScreenshotRequest(_param0 *ec2.GetConsoleScreenshotInput) (*request.Request, *ec2.GetConsoleScreenshotOutput) {
-	ret := _m.ctrl.Call(_m, "GetConsoleScreenshotRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.GetConsoleScreenshotOutput)
+func (_m *MockEC2API) GetConsoleOutputWithContext(_param0 aws.Context, _param1 *ec2.GetConsoleOutputInput, _param2 ...request.Option) (*ec2.GetConsoleOutputOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetConsoleOutputWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.GetConsoleOutputOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) GetConsoleScreenshotRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetConsoleScreenshotRequest", arg0)
+func (_mr *_MockEC2APIRecorder) GetConsoleOutputWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetConsoleOutputWithContext", _s...)
+}
+
+func (_m *MockEC2API) GetConsoleOutputRequest(_param0 *ec2.GetConsoleOutputInput) (*request.Request, *ec2.GetConsoleOutputOutput) {
+	ret := _m.ctrl.Call(_m, "GetConsoleOutputRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.GetConsoleOutputOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) GetConsoleOutputRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetConsoleOutputRequest", arg0)
 }
 
 func (_m *MockEC2API) GetConsoleScreenshot(_param0 *ec2.GetConsoleScreenshotInput) (*ec2.GetConsoleScreenshotOutput, error) {
@@ -3880,15 +6739,31 @@ func (_mr *_MockEC2APIRecorder) GetConsoleScreenshot(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetConsoleScreenshot", arg0)
 }
 
-func (_m *MockEC2API) GetHostReservationPurchasePreviewRequest(_param0 *ec2.GetHostReservationPurchasePreviewInput) (*request.Request, *ec2.GetHostReservationPurchasePreviewOutput) {
-	ret := _m.ctrl.Call(_m, "GetHostReservationPurchasePreviewRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.GetHostReservationPurchasePreviewOutput)
+func (_m *MockEC2API) GetConsoleScreenshotWithContext(_param0 aws.Context, _param1 *ec2.GetConsoleScreenshotInput, _param2 ...request.Option) (*ec2.GetConsoleScreenshotOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetConsoleScreenshotWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.GetConsoleScreenshotOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) GetHostReservationPurchasePreviewRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetHostReservationPurchasePreviewRequest", arg0)
+func (_mr *_MockEC2APIRecorder) GetConsoleScreenshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetConsoleScreenshotWithContext", _s...)
+}
+
+func (_m *MockEC2API) GetConsoleScreenshotRequest(_param0 *ec2.GetConsoleScreenshotInput) (*request.Request, *ec2.GetConsoleScreenshotOutput) {
+	ret := _m.ctrl.Call(_m, "GetConsoleScreenshotRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.GetConsoleScreenshotOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) GetConsoleScreenshotRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetConsoleScreenshotRequest", arg0)
 }
 
 func (_m *MockEC2API) GetHostReservationPurchasePreview(_param0 *ec2.GetHostReservationPurchasePreviewInput) (*ec2.GetHostReservationPurchasePreviewOutput, error) {
@@ -3902,15 +6777,31 @@ func (_mr *_MockEC2APIRecorder) GetHostReservationPurchasePreview(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetHostReservationPurchasePreview", arg0)
 }
 
-func (_m *MockEC2API) GetPasswordDataRequest(_param0 *ec2.GetPasswordDataInput) (*request.Request, *ec2.GetPasswordDataOutput) {
-	ret := _m.ctrl.Call(_m, "GetPasswordDataRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.GetPasswordDataOutput)
+func (_m *MockEC2API) GetHostReservationPurchasePreviewWithContext(_param0 aws.Context, _param1 *ec2.GetHostReservationPurchasePreviewInput, _param2 ...request.Option) (*ec2.GetHostReservationPurchasePreviewOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetHostReservationPurchasePreviewWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.GetHostReservationPurchasePreviewOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) GetPasswordDataRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPasswordDataRequest", arg0)
+func (_mr *_MockEC2APIRecorder) GetHostReservationPurchasePreviewWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetHostReservationPurchasePreviewWithContext", _s...)
+}
+
+func (_m *MockEC2API) GetHostReservationPurchasePreviewRequest(_param0 *ec2.GetHostReservationPurchasePreviewInput) (*request.Request, *ec2.GetHostReservationPurchasePreviewOutput) {
+	ret := _m.ctrl.Call(_m, "GetHostReservationPurchasePreviewRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.GetHostReservationPurchasePreviewOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) GetHostReservationPurchasePreviewRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetHostReservationPurchasePreviewRequest", arg0)
 }
 
 func (_m *MockEC2API) GetPasswordData(_param0 *ec2.GetPasswordDataInput) (*ec2.GetPasswordDataOutput, error) {
@@ -3924,15 +6815,31 @@ func (_mr *_MockEC2APIRecorder) GetPasswordData(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPasswordData", arg0)
 }
 
-func (_m *MockEC2API) GetReservedInstancesExchangeQuoteRequest(_param0 *ec2.GetReservedInstancesExchangeQuoteInput) (*request.Request, *ec2.GetReservedInstancesExchangeQuoteOutput) {
-	ret := _m.ctrl.Call(_m, "GetReservedInstancesExchangeQuoteRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.GetReservedInstancesExchangeQuoteOutput)
+func (_m *MockEC2API) GetPasswordDataWithContext(_param0 aws.Context, _param1 *ec2.GetPasswordDataInput, _param2 ...request.Option) (*ec2.GetPasswordDataOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetPasswordDataWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.GetPasswordDataOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) GetReservedInstancesExchangeQuoteRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetReservedInstancesExchangeQuoteRequest", arg0)
+func (_mr *_MockEC2APIRecorder) GetPasswordDataWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPasswordDataWithContext", _s...)
+}
+
+func (_m *MockEC2API) GetPasswordDataRequest(_param0 *ec2.GetPasswordDataInput) (*request.Request, *ec2.GetPasswordDataOutput) {
+	ret := _m.ctrl.Call(_m, "GetPasswordDataRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.GetPasswordDataOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) GetPasswordDataRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPasswordDataRequest", arg0)
 }
 
 func (_m *MockEC2API) GetReservedInstancesExchangeQuote(_param0 *ec2.GetReservedInstancesExchangeQuoteInput) (*ec2.GetReservedInstancesExchangeQuoteOutput, error) {
@@ -3946,15 +6853,31 @@ func (_mr *_MockEC2APIRecorder) GetReservedInstancesExchangeQuote(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetReservedInstancesExchangeQuote", arg0)
 }
 
-func (_m *MockEC2API) ImportImageRequest(_param0 *ec2.ImportImageInput) (*request.Request, *ec2.ImportImageOutput) {
-	ret := _m.ctrl.Call(_m, "ImportImageRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ImportImageOutput)
+func (_m *MockEC2API) GetReservedInstancesExchangeQuoteWithContext(_param0 aws.Context, _param1 *ec2.GetReservedInstancesExchangeQuoteInput, _param2 ...request.Option) (*ec2.GetReservedInstancesExchangeQuoteOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetReservedInstancesExchangeQuoteWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.GetReservedInstancesExchangeQuoteOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ImportImageRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportImageRequest", arg0)
+func (_mr *_MockEC2APIRecorder) GetReservedInstancesExchangeQuoteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetReservedInstancesExchangeQuoteWithContext", _s...)
+}
+
+func (_m *MockEC2API) GetReservedInstancesExchangeQuoteRequest(_param0 *ec2.GetReservedInstancesExchangeQuoteInput) (*request.Request, *ec2.GetReservedInstancesExchangeQuoteOutput) {
+	ret := _m.ctrl.Call(_m, "GetReservedInstancesExchangeQuoteRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.GetReservedInstancesExchangeQuoteOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) GetReservedInstancesExchangeQuoteRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetReservedInstancesExchangeQuoteRequest", arg0)
 }
 
 func (_m *MockEC2API) ImportImage(_param0 *ec2.ImportImageInput) (*ec2.ImportImageOutput, error) {
@@ -3968,15 +6891,31 @@ func (_mr *_MockEC2APIRecorder) ImportImage(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportImage", arg0)
 }
 
-func (_m *MockEC2API) ImportInstanceRequest(_param0 *ec2.ImportInstanceInput) (*request.Request, *ec2.ImportInstanceOutput) {
-	ret := _m.ctrl.Call(_m, "ImportInstanceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ImportInstanceOutput)
+func (_m *MockEC2API) ImportImageWithContext(_param0 aws.Context, _param1 *ec2.ImportImageInput, _param2 ...request.Option) (*ec2.ImportImageOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ImportImageWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ImportImageOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ImportInstanceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportInstanceRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ImportImageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportImageWithContext", _s...)
+}
+
+func (_m *MockEC2API) ImportImageRequest(_param0 *ec2.ImportImageInput) (*request.Request, *ec2.ImportImageOutput) {
+	ret := _m.ctrl.Call(_m, "ImportImageRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ImportImageOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ImportImageRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportImageRequest", arg0)
 }
 
 func (_m *MockEC2API) ImportInstance(_param0 *ec2.ImportInstanceInput) (*ec2.ImportInstanceOutput, error) {
@@ -3990,15 +6929,31 @@ func (_mr *_MockEC2APIRecorder) ImportInstance(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportInstance", arg0)
 }
 
-func (_m *MockEC2API) ImportKeyPairRequest(_param0 *ec2.ImportKeyPairInput) (*request.Request, *ec2.ImportKeyPairOutput) {
-	ret := _m.ctrl.Call(_m, "ImportKeyPairRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ImportKeyPairOutput)
+func (_m *MockEC2API) ImportInstanceWithContext(_param0 aws.Context, _param1 *ec2.ImportInstanceInput, _param2 ...request.Option) (*ec2.ImportInstanceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ImportInstanceWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ImportInstanceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ImportKeyPairRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportKeyPairRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ImportInstanceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportInstanceWithContext", _s...)
+}
+
+func (_m *MockEC2API) ImportInstanceRequest(_param0 *ec2.ImportInstanceInput) (*request.Request, *ec2.ImportInstanceOutput) {
+	ret := _m.ctrl.Call(_m, "ImportInstanceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ImportInstanceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ImportInstanceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportInstanceRequest", arg0)
 }
 
 func (_m *MockEC2API) ImportKeyPair(_param0 *ec2.ImportKeyPairInput) (*ec2.ImportKeyPairOutput, error) {
@@ -4012,15 +6967,31 @@ func (_mr *_MockEC2APIRecorder) ImportKeyPair(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportKeyPair", arg0)
 }
 
-func (_m *MockEC2API) ImportSnapshotRequest(_param0 *ec2.ImportSnapshotInput) (*request.Request, *ec2.ImportSnapshotOutput) {
-	ret := _m.ctrl.Call(_m, "ImportSnapshotRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ImportSnapshotOutput)
+func (_m *MockEC2API) ImportKeyPairWithContext(_param0 aws.Context, _param1 *ec2.ImportKeyPairInput, _param2 ...request.Option) (*ec2.ImportKeyPairOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ImportKeyPairWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ImportKeyPairOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ImportSnapshotRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportSnapshotRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ImportKeyPairWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportKeyPairWithContext", _s...)
+}
+
+func (_m *MockEC2API) ImportKeyPairRequest(_param0 *ec2.ImportKeyPairInput) (*request.Request, *ec2.ImportKeyPairOutput) {
+	ret := _m.ctrl.Call(_m, "ImportKeyPairRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ImportKeyPairOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ImportKeyPairRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportKeyPairRequest", arg0)
 }
 
 func (_m *MockEC2API) ImportSnapshot(_param0 *ec2.ImportSnapshotInput) (*ec2.ImportSnapshotOutput, error) {
@@ -4034,15 +7005,31 @@ func (_mr *_MockEC2APIRecorder) ImportSnapshot(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportSnapshot", arg0)
 }
 
-func (_m *MockEC2API) ImportVolumeRequest(_param0 *ec2.ImportVolumeInput) (*request.Request, *ec2.ImportVolumeOutput) {
-	ret := _m.ctrl.Call(_m, "ImportVolumeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ImportVolumeOutput)
+func (_m *MockEC2API) ImportSnapshotWithContext(_param0 aws.Context, _param1 *ec2.ImportSnapshotInput, _param2 ...request.Option) (*ec2.ImportSnapshotOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ImportSnapshotWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ImportSnapshotOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ImportVolumeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportVolumeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ImportSnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportSnapshotWithContext", _s...)
+}
+
+func (_m *MockEC2API) ImportSnapshotRequest(_param0 *ec2.ImportSnapshotInput) (*request.Request, *ec2.ImportSnapshotOutput) {
+	ret := _m.ctrl.Call(_m, "ImportSnapshotRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ImportSnapshotOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ImportSnapshotRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportSnapshotRequest", arg0)
 }
 
 func (_m *MockEC2API) ImportVolume(_param0 *ec2.ImportVolumeInput) (*ec2.ImportVolumeOutput, error) {
@@ -4056,15 +7043,31 @@ func (_mr *_MockEC2APIRecorder) ImportVolume(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportVolume", arg0)
 }
 
-func (_m *MockEC2API) ModifyHostsRequest(_param0 *ec2.ModifyHostsInput) (*request.Request, *ec2.ModifyHostsOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyHostsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ModifyHostsOutput)
+func (_m *MockEC2API) ImportVolumeWithContext(_param0 aws.Context, _param1 *ec2.ImportVolumeInput, _param2 ...request.Option) (*ec2.ImportVolumeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ImportVolumeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ImportVolumeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ModifyHostsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyHostsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ImportVolumeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportVolumeWithContext", _s...)
+}
+
+func (_m *MockEC2API) ImportVolumeRequest(_param0 *ec2.ImportVolumeInput) (*request.Request, *ec2.ImportVolumeOutput) {
+	ret := _m.ctrl.Call(_m, "ImportVolumeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ImportVolumeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ImportVolumeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImportVolumeRequest", arg0)
 }
 
 func (_m *MockEC2API) ModifyHosts(_param0 *ec2.ModifyHostsInput) (*ec2.ModifyHostsOutput, error) {
@@ -4078,15 +7081,31 @@ func (_mr *_MockEC2APIRecorder) ModifyHosts(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyHosts", arg0)
 }
 
-func (_m *MockEC2API) ModifyIdFormatRequest(_param0 *ec2.ModifyIdFormatInput) (*request.Request, *ec2.ModifyIdFormatOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyIdFormatRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ModifyIdFormatOutput)
+func (_m *MockEC2API) ModifyHostsWithContext(_param0 aws.Context, _param1 *ec2.ModifyHostsInput, _param2 ...request.Option) (*ec2.ModifyHostsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyHostsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ModifyHostsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ModifyIdFormatRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyIdFormatRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ModifyHostsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyHostsWithContext", _s...)
+}
+
+func (_m *MockEC2API) ModifyHostsRequest(_param0 *ec2.ModifyHostsInput) (*request.Request, *ec2.ModifyHostsOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyHostsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyHostsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ModifyHostsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyHostsRequest", arg0)
 }
 
 func (_m *MockEC2API) ModifyIdFormat(_param0 *ec2.ModifyIdFormatInput) (*ec2.ModifyIdFormatOutput, error) {
@@ -4100,15 +7119,31 @@ func (_mr *_MockEC2APIRecorder) ModifyIdFormat(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyIdFormat", arg0)
 }
 
-func (_m *MockEC2API) ModifyIdentityIdFormatRequest(_param0 *ec2.ModifyIdentityIdFormatInput) (*request.Request, *ec2.ModifyIdentityIdFormatOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyIdentityIdFormatRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ModifyIdentityIdFormatOutput)
+func (_m *MockEC2API) ModifyIdFormatWithContext(_param0 aws.Context, _param1 *ec2.ModifyIdFormatInput, _param2 ...request.Option) (*ec2.ModifyIdFormatOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyIdFormatWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ModifyIdFormatOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ModifyIdentityIdFormatRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyIdentityIdFormatRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ModifyIdFormatWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyIdFormatWithContext", _s...)
+}
+
+func (_m *MockEC2API) ModifyIdFormatRequest(_param0 *ec2.ModifyIdFormatInput) (*request.Request, *ec2.ModifyIdFormatOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyIdFormatRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyIdFormatOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ModifyIdFormatRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyIdFormatRequest", arg0)
 }
 
 func (_m *MockEC2API) ModifyIdentityIdFormat(_param0 *ec2.ModifyIdentityIdFormatInput) (*ec2.ModifyIdentityIdFormatOutput, error) {
@@ -4122,15 +7157,31 @@ func (_mr *_MockEC2APIRecorder) ModifyIdentityIdFormat(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyIdentityIdFormat", arg0)
 }
 
-func (_m *MockEC2API) ModifyImageAttributeRequest(_param0 *ec2.ModifyImageAttributeInput) (*request.Request, *ec2.ModifyImageAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyImageAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ModifyImageAttributeOutput)
+func (_m *MockEC2API) ModifyIdentityIdFormatWithContext(_param0 aws.Context, _param1 *ec2.ModifyIdentityIdFormatInput, _param2 ...request.Option) (*ec2.ModifyIdentityIdFormatOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyIdentityIdFormatWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ModifyIdentityIdFormatOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ModifyImageAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyImageAttributeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ModifyIdentityIdFormatWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyIdentityIdFormatWithContext", _s...)
+}
+
+func (_m *MockEC2API) ModifyIdentityIdFormatRequest(_param0 *ec2.ModifyIdentityIdFormatInput) (*request.Request, *ec2.ModifyIdentityIdFormatOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyIdentityIdFormatRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyIdentityIdFormatOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ModifyIdentityIdFormatRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyIdentityIdFormatRequest", arg0)
 }
 
 func (_m *MockEC2API) ModifyImageAttribute(_param0 *ec2.ModifyImageAttributeInput) (*ec2.ModifyImageAttributeOutput, error) {
@@ -4144,15 +7195,31 @@ func (_mr *_MockEC2APIRecorder) ModifyImageAttribute(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyImageAttribute", arg0)
 }
 
-func (_m *MockEC2API) ModifyInstanceAttributeRequest(_param0 *ec2.ModifyInstanceAttributeInput) (*request.Request, *ec2.ModifyInstanceAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyInstanceAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ModifyInstanceAttributeOutput)
+func (_m *MockEC2API) ModifyImageAttributeWithContext(_param0 aws.Context, _param1 *ec2.ModifyImageAttributeInput, _param2 ...request.Option) (*ec2.ModifyImageAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyImageAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ModifyImageAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ModifyInstanceAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyInstanceAttributeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ModifyImageAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyImageAttributeWithContext", _s...)
+}
+
+func (_m *MockEC2API) ModifyImageAttributeRequest(_param0 *ec2.ModifyImageAttributeInput) (*request.Request, *ec2.ModifyImageAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyImageAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyImageAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ModifyImageAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyImageAttributeRequest", arg0)
 }
 
 func (_m *MockEC2API) ModifyInstanceAttribute(_param0 *ec2.ModifyInstanceAttributeInput) (*ec2.ModifyInstanceAttributeOutput, error) {
@@ -4166,15 +7233,31 @@ func (_mr *_MockEC2APIRecorder) ModifyInstanceAttribute(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyInstanceAttribute", arg0)
 }
 
-func (_m *MockEC2API) ModifyInstancePlacementRequest(_param0 *ec2.ModifyInstancePlacementInput) (*request.Request, *ec2.ModifyInstancePlacementOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyInstancePlacementRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ModifyInstancePlacementOutput)
+func (_m *MockEC2API) ModifyInstanceAttributeWithContext(_param0 aws.Context, _param1 *ec2.ModifyInstanceAttributeInput, _param2 ...request.Option) (*ec2.ModifyInstanceAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyInstanceAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ModifyInstanceAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ModifyInstancePlacementRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyInstancePlacementRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ModifyInstanceAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyInstanceAttributeWithContext", _s...)
+}
+
+func (_m *MockEC2API) ModifyInstanceAttributeRequest(_param0 *ec2.ModifyInstanceAttributeInput) (*request.Request, *ec2.ModifyInstanceAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyInstanceAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyInstanceAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ModifyInstanceAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyInstanceAttributeRequest", arg0)
 }
 
 func (_m *MockEC2API) ModifyInstancePlacement(_param0 *ec2.ModifyInstancePlacementInput) (*ec2.ModifyInstancePlacementOutput, error) {
@@ -4188,15 +7271,31 @@ func (_mr *_MockEC2APIRecorder) ModifyInstancePlacement(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyInstancePlacement", arg0)
 }
 
-func (_m *MockEC2API) ModifyNetworkInterfaceAttributeRequest(_param0 *ec2.ModifyNetworkInterfaceAttributeInput) (*request.Request, *ec2.ModifyNetworkInterfaceAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyNetworkInterfaceAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ModifyNetworkInterfaceAttributeOutput)
+func (_m *MockEC2API) ModifyInstancePlacementWithContext(_param0 aws.Context, _param1 *ec2.ModifyInstancePlacementInput, _param2 ...request.Option) (*ec2.ModifyInstancePlacementOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyInstancePlacementWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ModifyInstancePlacementOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ModifyNetworkInterfaceAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyNetworkInterfaceAttributeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ModifyInstancePlacementWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyInstancePlacementWithContext", _s...)
+}
+
+func (_m *MockEC2API) ModifyInstancePlacementRequest(_param0 *ec2.ModifyInstancePlacementInput) (*request.Request, *ec2.ModifyInstancePlacementOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyInstancePlacementRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyInstancePlacementOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ModifyInstancePlacementRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyInstancePlacementRequest", arg0)
 }
 
 func (_m *MockEC2API) ModifyNetworkInterfaceAttribute(_param0 *ec2.ModifyNetworkInterfaceAttributeInput) (*ec2.ModifyNetworkInterfaceAttributeOutput, error) {
@@ -4210,15 +7309,31 @@ func (_mr *_MockEC2APIRecorder) ModifyNetworkInterfaceAttribute(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyNetworkInterfaceAttribute", arg0)
 }
 
-func (_m *MockEC2API) ModifyReservedInstancesRequest(_param0 *ec2.ModifyReservedInstancesInput) (*request.Request, *ec2.ModifyReservedInstancesOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyReservedInstancesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ModifyReservedInstancesOutput)
+func (_m *MockEC2API) ModifyNetworkInterfaceAttributeWithContext(_param0 aws.Context, _param1 *ec2.ModifyNetworkInterfaceAttributeInput, _param2 ...request.Option) (*ec2.ModifyNetworkInterfaceAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyNetworkInterfaceAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ModifyNetworkInterfaceAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ModifyReservedInstancesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyReservedInstancesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ModifyNetworkInterfaceAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyNetworkInterfaceAttributeWithContext", _s...)
+}
+
+func (_m *MockEC2API) ModifyNetworkInterfaceAttributeRequest(_param0 *ec2.ModifyNetworkInterfaceAttributeInput) (*request.Request, *ec2.ModifyNetworkInterfaceAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyNetworkInterfaceAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyNetworkInterfaceAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ModifyNetworkInterfaceAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyNetworkInterfaceAttributeRequest", arg0)
 }
 
 func (_m *MockEC2API) ModifyReservedInstances(_param0 *ec2.ModifyReservedInstancesInput) (*ec2.ModifyReservedInstancesOutput, error) {
@@ -4232,15 +7347,31 @@ func (_mr *_MockEC2APIRecorder) ModifyReservedInstances(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyReservedInstances", arg0)
 }
 
-func (_m *MockEC2API) ModifySnapshotAttributeRequest(_param0 *ec2.ModifySnapshotAttributeInput) (*request.Request, *ec2.ModifySnapshotAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "ModifySnapshotAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ModifySnapshotAttributeOutput)
+func (_m *MockEC2API) ModifyReservedInstancesWithContext(_param0 aws.Context, _param1 *ec2.ModifyReservedInstancesInput, _param2 ...request.Option) (*ec2.ModifyReservedInstancesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyReservedInstancesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ModifyReservedInstancesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ModifySnapshotAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifySnapshotAttributeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ModifyReservedInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyReservedInstancesWithContext", _s...)
+}
+
+func (_m *MockEC2API) ModifyReservedInstancesRequest(_param0 *ec2.ModifyReservedInstancesInput) (*request.Request, *ec2.ModifyReservedInstancesOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyReservedInstancesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyReservedInstancesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ModifyReservedInstancesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyReservedInstancesRequest", arg0)
 }
 
 func (_m *MockEC2API) ModifySnapshotAttribute(_param0 *ec2.ModifySnapshotAttributeInput) (*ec2.ModifySnapshotAttributeOutput, error) {
@@ -4254,15 +7385,31 @@ func (_mr *_MockEC2APIRecorder) ModifySnapshotAttribute(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifySnapshotAttribute", arg0)
 }
 
-func (_m *MockEC2API) ModifySpotFleetRequestRequest(_param0 *ec2.ModifySpotFleetRequestInput) (*request.Request, *ec2.ModifySpotFleetRequestOutput) {
-	ret := _m.ctrl.Call(_m, "ModifySpotFleetRequestRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ModifySpotFleetRequestOutput)
+func (_m *MockEC2API) ModifySnapshotAttributeWithContext(_param0 aws.Context, _param1 *ec2.ModifySnapshotAttributeInput, _param2 ...request.Option) (*ec2.ModifySnapshotAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifySnapshotAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ModifySnapshotAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ModifySpotFleetRequestRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifySpotFleetRequestRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ModifySnapshotAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifySnapshotAttributeWithContext", _s...)
+}
+
+func (_m *MockEC2API) ModifySnapshotAttributeRequest(_param0 *ec2.ModifySnapshotAttributeInput) (*request.Request, *ec2.ModifySnapshotAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "ModifySnapshotAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifySnapshotAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ModifySnapshotAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifySnapshotAttributeRequest", arg0)
 }
 
 func (_m *MockEC2API) ModifySpotFleetRequest(_param0 *ec2.ModifySpotFleetRequestInput) (*ec2.ModifySpotFleetRequestOutput, error) {
@@ -4276,15 +7423,31 @@ func (_mr *_MockEC2APIRecorder) ModifySpotFleetRequest(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifySpotFleetRequest", arg0)
 }
 
-func (_m *MockEC2API) ModifySubnetAttributeRequest(_param0 *ec2.ModifySubnetAttributeInput) (*request.Request, *ec2.ModifySubnetAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "ModifySubnetAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ModifySubnetAttributeOutput)
+func (_m *MockEC2API) ModifySpotFleetRequestWithContext(_param0 aws.Context, _param1 *ec2.ModifySpotFleetRequestInput, _param2 ...request.Option) (*ec2.ModifySpotFleetRequestOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifySpotFleetRequestWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ModifySpotFleetRequestOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ModifySubnetAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifySubnetAttributeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ModifySpotFleetRequestWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifySpotFleetRequestWithContext", _s...)
+}
+
+func (_m *MockEC2API) ModifySpotFleetRequestRequest(_param0 *ec2.ModifySpotFleetRequestInput) (*request.Request, *ec2.ModifySpotFleetRequestOutput) {
+	ret := _m.ctrl.Call(_m, "ModifySpotFleetRequestRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifySpotFleetRequestOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ModifySpotFleetRequestRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifySpotFleetRequestRequest", arg0)
 }
 
 func (_m *MockEC2API) ModifySubnetAttribute(_param0 *ec2.ModifySubnetAttributeInput) (*ec2.ModifySubnetAttributeOutput, error) {
@@ -4298,15 +7461,31 @@ func (_mr *_MockEC2APIRecorder) ModifySubnetAttribute(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifySubnetAttribute", arg0)
 }
 
-func (_m *MockEC2API) ModifyVolumeRequest(_param0 *ec2.ModifyVolumeInput) (*request.Request, *ec2.ModifyVolumeOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyVolumeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ModifyVolumeOutput)
+func (_m *MockEC2API) ModifySubnetAttributeWithContext(_param0 aws.Context, _param1 *ec2.ModifySubnetAttributeInput, _param2 ...request.Option) (*ec2.ModifySubnetAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifySubnetAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ModifySubnetAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ModifyVolumeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVolumeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ModifySubnetAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifySubnetAttributeWithContext", _s...)
+}
+
+func (_m *MockEC2API) ModifySubnetAttributeRequest(_param0 *ec2.ModifySubnetAttributeInput) (*request.Request, *ec2.ModifySubnetAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "ModifySubnetAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifySubnetAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ModifySubnetAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifySubnetAttributeRequest", arg0)
 }
 
 func (_m *MockEC2API) ModifyVolume(_param0 *ec2.ModifyVolumeInput) (*ec2.ModifyVolumeOutput, error) {
@@ -4320,15 +7499,31 @@ func (_mr *_MockEC2APIRecorder) ModifyVolume(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVolume", arg0)
 }
 
-func (_m *MockEC2API) ModifyVolumeAttributeRequest(_param0 *ec2.ModifyVolumeAttributeInput) (*request.Request, *ec2.ModifyVolumeAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyVolumeAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ModifyVolumeAttributeOutput)
+func (_m *MockEC2API) ModifyVolumeWithContext(_param0 aws.Context, _param1 *ec2.ModifyVolumeInput, _param2 ...request.Option) (*ec2.ModifyVolumeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyVolumeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ModifyVolumeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ModifyVolumeAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVolumeAttributeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ModifyVolumeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVolumeWithContext", _s...)
+}
+
+func (_m *MockEC2API) ModifyVolumeRequest(_param0 *ec2.ModifyVolumeInput) (*request.Request, *ec2.ModifyVolumeOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyVolumeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyVolumeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ModifyVolumeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVolumeRequest", arg0)
 }
 
 func (_m *MockEC2API) ModifyVolumeAttribute(_param0 *ec2.ModifyVolumeAttributeInput) (*ec2.ModifyVolumeAttributeOutput, error) {
@@ -4342,15 +7537,31 @@ func (_mr *_MockEC2APIRecorder) ModifyVolumeAttribute(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVolumeAttribute", arg0)
 }
 
-func (_m *MockEC2API) ModifyVpcAttributeRequest(_param0 *ec2.ModifyVpcAttributeInput) (*request.Request, *ec2.ModifyVpcAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyVpcAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ModifyVpcAttributeOutput)
+func (_m *MockEC2API) ModifyVolumeAttributeWithContext(_param0 aws.Context, _param1 *ec2.ModifyVolumeAttributeInput, _param2 ...request.Option) (*ec2.ModifyVolumeAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyVolumeAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ModifyVolumeAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ModifyVpcAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVpcAttributeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ModifyVolumeAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVolumeAttributeWithContext", _s...)
+}
+
+func (_m *MockEC2API) ModifyVolumeAttributeRequest(_param0 *ec2.ModifyVolumeAttributeInput) (*request.Request, *ec2.ModifyVolumeAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyVolumeAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyVolumeAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ModifyVolumeAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVolumeAttributeRequest", arg0)
 }
 
 func (_m *MockEC2API) ModifyVpcAttribute(_param0 *ec2.ModifyVpcAttributeInput) (*ec2.ModifyVpcAttributeOutput, error) {
@@ -4364,15 +7575,31 @@ func (_mr *_MockEC2APIRecorder) ModifyVpcAttribute(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVpcAttribute", arg0)
 }
 
-func (_m *MockEC2API) ModifyVpcEndpointRequest(_param0 *ec2.ModifyVpcEndpointInput) (*request.Request, *ec2.ModifyVpcEndpointOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyVpcEndpointRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ModifyVpcEndpointOutput)
+func (_m *MockEC2API) ModifyVpcAttributeWithContext(_param0 aws.Context, _param1 *ec2.ModifyVpcAttributeInput, _param2 ...request.Option) (*ec2.ModifyVpcAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyVpcAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ModifyVpcAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ModifyVpcEndpointRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVpcEndpointRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ModifyVpcAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVpcAttributeWithContext", _s...)
+}
+
+func (_m *MockEC2API) ModifyVpcAttributeRequest(_param0 *ec2.ModifyVpcAttributeInput) (*request.Request, *ec2.ModifyVpcAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyVpcAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyVpcAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ModifyVpcAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVpcAttributeRequest", arg0)
 }
 
 func (_m *MockEC2API) ModifyVpcEndpoint(_param0 *ec2.ModifyVpcEndpointInput) (*ec2.ModifyVpcEndpointOutput, error) {
@@ -4386,15 +7613,31 @@ func (_mr *_MockEC2APIRecorder) ModifyVpcEndpoint(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVpcEndpoint", arg0)
 }
 
-func (_m *MockEC2API) ModifyVpcPeeringConnectionOptionsRequest(_param0 *ec2.ModifyVpcPeeringConnectionOptionsInput) (*request.Request, *ec2.ModifyVpcPeeringConnectionOptionsOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyVpcPeeringConnectionOptionsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ModifyVpcPeeringConnectionOptionsOutput)
+func (_m *MockEC2API) ModifyVpcEndpointWithContext(_param0 aws.Context, _param1 *ec2.ModifyVpcEndpointInput, _param2 ...request.Option) (*ec2.ModifyVpcEndpointOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyVpcEndpointWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ModifyVpcEndpointOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ModifyVpcPeeringConnectionOptionsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVpcPeeringConnectionOptionsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ModifyVpcEndpointWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVpcEndpointWithContext", _s...)
+}
+
+func (_m *MockEC2API) ModifyVpcEndpointRequest(_param0 *ec2.ModifyVpcEndpointInput) (*request.Request, *ec2.ModifyVpcEndpointOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyVpcEndpointRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyVpcEndpointOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ModifyVpcEndpointRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVpcEndpointRequest", arg0)
 }
 
 func (_m *MockEC2API) ModifyVpcPeeringConnectionOptions(_param0 *ec2.ModifyVpcPeeringConnectionOptionsInput) (*ec2.ModifyVpcPeeringConnectionOptionsOutput, error) {
@@ -4408,15 +7651,31 @@ func (_mr *_MockEC2APIRecorder) ModifyVpcPeeringConnectionOptions(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVpcPeeringConnectionOptions", arg0)
 }
 
-func (_m *MockEC2API) MonitorInstancesRequest(_param0 *ec2.MonitorInstancesInput) (*request.Request, *ec2.MonitorInstancesOutput) {
-	ret := _m.ctrl.Call(_m, "MonitorInstancesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.MonitorInstancesOutput)
+func (_m *MockEC2API) ModifyVpcPeeringConnectionOptionsWithContext(_param0 aws.Context, _param1 *ec2.ModifyVpcPeeringConnectionOptionsInput, _param2 ...request.Option) (*ec2.ModifyVpcPeeringConnectionOptionsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyVpcPeeringConnectionOptionsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ModifyVpcPeeringConnectionOptionsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) MonitorInstancesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "MonitorInstancesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ModifyVpcPeeringConnectionOptionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVpcPeeringConnectionOptionsWithContext", _s...)
+}
+
+func (_m *MockEC2API) ModifyVpcPeeringConnectionOptionsRequest(_param0 *ec2.ModifyVpcPeeringConnectionOptionsInput) (*request.Request, *ec2.ModifyVpcPeeringConnectionOptionsOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyVpcPeeringConnectionOptionsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyVpcPeeringConnectionOptionsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ModifyVpcPeeringConnectionOptionsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyVpcPeeringConnectionOptionsRequest", arg0)
 }
 
 func (_m *MockEC2API) MonitorInstances(_param0 *ec2.MonitorInstancesInput) (*ec2.MonitorInstancesOutput, error) {
@@ -4430,15 +7689,31 @@ func (_mr *_MockEC2APIRecorder) MonitorInstances(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MonitorInstances", arg0)
 }
 
-func (_m *MockEC2API) MoveAddressToVpcRequest(_param0 *ec2.MoveAddressToVpcInput) (*request.Request, *ec2.MoveAddressToVpcOutput) {
-	ret := _m.ctrl.Call(_m, "MoveAddressToVpcRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.MoveAddressToVpcOutput)
+func (_m *MockEC2API) MonitorInstancesWithContext(_param0 aws.Context, _param1 *ec2.MonitorInstancesInput, _param2 ...request.Option) (*ec2.MonitorInstancesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "MonitorInstancesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.MonitorInstancesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) MoveAddressToVpcRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "MoveAddressToVpcRequest", arg0)
+func (_mr *_MockEC2APIRecorder) MonitorInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MonitorInstancesWithContext", _s...)
+}
+
+func (_m *MockEC2API) MonitorInstancesRequest(_param0 *ec2.MonitorInstancesInput) (*request.Request, *ec2.MonitorInstancesOutput) {
+	ret := _m.ctrl.Call(_m, "MonitorInstancesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.MonitorInstancesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) MonitorInstancesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MonitorInstancesRequest", arg0)
 }
 
 func (_m *MockEC2API) MoveAddressToVpc(_param0 *ec2.MoveAddressToVpcInput) (*ec2.MoveAddressToVpcOutput, error) {
@@ -4452,15 +7727,31 @@ func (_mr *_MockEC2APIRecorder) MoveAddressToVpc(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MoveAddressToVpc", arg0)
 }
 
-func (_m *MockEC2API) PurchaseHostReservationRequest(_param0 *ec2.PurchaseHostReservationInput) (*request.Request, *ec2.PurchaseHostReservationOutput) {
-	ret := _m.ctrl.Call(_m, "PurchaseHostReservationRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.PurchaseHostReservationOutput)
+func (_m *MockEC2API) MoveAddressToVpcWithContext(_param0 aws.Context, _param1 *ec2.MoveAddressToVpcInput, _param2 ...request.Option) (*ec2.MoveAddressToVpcOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "MoveAddressToVpcWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.MoveAddressToVpcOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) PurchaseHostReservationRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseHostReservationRequest", arg0)
+func (_mr *_MockEC2APIRecorder) MoveAddressToVpcWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MoveAddressToVpcWithContext", _s...)
+}
+
+func (_m *MockEC2API) MoveAddressToVpcRequest(_param0 *ec2.MoveAddressToVpcInput) (*request.Request, *ec2.MoveAddressToVpcOutput) {
+	ret := _m.ctrl.Call(_m, "MoveAddressToVpcRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.MoveAddressToVpcOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) MoveAddressToVpcRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MoveAddressToVpcRequest", arg0)
 }
 
 func (_m *MockEC2API) PurchaseHostReservation(_param0 *ec2.PurchaseHostReservationInput) (*ec2.PurchaseHostReservationOutput, error) {
@@ -4474,15 +7765,31 @@ func (_mr *_MockEC2APIRecorder) PurchaseHostReservation(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseHostReservation", arg0)
 }
 
-func (_m *MockEC2API) PurchaseReservedInstancesOfferingRequest(_param0 *ec2.PurchaseReservedInstancesOfferingInput) (*request.Request, *ec2.PurchaseReservedInstancesOfferingOutput) {
-	ret := _m.ctrl.Call(_m, "PurchaseReservedInstancesOfferingRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.PurchaseReservedInstancesOfferingOutput)
+func (_m *MockEC2API) PurchaseHostReservationWithContext(_param0 aws.Context, _param1 *ec2.PurchaseHostReservationInput, _param2 ...request.Option) (*ec2.PurchaseHostReservationOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "PurchaseHostReservationWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.PurchaseHostReservationOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) PurchaseReservedInstancesOfferingRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseReservedInstancesOfferingRequest", arg0)
+func (_mr *_MockEC2APIRecorder) PurchaseHostReservationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseHostReservationWithContext", _s...)
+}
+
+func (_m *MockEC2API) PurchaseHostReservationRequest(_param0 *ec2.PurchaseHostReservationInput) (*request.Request, *ec2.PurchaseHostReservationOutput) {
+	ret := _m.ctrl.Call(_m, "PurchaseHostReservationRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.PurchaseHostReservationOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) PurchaseHostReservationRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseHostReservationRequest", arg0)
 }
 
 func (_m *MockEC2API) PurchaseReservedInstancesOffering(_param0 *ec2.PurchaseReservedInstancesOfferingInput) (*ec2.PurchaseReservedInstancesOfferingOutput, error) {
@@ -4496,15 +7803,31 @@ func (_mr *_MockEC2APIRecorder) PurchaseReservedInstancesOffering(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseReservedInstancesOffering", arg0)
 }
 
-func (_m *MockEC2API) PurchaseScheduledInstancesRequest(_param0 *ec2.PurchaseScheduledInstancesInput) (*request.Request, *ec2.PurchaseScheduledInstancesOutput) {
-	ret := _m.ctrl.Call(_m, "PurchaseScheduledInstancesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.PurchaseScheduledInstancesOutput)
+func (_m *MockEC2API) PurchaseReservedInstancesOfferingWithContext(_param0 aws.Context, _param1 *ec2.PurchaseReservedInstancesOfferingInput, _param2 ...request.Option) (*ec2.PurchaseReservedInstancesOfferingOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "PurchaseReservedInstancesOfferingWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.PurchaseReservedInstancesOfferingOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) PurchaseScheduledInstancesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseScheduledInstancesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) PurchaseReservedInstancesOfferingWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseReservedInstancesOfferingWithContext", _s...)
+}
+
+func (_m *MockEC2API) PurchaseReservedInstancesOfferingRequest(_param0 *ec2.PurchaseReservedInstancesOfferingInput) (*request.Request, *ec2.PurchaseReservedInstancesOfferingOutput) {
+	ret := _m.ctrl.Call(_m, "PurchaseReservedInstancesOfferingRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.PurchaseReservedInstancesOfferingOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) PurchaseReservedInstancesOfferingRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseReservedInstancesOfferingRequest", arg0)
 }
 
 func (_m *MockEC2API) PurchaseScheduledInstances(_param0 *ec2.PurchaseScheduledInstancesInput) (*ec2.PurchaseScheduledInstancesOutput, error) {
@@ -4518,15 +7841,31 @@ func (_mr *_MockEC2APIRecorder) PurchaseScheduledInstances(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseScheduledInstances", arg0)
 }
 
-func (_m *MockEC2API) RebootInstancesRequest(_param0 *ec2.RebootInstancesInput) (*request.Request, *ec2.RebootInstancesOutput) {
-	ret := _m.ctrl.Call(_m, "RebootInstancesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.RebootInstancesOutput)
+func (_m *MockEC2API) PurchaseScheduledInstancesWithContext(_param0 aws.Context, _param1 *ec2.PurchaseScheduledInstancesInput, _param2 ...request.Option) (*ec2.PurchaseScheduledInstancesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "PurchaseScheduledInstancesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.PurchaseScheduledInstancesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) RebootInstancesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RebootInstancesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) PurchaseScheduledInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseScheduledInstancesWithContext", _s...)
+}
+
+func (_m *MockEC2API) PurchaseScheduledInstancesRequest(_param0 *ec2.PurchaseScheduledInstancesInput) (*request.Request, *ec2.PurchaseScheduledInstancesOutput) {
+	ret := _m.ctrl.Call(_m, "PurchaseScheduledInstancesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.PurchaseScheduledInstancesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) PurchaseScheduledInstancesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseScheduledInstancesRequest", arg0)
 }
 
 func (_m *MockEC2API) RebootInstances(_param0 *ec2.RebootInstancesInput) (*ec2.RebootInstancesOutput, error) {
@@ -4540,15 +7879,31 @@ func (_mr *_MockEC2APIRecorder) RebootInstances(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RebootInstances", arg0)
 }
 
-func (_m *MockEC2API) RegisterImageRequest(_param0 *ec2.RegisterImageInput) (*request.Request, *ec2.RegisterImageOutput) {
-	ret := _m.ctrl.Call(_m, "RegisterImageRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.RegisterImageOutput)
+func (_m *MockEC2API) RebootInstancesWithContext(_param0 aws.Context, _param1 *ec2.RebootInstancesInput, _param2 ...request.Option) (*ec2.RebootInstancesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RebootInstancesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.RebootInstancesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) RegisterImageRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RegisterImageRequest", arg0)
+func (_mr *_MockEC2APIRecorder) RebootInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RebootInstancesWithContext", _s...)
+}
+
+func (_m *MockEC2API) RebootInstancesRequest(_param0 *ec2.RebootInstancesInput) (*request.Request, *ec2.RebootInstancesOutput) {
+	ret := _m.ctrl.Call(_m, "RebootInstancesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.RebootInstancesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) RebootInstancesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RebootInstancesRequest", arg0)
 }
 
 func (_m *MockEC2API) RegisterImage(_param0 *ec2.RegisterImageInput) (*ec2.RegisterImageOutput, error) {
@@ -4562,15 +7917,31 @@ func (_mr *_MockEC2APIRecorder) RegisterImage(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RegisterImage", arg0)
 }
 
-func (_m *MockEC2API) RejectVpcPeeringConnectionRequest(_param0 *ec2.RejectVpcPeeringConnectionInput) (*request.Request, *ec2.RejectVpcPeeringConnectionOutput) {
-	ret := _m.ctrl.Call(_m, "RejectVpcPeeringConnectionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.RejectVpcPeeringConnectionOutput)
+func (_m *MockEC2API) RegisterImageWithContext(_param0 aws.Context, _param1 *ec2.RegisterImageInput, _param2 ...request.Option) (*ec2.RegisterImageOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RegisterImageWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.RegisterImageOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) RejectVpcPeeringConnectionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RejectVpcPeeringConnectionRequest", arg0)
+func (_mr *_MockEC2APIRecorder) RegisterImageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RegisterImageWithContext", _s...)
+}
+
+func (_m *MockEC2API) RegisterImageRequest(_param0 *ec2.RegisterImageInput) (*request.Request, *ec2.RegisterImageOutput) {
+	ret := _m.ctrl.Call(_m, "RegisterImageRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.RegisterImageOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) RegisterImageRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RegisterImageRequest", arg0)
 }
 
 func (_m *MockEC2API) RejectVpcPeeringConnection(_param0 *ec2.RejectVpcPeeringConnectionInput) (*ec2.RejectVpcPeeringConnectionOutput, error) {
@@ -4584,15 +7955,31 @@ func (_mr *_MockEC2APIRecorder) RejectVpcPeeringConnection(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RejectVpcPeeringConnection", arg0)
 }
 
-func (_m *MockEC2API) ReleaseAddressRequest(_param0 *ec2.ReleaseAddressInput) (*request.Request, *ec2.ReleaseAddressOutput) {
-	ret := _m.ctrl.Call(_m, "ReleaseAddressRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ReleaseAddressOutput)
+func (_m *MockEC2API) RejectVpcPeeringConnectionWithContext(_param0 aws.Context, _param1 *ec2.RejectVpcPeeringConnectionInput, _param2 ...request.Option) (*ec2.RejectVpcPeeringConnectionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RejectVpcPeeringConnectionWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.RejectVpcPeeringConnectionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ReleaseAddressRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReleaseAddressRequest", arg0)
+func (_mr *_MockEC2APIRecorder) RejectVpcPeeringConnectionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RejectVpcPeeringConnectionWithContext", _s...)
+}
+
+func (_m *MockEC2API) RejectVpcPeeringConnectionRequest(_param0 *ec2.RejectVpcPeeringConnectionInput) (*request.Request, *ec2.RejectVpcPeeringConnectionOutput) {
+	ret := _m.ctrl.Call(_m, "RejectVpcPeeringConnectionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.RejectVpcPeeringConnectionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) RejectVpcPeeringConnectionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RejectVpcPeeringConnectionRequest", arg0)
 }
 
 func (_m *MockEC2API) ReleaseAddress(_param0 *ec2.ReleaseAddressInput) (*ec2.ReleaseAddressOutput, error) {
@@ -4606,15 +7993,31 @@ func (_mr *_MockEC2APIRecorder) ReleaseAddress(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReleaseAddress", arg0)
 }
 
-func (_m *MockEC2API) ReleaseHostsRequest(_param0 *ec2.ReleaseHostsInput) (*request.Request, *ec2.ReleaseHostsOutput) {
-	ret := _m.ctrl.Call(_m, "ReleaseHostsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ReleaseHostsOutput)
+func (_m *MockEC2API) ReleaseAddressWithContext(_param0 aws.Context, _param1 *ec2.ReleaseAddressInput, _param2 ...request.Option) (*ec2.ReleaseAddressOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ReleaseAddressWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ReleaseAddressOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ReleaseHostsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReleaseHostsRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ReleaseAddressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReleaseAddressWithContext", _s...)
+}
+
+func (_m *MockEC2API) ReleaseAddressRequest(_param0 *ec2.ReleaseAddressInput) (*request.Request, *ec2.ReleaseAddressOutput) {
+	ret := _m.ctrl.Call(_m, "ReleaseAddressRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ReleaseAddressOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ReleaseAddressRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReleaseAddressRequest", arg0)
 }
 
 func (_m *MockEC2API) ReleaseHosts(_param0 *ec2.ReleaseHostsInput) (*ec2.ReleaseHostsOutput, error) {
@@ -4628,15 +8031,31 @@ func (_mr *_MockEC2APIRecorder) ReleaseHosts(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReleaseHosts", arg0)
 }
 
-func (_m *MockEC2API) ReplaceIamInstanceProfileAssociationRequest(_param0 *ec2.ReplaceIamInstanceProfileAssociationInput) (*request.Request, *ec2.ReplaceIamInstanceProfileAssociationOutput) {
-	ret := _m.ctrl.Call(_m, "ReplaceIamInstanceProfileAssociationRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ReplaceIamInstanceProfileAssociationOutput)
+func (_m *MockEC2API) ReleaseHostsWithContext(_param0 aws.Context, _param1 *ec2.ReleaseHostsInput, _param2 ...request.Option) (*ec2.ReleaseHostsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ReleaseHostsWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ReleaseHostsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ReplaceIamInstanceProfileAssociationRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceIamInstanceProfileAssociationRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ReleaseHostsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReleaseHostsWithContext", _s...)
+}
+
+func (_m *MockEC2API) ReleaseHostsRequest(_param0 *ec2.ReleaseHostsInput) (*request.Request, *ec2.ReleaseHostsOutput) {
+	ret := _m.ctrl.Call(_m, "ReleaseHostsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ReleaseHostsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ReleaseHostsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReleaseHostsRequest", arg0)
 }
 
 func (_m *MockEC2API) ReplaceIamInstanceProfileAssociation(_param0 *ec2.ReplaceIamInstanceProfileAssociationInput) (*ec2.ReplaceIamInstanceProfileAssociationOutput, error) {
@@ -4650,15 +8069,31 @@ func (_mr *_MockEC2APIRecorder) ReplaceIamInstanceProfileAssociation(arg0 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceIamInstanceProfileAssociation", arg0)
 }
 
-func (_m *MockEC2API) ReplaceNetworkAclAssociationRequest(_param0 *ec2.ReplaceNetworkAclAssociationInput) (*request.Request, *ec2.ReplaceNetworkAclAssociationOutput) {
-	ret := _m.ctrl.Call(_m, "ReplaceNetworkAclAssociationRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ReplaceNetworkAclAssociationOutput)
+func (_m *MockEC2API) ReplaceIamInstanceProfileAssociationWithContext(_param0 aws.Context, _param1 *ec2.ReplaceIamInstanceProfileAssociationInput, _param2 ...request.Option) (*ec2.ReplaceIamInstanceProfileAssociationOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ReplaceIamInstanceProfileAssociationWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ReplaceIamInstanceProfileAssociationOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ReplaceNetworkAclAssociationRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceNetworkAclAssociationRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ReplaceIamInstanceProfileAssociationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceIamInstanceProfileAssociationWithContext", _s...)
+}
+
+func (_m *MockEC2API) ReplaceIamInstanceProfileAssociationRequest(_param0 *ec2.ReplaceIamInstanceProfileAssociationInput) (*request.Request, *ec2.ReplaceIamInstanceProfileAssociationOutput) {
+	ret := _m.ctrl.Call(_m, "ReplaceIamInstanceProfileAssociationRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ReplaceIamInstanceProfileAssociationOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ReplaceIamInstanceProfileAssociationRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceIamInstanceProfileAssociationRequest", arg0)
 }
 
 func (_m *MockEC2API) ReplaceNetworkAclAssociation(_param0 *ec2.ReplaceNetworkAclAssociationInput) (*ec2.ReplaceNetworkAclAssociationOutput, error) {
@@ -4672,15 +8107,31 @@ func (_mr *_MockEC2APIRecorder) ReplaceNetworkAclAssociation(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceNetworkAclAssociation", arg0)
 }
 
-func (_m *MockEC2API) ReplaceNetworkAclEntryRequest(_param0 *ec2.ReplaceNetworkAclEntryInput) (*request.Request, *ec2.ReplaceNetworkAclEntryOutput) {
-	ret := _m.ctrl.Call(_m, "ReplaceNetworkAclEntryRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ReplaceNetworkAclEntryOutput)
+func (_m *MockEC2API) ReplaceNetworkAclAssociationWithContext(_param0 aws.Context, _param1 *ec2.ReplaceNetworkAclAssociationInput, _param2 ...request.Option) (*ec2.ReplaceNetworkAclAssociationOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ReplaceNetworkAclAssociationWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ReplaceNetworkAclAssociationOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ReplaceNetworkAclEntryRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceNetworkAclEntryRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ReplaceNetworkAclAssociationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceNetworkAclAssociationWithContext", _s...)
+}
+
+func (_m *MockEC2API) ReplaceNetworkAclAssociationRequest(_param0 *ec2.ReplaceNetworkAclAssociationInput) (*request.Request, *ec2.ReplaceNetworkAclAssociationOutput) {
+	ret := _m.ctrl.Call(_m, "ReplaceNetworkAclAssociationRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ReplaceNetworkAclAssociationOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ReplaceNetworkAclAssociationRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceNetworkAclAssociationRequest", arg0)
 }
 
 func (_m *MockEC2API) ReplaceNetworkAclEntry(_param0 *ec2.ReplaceNetworkAclEntryInput) (*ec2.ReplaceNetworkAclEntryOutput, error) {
@@ -4694,15 +8145,31 @@ func (_mr *_MockEC2APIRecorder) ReplaceNetworkAclEntry(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceNetworkAclEntry", arg0)
 }
 
-func (_m *MockEC2API) ReplaceRouteRequest(_param0 *ec2.ReplaceRouteInput) (*request.Request, *ec2.ReplaceRouteOutput) {
-	ret := _m.ctrl.Call(_m, "ReplaceRouteRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ReplaceRouteOutput)
+func (_m *MockEC2API) ReplaceNetworkAclEntryWithContext(_param0 aws.Context, _param1 *ec2.ReplaceNetworkAclEntryInput, _param2 ...request.Option) (*ec2.ReplaceNetworkAclEntryOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ReplaceNetworkAclEntryWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ReplaceNetworkAclEntryOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ReplaceRouteRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceRouteRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ReplaceNetworkAclEntryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceNetworkAclEntryWithContext", _s...)
+}
+
+func (_m *MockEC2API) ReplaceNetworkAclEntryRequest(_param0 *ec2.ReplaceNetworkAclEntryInput) (*request.Request, *ec2.ReplaceNetworkAclEntryOutput) {
+	ret := _m.ctrl.Call(_m, "ReplaceNetworkAclEntryRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ReplaceNetworkAclEntryOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ReplaceNetworkAclEntryRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceNetworkAclEntryRequest", arg0)
 }
 
 func (_m *MockEC2API) ReplaceRoute(_param0 *ec2.ReplaceRouteInput) (*ec2.ReplaceRouteOutput, error) {
@@ -4716,15 +8183,31 @@ func (_mr *_MockEC2APIRecorder) ReplaceRoute(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceRoute", arg0)
 }
 
-func (_m *MockEC2API) ReplaceRouteTableAssociationRequest(_param0 *ec2.ReplaceRouteTableAssociationInput) (*request.Request, *ec2.ReplaceRouteTableAssociationOutput) {
-	ret := _m.ctrl.Call(_m, "ReplaceRouteTableAssociationRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ReplaceRouteTableAssociationOutput)
+func (_m *MockEC2API) ReplaceRouteWithContext(_param0 aws.Context, _param1 *ec2.ReplaceRouteInput, _param2 ...request.Option) (*ec2.ReplaceRouteOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ReplaceRouteWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ReplaceRouteOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ReplaceRouteTableAssociationRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceRouteTableAssociationRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ReplaceRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceRouteWithContext", _s...)
+}
+
+func (_m *MockEC2API) ReplaceRouteRequest(_param0 *ec2.ReplaceRouteInput) (*request.Request, *ec2.ReplaceRouteOutput) {
+	ret := _m.ctrl.Call(_m, "ReplaceRouteRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ReplaceRouteOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ReplaceRouteRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceRouteRequest", arg0)
 }
 
 func (_m *MockEC2API) ReplaceRouteTableAssociation(_param0 *ec2.ReplaceRouteTableAssociationInput) (*ec2.ReplaceRouteTableAssociationOutput, error) {
@@ -4738,15 +8221,31 @@ func (_mr *_MockEC2APIRecorder) ReplaceRouteTableAssociation(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceRouteTableAssociation", arg0)
 }
 
-func (_m *MockEC2API) ReportInstanceStatusRequest(_param0 *ec2.ReportInstanceStatusInput) (*request.Request, *ec2.ReportInstanceStatusOutput) {
-	ret := _m.ctrl.Call(_m, "ReportInstanceStatusRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ReportInstanceStatusOutput)
+func (_m *MockEC2API) ReplaceRouteTableAssociationWithContext(_param0 aws.Context, _param1 *ec2.ReplaceRouteTableAssociationInput, _param2 ...request.Option) (*ec2.ReplaceRouteTableAssociationOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ReplaceRouteTableAssociationWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ReplaceRouteTableAssociationOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ReportInstanceStatusRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReportInstanceStatusRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ReplaceRouteTableAssociationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceRouteTableAssociationWithContext", _s...)
+}
+
+func (_m *MockEC2API) ReplaceRouteTableAssociationRequest(_param0 *ec2.ReplaceRouteTableAssociationInput) (*request.Request, *ec2.ReplaceRouteTableAssociationOutput) {
+	ret := _m.ctrl.Call(_m, "ReplaceRouteTableAssociationRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ReplaceRouteTableAssociationOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ReplaceRouteTableAssociationRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplaceRouteTableAssociationRequest", arg0)
 }
 
 func (_m *MockEC2API) ReportInstanceStatus(_param0 *ec2.ReportInstanceStatusInput) (*ec2.ReportInstanceStatusOutput, error) {
@@ -4760,15 +8259,31 @@ func (_mr *_MockEC2APIRecorder) ReportInstanceStatus(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReportInstanceStatus", arg0)
 }
 
-func (_m *MockEC2API) RequestSpotFleetRequest(_param0 *ec2.RequestSpotFleetInput) (*request.Request, *ec2.RequestSpotFleetOutput) {
-	ret := _m.ctrl.Call(_m, "RequestSpotFleetRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.RequestSpotFleetOutput)
+func (_m *MockEC2API) ReportInstanceStatusWithContext(_param0 aws.Context, _param1 *ec2.ReportInstanceStatusInput, _param2 ...request.Option) (*ec2.ReportInstanceStatusOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ReportInstanceStatusWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ReportInstanceStatusOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) RequestSpotFleetRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RequestSpotFleetRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ReportInstanceStatusWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReportInstanceStatusWithContext", _s...)
+}
+
+func (_m *MockEC2API) ReportInstanceStatusRequest(_param0 *ec2.ReportInstanceStatusInput) (*request.Request, *ec2.ReportInstanceStatusOutput) {
+	ret := _m.ctrl.Call(_m, "ReportInstanceStatusRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ReportInstanceStatusOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ReportInstanceStatusRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReportInstanceStatusRequest", arg0)
 }
 
 func (_m *MockEC2API) RequestSpotFleet(_param0 *ec2.RequestSpotFleetInput) (*ec2.RequestSpotFleetOutput, error) {
@@ -4782,15 +8297,31 @@ func (_mr *_MockEC2APIRecorder) RequestSpotFleet(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RequestSpotFleet", arg0)
 }
 
-func (_m *MockEC2API) RequestSpotInstancesRequest(_param0 *ec2.RequestSpotInstancesInput) (*request.Request, *ec2.RequestSpotInstancesOutput) {
-	ret := _m.ctrl.Call(_m, "RequestSpotInstancesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.RequestSpotInstancesOutput)
+func (_m *MockEC2API) RequestSpotFleetWithContext(_param0 aws.Context, _param1 *ec2.RequestSpotFleetInput, _param2 ...request.Option) (*ec2.RequestSpotFleetOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RequestSpotFleetWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.RequestSpotFleetOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) RequestSpotInstancesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RequestSpotInstancesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) RequestSpotFleetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RequestSpotFleetWithContext", _s...)
+}
+
+func (_m *MockEC2API) RequestSpotFleetRequest(_param0 *ec2.RequestSpotFleetInput) (*request.Request, *ec2.RequestSpotFleetOutput) {
+	ret := _m.ctrl.Call(_m, "RequestSpotFleetRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.RequestSpotFleetOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) RequestSpotFleetRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RequestSpotFleetRequest", arg0)
 }
 
 func (_m *MockEC2API) RequestSpotInstances(_param0 *ec2.RequestSpotInstancesInput) (*ec2.RequestSpotInstancesOutput, error) {
@@ -4804,15 +8335,31 @@ func (_mr *_MockEC2APIRecorder) RequestSpotInstances(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RequestSpotInstances", arg0)
 }
 
-func (_m *MockEC2API) ResetImageAttributeRequest(_param0 *ec2.ResetImageAttributeInput) (*request.Request, *ec2.ResetImageAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "ResetImageAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ResetImageAttributeOutput)
+func (_m *MockEC2API) RequestSpotInstancesWithContext(_param0 aws.Context, _param1 *ec2.RequestSpotInstancesInput, _param2 ...request.Option) (*ec2.RequestSpotInstancesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RequestSpotInstancesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.RequestSpotInstancesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ResetImageAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetImageAttributeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) RequestSpotInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RequestSpotInstancesWithContext", _s...)
+}
+
+func (_m *MockEC2API) RequestSpotInstancesRequest(_param0 *ec2.RequestSpotInstancesInput) (*request.Request, *ec2.RequestSpotInstancesOutput) {
+	ret := _m.ctrl.Call(_m, "RequestSpotInstancesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.RequestSpotInstancesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) RequestSpotInstancesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RequestSpotInstancesRequest", arg0)
 }
 
 func (_m *MockEC2API) ResetImageAttribute(_param0 *ec2.ResetImageAttributeInput) (*ec2.ResetImageAttributeOutput, error) {
@@ -4826,15 +8373,31 @@ func (_mr *_MockEC2APIRecorder) ResetImageAttribute(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetImageAttribute", arg0)
 }
 
-func (_m *MockEC2API) ResetInstanceAttributeRequest(_param0 *ec2.ResetInstanceAttributeInput) (*request.Request, *ec2.ResetInstanceAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "ResetInstanceAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ResetInstanceAttributeOutput)
+func (_m *MockEC2API) ResetImageAttributeWithContext(_param0 aws.Context, _param1 *ec2.ResetImageAttributeInput, _param2 ...request.Option) (*ec2.ResetImageAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ResetImageAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ResetImageAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ResetInstanceAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetInstanceAttributeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ResetImageAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetImageAttributeWithContext", _s...)
+}
+
+func (_m *MockEC2API) ResetImageAttributeRequest(_param0 *ec2.ResetImageAttributeInput) (*request.Request, *ec2.ResetImageAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "ResetImageAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ResetImageAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ResetImageAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetImageAttributeRequest", arg0)
 }
 
 func (_m *MockEC2API) ResetInstanceAttribute(_param0 *ec2.ResetInstanceAttributeInput) (*ec2.ResetInstanceAttributeOutput, error) {
@@ -4848,15 +8411,31 @@ func (_mr *_MockEC2APIRecorder) ResetInstanceAttribute(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetInstanceAttribute", arg0)
 }
 
-func (_m *MockEC2API) ResetNetworkInterfaceAttributeRequest(_param0 *ec2.ResetNetworkInterfaceAttributeInput) (*request.Request, *ec2.ResetNetworkInterfaceAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "ResetNetworkInterfaceAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ResetNetworkInterfaceAttributeOutput)
+func (_m *MockEC2API) ResetInstanceAttributeWithContext(_param0 aws.Context, _param1 *ec2.ResetInstanceAttributeInput, _param2 ...request.Option) (*ec2.ResetInstanceAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ResetInstanceAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ResetInstanceAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ResetNetworkInterfaceAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetNetworkInterfaceAttributeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ResetInstanceAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetInstanceAttributeWithContext", _s...)
+}
+
+func (_m *MockEC2API) ResetInstanceAttributeRequest(_param0 *ec2.ResetInstanceAttributeInput) (*request.Request, *ec2.ResetInstanceAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "ResetInstanceAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ResetInstanceAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ResetInstanceAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetInstanceAttributeRequest", arg0)
 }
 
 func (_m *MockEC2API) ResetNetworkInterfaceAttribute(_param0 *ec2.ResetNetworkInterfaceAttributeInput) (*ec2.ResetNetworkInterfaceAttributeOutput, error) {
@@ -4870,15 +8449,31 @@ func (_mr *_MockEC2APIRecorder) ResetNetworkInterfaceAttribute(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetNetworkInterfaceAttribute", arg0)
 }
 
-func (_m *MockEC2API) ResetSnapshotAttributeRequest(_param0 *ec2.ResetSnapshotAttributeInput) (*request.Request, *ec2.ResetSnapshotAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "ResetSnapshotAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.ResetSnapshotAttributeOutput)
+func (_m *MockEC2API) ResetNetworkInterfaceAttributeWithContext(_param0 aws.Context, _param1 *ec2.ResetNetworkInterfaceAttributeInput, _param2 ...request.Option) (*ec2.ResetNetworkInterfaceAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ResetNetworkInterfaceAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ResetNetworkInterfaceAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) ResetSnapshotAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetSnapshotAttributeRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ResetNetworkInterfaceAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetNetworkInterfaceAttributeWithContext", _s...)
+}
+
+func (_m *MockEC2API) ResetNetworkInterfaceAttributeRequest(_param0 *ec2.ResetNetworkInterfaceAttributeInput) (*request.Request, *ec2.ResetNetworkInterfaceAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "ResetNetworkInterfaceAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ResetNetworkInterfaceAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ResetNetworkInterfaceAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetNetworkInterfaceAttributeRequest", arg0)
 }
 
 func (_m *MockEC2API) ResetSnapshotAttribute(_param0 *ec2.ResetSnapshotAttributeInput) (*ec2.ResetSnapshotAttributeOutput, error) {
@@ -4892,15 +8487,31 @@ func (_mr *_MockEC2APIRecorder) ResetSnapshotAttribute(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetSnapshotAttribute", arg0)
 }
 
-func (_m *MockEC2API) RestoreAddressToClassicRequest(_param0 *ec2.RestoreAddressToClassicInput) (*request.Request, *ec2.RestoreAddressToClassicOutput) {
-	ret := _m.ctrl.Call(_m, "RestoreAddressToClassicRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.RestoreAddressToClassicOutput)
+func (_m *MockEC2API) ResetSnapshotAttributeWithContext(_param0 aws.Context, _param1 *ec2.ResetSnapshotAttributeInput, _param2 ...request.Option) (*ec2.ResetSnapshotAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ResetSnapshotAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.ResetSnapshotAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) RestoreAddressToClassicRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreAddressToClassicRequest", arg0)
+func (_mr *_MockEC2APIRecorder) ResetSnapshotAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetSnapshotAttributeWithContext", _s...)
+}
+
+func (_m *MockEC2API) ResetSnapshotAttributeRequest(_param0 *ec2.ResetSnapshotAttributeInput) (*request.Request, *ec2.ResetSnapshotAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "ResetSnapshotAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ResetSnapshotAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) ResetSnapshotAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetSnapshotAttributeRequest", arg0)
 }
 
 func (_m *MockEC2API) RestoreAddressToClassic(_param0 *ec2.RestoreAddressToClassicInput) (*ec2.RestoreAddressToClassicOutput, error) {
@@ -4914,15 +8525,31 @@ func (_mr *_MockEC2APIRecorder) RestoreAddressToClassic(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreAddressToClassic", arg0)
 }
 
-func (_m *MockEC2API) RevokeSecurityGroupEgressRequest(_param0 *ec2.RevokeSecurityGroupEgressInput) (*request.Request, *ec2.RevokeSecurityGroupEgressOutput) {
-	ret := _m.ctrl.Call(_m, "RevokeSecurityGroupEgressRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.RevokeSecurityGroupEgressOutput)
+func (_m *MockEC2API) RestoreAddressToClassicWithContext(_param0 aws.Context, _param1 *ec2.RestoreAddressToClassicInput, _param2 ...request.Option) (*ec2.RestoreAddressToClassicOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RestoreAddressToClassicWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.RestoreAddressToClassicOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) RevokeSecurityGroupEgressRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevokeSecurityGroupEgressRequest", arg0)
+func (_mr *_MockEC2APIRecorder) RestoreAddressToClassicWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreAddressToClassicWithContext", _s...)
+}
+
+func (_m *MockEC2API) RestoreAddressToClassicRequest(_param0 *ec2.RestoreAddressToClassicInput) (*request.Request, *ec2.RestoreAddressToClassicOutput) {
+	ret := _m.ctrl.Call(_m, "RestoreAddressToClassicRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.RestoreAddressToClassicOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) RestoreAddressToClassicRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreAddressToClassicRequest", arg0)
 }
 
 func (_m *MockEC2API) RevokeSecurityGroupEgress(_param0 *ec2.RevokeSecurityGroupEgressInput) (*ec2.RevokeSecurityGroupEgressOutput, error) {
@@ -4936,15 +8563,31 @@ func (_mr *_MockEC2APIRecorder) RevokeSecurityGroupEgress(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevokeSecurityGroupEgress", arg0)
 }
 
-func (_m *MockEC2API) RevokeSecurityGroupIngressRequest(_param0 *ec2.RevokeSecurityGroupIngressInput) (*request.Request, *ec2.RevokeSecurityGroupIngressOutput) {
-	ret := _m.ctrl.Call(_m, "RevokeSecurityGroupIngressRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.RevokeSecurityGroupIngressOutput)
+func (_m *MockEC2API) RevokeSecurityGroupEgressWithContext(_param0 aws.Context, _param1 *ec2.RevokeSecurityGroupEgressInput, _param2 ...request.Option) (*ec2.RevokeSecurityGroupEgressOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RevokeSecurityGroupEgressWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.RevokeSecurityGroupEgressOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) RevokeSecurityGroupIngressRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevokeSecurityGroupIngressRequest", arg0)
+func (_mr *_MockEC2APIRecorder) RevokeSecurityGroupEgressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevokeSecurityGroupEgressWithContext", _s...)
+}
+
+func (_m *MockEC2API) RevokeSecurityGroupEgressRequest(_param0 *ec2.RevokeSecurityGroupEgressInput) (*request.Request, *ec2.RevokeSecurityGroupEgressOutput) {
+	ret := _m.ctrl.Call(_m, "RevokeSecurityGroupEgressRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.RevokeSecurityGroupEgressOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) RevokeSecurityGroupEgressRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevokeSecurityGroupEgressRequest", arg0)
 }
 
 func (_m *MockEC2API) RevokeSecurityGroupIngress(_param0 *ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error) {
@@ -4958,15 +8601,31 @@ func (_mr *_MockEC2APIRecorder) RevokeSecurityGroupIngress(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevokeSecurityGroupIngress", arg0)
 }
 
-func (_m *MockEC2API) RunInstancesRequest(_param0 *ec2.RunInstancesInput) (*request.Request, *ec2.Reservation) {
-	ret := _m.ctrl.Call(_m, "RunInstancesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.Reservation)
+func (_m *MockEC2API) RevokeSecurityGroupIngressWithContext(_param0 aws.Context, _param1 *ec2.RevokeSecurityGroupIngressInput, _param2 ...request.Option) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RevokeSecurityGroupIngressWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.RevokeSecurityGroupIngressOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) RunInstancesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RunInstancesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) RevokeSecurityGroupIngressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevokeSecurityGroupIngressWithContext", _s...)
+}
+
+func (_m *MockEC2API) RevokeSecurityGroupIngressRequest(_param0 *ec2.RevokeSecurityGroupIngressInput) (*request.Request, *ec2.RevokeSecurityGroupIngressOutput) {
+	ret := _m.ctrl.Call(_m, "RevokeSecurityGroupIngressRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.RevokeSecurityGroupIngressOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) RevokeSecurityGroupIngressRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevokeSecurityGroupIngressRequest", arg0)
 }
 
 func (_m *MockEC2API) RunInstances(_param0 *ec2.RunInstancesInput) (*ec2.Reservation, error) {
@@ -4980,15 +8639,31 @@ func (_mr *_MockEC2APIRecorder) RunInstances(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RunInstances", arg0)
 }
 
-func (_m *MockEC2API) RunScheduledInstancesRequest(_param0 *ec2.RunScheduledInstancesInput) (*request.Request, *ec2.RunScheduledInstancesOutput) {
-	ret := _m.ctrl.Call(_m, "RunScheduledInstancesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.RunScheduledInstancesOutput)
+func (_m *MockEC2API) RunInstancesWithContext(_param0 aws.Context, _param1 *ec2.RunInstancesInput, _param2 ...request.Option) (*ec2.Reservation, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RunInstancesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.Reservation)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) RunScheduledInstancesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RunScheduledInstancesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) RunInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RunInstancesWithContext", _s...)
+}
+
+func (_m *MockEC2API) RunInstancesRequest(_param0 *ec2.RunInstancesInput) (*request.Request, *ec2.Reservation) {
+	ret := _m.ctrl.Call(_m, "RunInstancesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.Reservation)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) RunInstancesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RunInstancesRequest", arg0)
 }
 
 func (_m *MockEC2API) RunScheduledInstances(_param0 *ec2.RunScheduledInstancesInput) (*ec2.RunScheduledInstancesOutput, error) {
@@ -5002,15 +8677,31 @@ func (_mr *_MockEC2APIRecorder) RunScheduledInstances(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RunScheduledInstances", arg0)
 }
 
-func (_m *MockEC2API) StartInstancesRequest(_param0 *ec2.StartInstancesInput) (*request.Request, *ec2.StartInstancesOutput) {
-	ret := _m.ctrl.Call(_m, "StartInstancesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.StartInstancesOutput)
+func (_m *MockEC2API) RunScheduledInstancesWithContext(_param0 aws.Context, _param1 *ec2.RunScheduledInstancesInput, _param2 ...request.Option) (*ec2.RunScheduledInstancesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RunScheduledInstancesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.RunScheduledInstancesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) StartInstancesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartInstancesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) RunScheduledInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RunScheduledInstancesWithContext", _s...)
+}
+
+func (_m *MockEC2API) RunScheduledInstancesRequest(_param0 *ec2.RunScheduledInstancesInput) (*request.Request, *ec2.RunScheduledInstancesOutput) {
+	ret := _m.ctrl.Call(_m, "RunScheduledInstancesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.RunScheduledInstancesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) RunScheduledInstancesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RunScheduledInstancesRequest", arg0)
 }
 
 func (_m *MockEC2API) StartInstances(_param0 *ec2.StartInstancesInput) (*ec2.StartInstancesOutput, error) {
@@ -5024,15 +8715,31 @@ func (_mr *_MockEC2APIRecorder) StartInstances(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartInstances", arg0)
 }
 
-func (_m *MockEC2API) StopInstancesRequest(_param0 *ec2.StopInstancesInput) (*request.Request, *ec2.StopInstancesOutput) {
-	ret := _m.ctrl.Call(_m, "StopInstancesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.StopInstancesOutput)
+func (_m *MockEC2API) StartInstancesWithContext(_param0 aws.Context, _param1 *ec2.StartInstancesInput, _param2 ...request.Option) (*ec2.StartInstancesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "StartInstancesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.StartInstancesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) StopInstancesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "StopInstancesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) StartInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartInstancesWithContext", _s...)
+}
+
+func (_m *MockEC2API) StartInstancesRequest(_param0 *ec2.StartInstancesInput) (*request.Request, *ec2.StartInstancesOutput) {
+	ret := _m.ctrl.Call(_m, "StartInstancesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.StartInstancesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) StartInstancesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartInstancesRequest", arg0)
 }
 
 func (_m *MockEC2API) StopInstances(_param0 *ec2.StopInstancesInput) (*ec2.StopInstancesOutput, error) {
@@ -5046,15 +8753,31 @@ func (_mr *_MockEC2APIRecorder) StopInstances(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "StopInstances", arg0)
 }
 
-func (_m *MockEC2API) TerminateInstancesRequest(_param0 *ec2.TerminateInstancesInput) (*request.Request, *ec2.TerminateInstancesOutput) {
-	ret := _m.ctrl.Call(_m, "TerminateInstancesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.TerminateInstancesOutput)
+func (_m *MockEC2API) StopInstancesWithContext(_param0 aws.Context, _param1 *ec2.StopInstancesInput, _param2 ...request.Option) (*ec2.StopInstancesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "StopInstancesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.StopInstancesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) TerminateInstancesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "TerminateInstancesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) StopInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "StopInstancesWithContext", _s...)
+}
+
+func (_m *MockEC2API) StopInstancesRequest(_param0 *ec2.StopInstancesInput) (*request.Request, *ec2.StopInstancesOutput) {
+	ret := _m.ctrl.Call(_m, "StopInstancesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.StopInstancesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) StopInstancesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "StopInstancesRequest", arg0)
 }
 
 func (_m *MockEC2API) TerminateInstances(_param0 *ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error) {
@@ -5068,15 +8791,31 @@ func (_mr *_MockEC2APIRecorder) TerminateInstances(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TerminateInstances", arg0)
 }
 
-func (_m *MockEC2API) UnassignIpv6AddressesRequest(_param0 *ec2.UnassignIpv6AddressesInput) (*request.Request, *ec2.UnassignIpv6AddressesOutput) {
-	ret := _m.ctrl.Call(_m, "UnassignIpv6AddressesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.UnassignIpv6AddressesOutput)
+func (_m *MockEC2API) TerminateInstancesWithContext(_param0 aws.Context, _param1 *ec2.TerminateInstancesInput, _param2 ...request.Option) (*ec2.TerminateInstancesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "TerminateInstancesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.TerminateInstancesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) UnassignIpv6AddressesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnassignIpv6AddressesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) TerminateInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "TerminateInstancesWithContext", _s...)
+}
+
+func (_m *MockEC2API) TerminateInstancesRequest(_param0 *ec2.TerminateInstancesInput) (*request.Request, *ec2.TerminateInstancesOutput) {
+	ret := _m.ctrl.Call(_m, "TerminateInstancesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.TerminateInstancesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) TerminateInstancesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "TerminateInstancesRequest", arg0)
 }
 
 func (_m *MockEC2API) UnassignIpv6Addresses(_param0 *ec2.UnassignIpv6AddressesInput) (*ec2.UnassignIpv6AddressesOutput, error) {
@@ -5090,15 +8829,31 @@ func (_mr *_MockEC2APIRecorder) UnassignIpv6Addresses(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnassignIpv6Addresses", arg0)
 }
 
-func (_m *MockEC2API) UnassignPrivateIpAddressesRequest(_param0 *ec2.UnassignPrivateIpAddressesInput) (*request.Request, *ec2.UnassignPrivateIpAddressesOutput) {
-	ret := _m.ctrl.Call(_m, "UnassignPrivateIpAddressesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.UnassignPrivateIpAddressesOutput)
+func (_m *MockEC2API) UnassignIpv6AddressesWithContext(_param0 aws.Context, _param1 *ec2.UnassignIpv6AddressesInput, _param2 ...request.Option) (*ec2.UnassignIpv6AddressesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "UnassignIpv6AddressesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.UnassignIpv6AddressesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) UnassignPrivateIpAddressesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnassignPrivateIpAddressesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) UnassignIpv6AddressesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnassignIpv6AddressesWithContext", _s...)
+}
+
+func (_m *MockEC2API) UnassignIpv6AddressesRequest(_param0 *ec2.UnassignIpv6AddressesInput) (*request.Request, *ec2.UnassignIpv6AddressesOutput) {
+	ret := _m.ctrl.Call(_m, "UnassignIpv6AddressesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.UnassignIpv6AddressesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) UnassignIpv6AddressesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnassignIpv6AddressesRequest", arg0)
 }
 
 func (_m *MockEC2API) UnassignPrivateIpAddresses(_param0 *ec2.UnassignPrivateIpAddressesInput) (*ec2.UnassignPrivateIpAddressesOutput, error) {
@@ -5112,15 +8867,31 @@ func (_mr *_MockEC2APIRecorder) UnassignPrivateIpAddresses(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnassignPrivateIpAddresses", arg0)
 }
 
-func (_m *MockEC2API) UnmonitorInstancesRequest(_param0 *ec2.UnmonitorInstancesInput) (*request.Request, *ec2.UnmonitorInstancesOutput) {
-	ret := _m.ctrl.Call(_m, "UnmonitorInstancesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*ec2.UnmonitorInstancesOutput)
+func (_m *MockEC2API) UnassignPrivateIpAddressesWithContext(_param0 aws.Context, _param1 *ec2.UnassignPrivateIpAddressesInput, _param2 ...request.Option) (*ec2.UnassignPrivateIpAddressesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "UnassignPrivateIpAddressesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.UnassignPrivateIpAddressesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockEC2APIRecorder) UnmonitorInstancesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnmonitorInstancesRequest", arg0)
+func (_mr *_MockEC2APIRecorder) UnassignPrivateIpAddressesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnassignPrivateIpAddressesWithContext", _s...)
+}
+
+func (_m *MockEC2API) UnassignPrivateIpAddressesRequest(_param0 *ec2.UnassignPrivateIpAddressesInput) (*request.Request, *ec2.UnassignPrivateIpAddressesOutput) {
+	ret := _m.ctrl.Call(_m, "UnassignPrivateIpAddressesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.UnassignPrivateIpAddressesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) UnassignPrivateIpAddressesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnassignPrivateIpAddressesRequest", arg0)
 }
 
 func (_m *MockEC2API) UnmonitorInstances(_param0 *ec2.UnmonitorInstancesInput) (*ec2.UnmonitorInstancesOutput, error) {
@@ -5134,6 +8905,33 @@ func (_mr *_MockEC2APIRecorder) UnmonitorInstances(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnmonitorInstances", arg0)
 }
 
+func (_m *MockEC2API) UnmonitorInstancesWithContext(_param0 aws.Context, _param1 *ec2.UnmonitorInstancesInput, _param2 ...request.Option) (*ec2.UnmonitorInstancesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "UnmonitorInstancesWithContext", _s...)
+	ret0, _ := ret[0].(*ec2.UnmonitorInstancesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) UnmonitorInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnmonitorInstancesWithContext", _s...)
+}
+
+func (_m *MockEC2API) UnmonitorInstancesRequest(_param0 *ec2.UnmonitorInstancesInput) (*request.Request, *ec2.UnmonitorInstancesOutput) {
+	ret := _m.ctrl.Call(_m, "UnmonitorInstancesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.UnmonitorInstancesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockEC2APIRecorder) UnmonitorInstancesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnmonitorInstancesRequest", arg0)
+}
+
 func (_m *MockEC2API) WaitUntilBundleTaskComplete(_param0 *ec2.DescribeBundleTasksInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilBundleTaskComplete", _param0)
 	ret0, _ := ret[0].(error)
@@ -5142,6 +8940,21 @@ func (_m *MockEC2API) WaitUntilBundleTaskComplete(_param0 *ec2.DescribeBundleTas
 
 func (_mr *_MockEC2APIRecorder) WaitUntilBundleTaskComplete(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilBundleTaskComplete", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilBundleTaskCompleteWithContext(_param0 aws.Context, _param1 *ec2.DescribeBundleTasksInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilBundleTaskCompleteWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilBundleTaskCompleteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilBundleTaskCompleteWithContext", _s...)
 }
 
 func (_m *MockEC2API) WaitUntilConversionTaskCancelled(_param0 *ec2.DescribeConversionTasksInput) error {
@@ -5154,6 +8967,21 @@ func (_mr *_MockEC2APIRecorder) WaitUntilConversionTaskCancelled(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilConversionTaskCancelled", arg0)
 }
 
+func (_m *MockEC2API) WaitUntilConversionTaskCancelledWithContext(_param0 aws.Context, _param1 *ec2.DescribeConversionTasksInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilConversionTaskCancelledWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilConversionTaskCancelledWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilConversionTaskCancelledWithContext", _s...)
+}
+
 func (_m *MockEC2API) WaitUntilConversionTaskCompleted(_param0 *ec2.DescribeConversionTasksInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilConversionTaskCompleted", _param0)
 	ret0, _ := ret[0].(error)
@@ -5162,6 +8990,21 @@ func (_m *MockEC2API) WaitUntilConversionTaskCompleted(_param0 *ec2.DescribeConv
 
 func (_mr *_MockEC2APIRecorder) WaitUntilConversionTaskCompleted(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilConversionTaskCompleted", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilConversionTaskCompletedWithContext(_param0 aws.Context, _param1 *ec2.DescribeConversionTasksInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilConversionTaskCompletedWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilConversionTaskCompletedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilConversionTaskCompletedWithContext", _s...)
 }
 
 func (_m *MockEC2API) WaitUntilConversionTaskDeleted(_param0 *ec2.DescribeConversionTasksInput) error {
@@ -5174,6 +9017,21 @@ func (_mr *_MockEC2APIRecorder) WaitUntilConversionTaskDeleted(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilConversionTaskDeleted", arg0)
 }
 
+func (_m *MockEC2API) WaitUntilConversionTaskDeletedWithContext(_param0 aws.Context, _param1 *ec2.DescribeConversionTasksInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilConversionTaskDeletedWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilConversionTaskDeletedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilConversionTaskDeletedWithContext", _s...)
+}
+
 func (_m *MockEC2API) WaitUntilCustomerGatewayAvailable(_param0 *ec2.DescribeCustomerGatewaysInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilCustomerGatewayAvailable", _param0)
 	ret0, _ := ret[0].(error)
@@ -5182,6 +9040,21 @@ func (_m *MockEC2API) WaitUntilCustomerGatewayAvailable(_param0 *ec2.DescribeCus
 
 func (_mr *_MockEC2APIRecorder) WaitUntilCustomerGatewayAvailable(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilCustomerGatewayAvailable", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilCustomerGatewayAvailableWithContext(_param0 aws.Context, _param1 *ec2.DescribeCustomerGatewaysInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilCustomerGatewayAvailableWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilCustomerGatewayAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilCustomerGatewayAvailableWithContext", _s...)
 }
 
 func (_m *MockEC2API) WaitUntilExportTaskCancelled(_param0 *ec2.DescribeExportTasksInput) error {
@@ -5194,6 +9067,21 @@ func (_mr *_MockEC2APIRecorder) WaitUntilExportTaskCancelled(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilExportTaskCancelled", arg0)
 }
 
+func (_m *MockEC2API) WaitUntilExportTaskCancelledWithContext(_param0 aws.Context, _param1 *ec2.DescribeExportTasksInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilExportTaskCancelledWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilExportTaskCancelledWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilExportTaskCancelledWithContext", _s...)
+}
+
 func (_m *MockEC2API) WaitUntilExportTaskCompleted(_param0 *ec2.DescribeExportTasksInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilExportTaskCompleted", _param0)
 	ret0, _ := ret[0].(error)
@@ -5202,6 +9090,21 @@ func (_m *MockEC2API) WaitUntilExportTaskCompleted(_param0 *ec2.DescribeExportTa
 
 func (_mr *_MockEC2APIRecorder) WaitUntilExportTaskCompleted(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilExportTaskCompleted", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilExportTaskCompletedWithContext(_param0 aws.Context, _param1 *ec2.DescribeExportTasksInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilExportTaskCompletedWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilExportTaskCompletedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilExportTaskCompletedWithContext", _s...)
 }
 
 func (_m *MockEC2API) WaitUntilImageAvailable(_param0 *ec2.DescribeImagesInput) error {
@@ -5214,6 +9117,21 @@ func (_mr *_MockEC2APIRecorder) WaitUntilImageAvailable(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilImageAvailable", arg0)
 }
 
+func (_m *MockEC2API) WaitUntilImageAvailableWithContext(_param0 aws.Context, _param1 *ec2.DescribeImagesInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilImageAvailableWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilImageAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilImageAvailableWithContext", _s...)
+}
+
 func (_m *MockEC2API) WaitUntilImageExists(_param0 *ec2.DescribeImagesInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilImageExists", _param0)
 	ret0, _ := ret[0].(error)
@@ -5222,6 +9140,21 @@ func (_m *MockEC2API) WaitUntilImageExists(_param0 *ec2.DescribeImagesInput) err
 
 func (_mr *_MockEC2APIRecorder) WaitUntilImageExists(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilImageExists", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilImageExistsWithContext(_param0 aws.Context, _param1 *ec2.DescribeImagesInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilImageExistsWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilImageExistsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilImageExistsWithContext", _s...)
 }
 
 func (_m *MockEC2API) WaitUntilInstanceExists(_param0 *ec2.DescribeInstancesInput) error {
@@ -5234,6 +9167,21 @@ func (_mr *_MockEC2APIRecorder) WaitUntilInstanceExists(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceExists", arg0)
 }
 
+func (_m *MockEC2API) WaitUntilInstanceExistsWithContext(_param0 aws.Context, _param1 *ec2.DescribeInstancesInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilInstanceExistsWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilInstanceExistsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceExistsWithContext", _s...)
+}
+
 func (_m *MockEC2API) WaitUntilInstanceRunning(_param0 *ec2.DescribeInstancesInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilInstanceRunning", _param0)
 	ret0, _ := ret[0].(error)
@@ -5242,6 +9190,21 @@ func (_m *MockEC2API) WaitUntilInstanceRunning(_param0 *ec2.DescribeInstancesInp
 
 func (_mr *_MockEC2APIRecorder) WaitUntilInstanceRunning(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceRunning", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilInstanceRunningWithContext(_param0 aws.Context, _param1 *ec2.DescribeInstancesInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilInstanceRunningWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilInstanceRunningWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceRunningWithContext", _s...)
 }
 
 func (_m *MockEC2API) WaitUntilInstanceStatusOk(_param0 *ec2.DescribeInstanceStatusInput) error {
@@ -5254,6 +9217,21 @@ func (_mr *_MockEC2APIRecorder) WaitUntilInstanceStatusOk(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceStatusOk", arg0)
 }
 
+func (_m *MockEC2API) WaitUntilInstanceStatusOkWithContext(_param0 aws.Context, _param1 *ec2.DescribeInstanceStatusInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilInstanceStatusOkWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilInstanceStatusOkWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceStatusOkWithContext", _s...)
+}
+
 func (_m *MockEC2API) WaitUntilInstanceStopped(_param0 *ec2.DescribeInstancesInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilInstanceStopped", _param0)
 	ret0, _ := ret[0].(error)
@@ -5262,6 +9240,21 @@ func (_m *MockEC2API) WaitUntilInstanceStopped(_param0 *ec2.DescribeInstancesInp
 
 func (_mr *_MockEC2APIRecorder) WaitUntilInstanceStopped(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceStopped", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilInstanceStoppedWithContext(_param0 aws.Context, _param1 *ec2.DescribeInstancesInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilInstanceStoppedWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilInstanceStoppedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceStoppedWithContext", _s...)
 }
 
 func (_m *MockEC2API) WaitUntilInstanceTerminated(_param0 *ec2.DescribeInstancesInput) error {
@@ -5274,6 +9267,21 @@ func (_mr *_MockEC2APIRecorder) WaitUntilInstanceTerminated(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceTerminated", arg0)
 }
 
+func (_m *MockEC2API) WaitUntilInstanceTerminatedWithContext(_param0 aws.Context, _param1 *ec2.DescribeInstancesInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilInstanceTerminatedWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilInstanceTerminatedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceTerminatedWithContext", _s...)
+}
+
 func (_m *MockEC2API) WaitUntilKeyPairExists(_param0 *ec2.DescribeKeyPairsInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilKeyPairExists", _param0)
 	ret0, _ := ret[0].(error)
@@ -5282,6 +9290,21 @@ func (_m *MockEC2API) WaitUntilKeyPairExists(_param0 *ec2.DescribeKeyPairsInput)
 
 func (_mr *_MockEC2APIRecorder) WaitUntilKeyPairExists(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilKeyPairExists", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilKeyPairExistsWithContext(_param0 aws.Context, _param1 *ec2.DescribeKeyPairsInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilKeyPairExistsWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilKeyPairExistsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilKeyPairExistsWithContext", _s...)
 }
 
 func (_m *MockEC2API) WaitUntilNatGatewayAvailable(_param0 *ec2.DescribeNatGatewaysInput) error {
@@ -5294,6 +9317,21 @@ func (_mr *_MockEC2APIRecorder) WaitUntilNatGatewayAvailable(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilNatGatewayAvailable", arg0)
 }
 
+func (_m *MockEC2API) WaitUntilNatGatewayAvailableWithContext(_param0 aws.Context, _param1 *ec2.DescribeNatGatewaysInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilNatGatewayAvailableWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilNatGatewayAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilNatGatewayAvailableWithContext", _s...)
+}
+
 func (_m *MockEC2API) WaitUntilNetworkInterfaceAvailable(_param0 *ec2.DescribeNetworkInterfacesInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilNetworkInterfaceAvailable", _param0)
 	ret0, _ := ret[0].(error)
@@ -5302,6 +9340,21 @@ func (_m *MockEC2API) WaitUntilNetworkInterfaceAvailable(_param0 *ec2.DescribeNe
 
 func (_mr *_MockEC2APIRecorder) WaitUntilNetworkInterfaceAvailable(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilNetworkInterfaceAvailable", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilNetworkInterfaceAvailableWithContext(_param0 aws.Context, _param1 *ec2.DescribeNetworkInterfacesInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilNetworkInterfaceAvailableWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilNetworkInterfaceAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilNetworkInterfaceAvailableWithContext", _s...)
 }
 
 func (_m *MockEC2API) WaitUntilPasswordDataAvailable(_param0 *ec2.GetPasswordDataInput) error {
@@ -5314,6 +9367,21 @@ func (_mr *_MockEC2APIRecorder) WaitUntilPasswordDataAvailable(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilPasswordDataAvailable", arg0)
 }
 
+func (_m *MockEC2API) WaitUntilPasswordDataAvailableWithContext(_param0 aws.Context, _param1 *ec2.GetPasswordDataInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilPasswordDataAvailableWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilPasswordDataAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilPasswordDataAvailableWithContext", _s...)
+}
+
 func (_m *MockEC2API) WaitUntilSnapshotCompleted(_param0 *ec2.DescribeSnapshotsInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilSnapshotCompleted", _param0)
 	ret0, _ := ret[0].(error)
@@ -5322,6 +9390,21 @@ func (_m *MockEC2API) WaitUntilSnapshotCompleted(_param0 *ec2.DescribeSnapshotsI
 
 func (_mr *_MockEC2APIRecorder) WaitUntilSnapshotCompleted(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilSnapshotCompleted", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilSnapshotCompletedWithContext(_param0 aws.Context, _param1 *ec2.DescribeSnapshotsInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilSnapshotCompletedWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilSnapshotCompletedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilSnapshotCompletedWithContext", _s...)
 }
 
 func (_m *MockEC2API) WaitUntilSpotInstanceRequestFulfilled(_param0 *ec2.DescribeSpotInstanceRequestsInput) error {
@@ -5334,6 +9417,21 @@ func (_mr *_MockEC2APIRecorder) WaitUntilSpotInstanceRequestFulfilled(arg0 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilSpotInstanceRequestFulfilled", arg0)
 }
 
+func (_m *MockEC2API) WaitUntilSpotInstanceRequestFulfilledWithContext(_param0 aws.Context, _param1 *ec2.DescribeSpotInstanceRequestsInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilSpotInstanceRequestFulfilledWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilSpotInstanceRequestFulfilledWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilSpotInstanceRequestFulfilledWithContext", _s...)
+}
+
 func (_m *MockEC2API) WaitUntilSubnetAvailable(_param0 *ec2.DescribeSubnetsInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilSubnetAvailable", _param0)
 	ret0, _ := ret[0].(error)
@@ -5342,6 +9440,21 @@ func (_m *MockEC2API) WaitUntilSubnetAvailable(_param0 *ec2.DescribeSubnetsInput
 
 func (_mr *_MockEC2APIRecorder) WaitUntilSubnetAvailable(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilSubnetAvailable", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilSubnetAvailableWithContext(_param0 aws.Context, _param1 *ec2.DescribeSubnetsInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilSubnetAvailableWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilSubnetAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilSubnetAvailableWithContext", _s...)
 }
 
 func (_m *MockEC2API) WaitUntilSystemStatusOk(_param0 *ec2.DescribeInstanceStatusInput) error {
@@ -5354,6 +9467,21 @@ func (_mr *_MockEC2APIRecorder) WaitUntilSystemStatusOk(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilSystemStatusOk", arg0)
 }
 
+func (_m *MockEC2API) WaitUntilSystemStatusOkWithContext(_param0 aws.Context, _param1 *ec2.DescribeInstanceStatusInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilSystemStatusOkWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilSystemStatusOkWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilSystemStatusOkWithContext", _s...)
+}
+
 func (_m *MockEC2API) WaitUntilVolumeAvailable(_param0 *ec2.DescribeVolumesInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilVolumeAvailable", _param0)
 	ret0, _ := ret[0].(error)
@@ -5362,6 +9490,21 @@ func (_m *MockEC2API) WaitUntilVolumeAvailable(_param0 *ec2.DescribeVolumesInput
 
 func (_mr *_MockEC2APIRecorder) WaitUntilVolumeAvailable(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVolumeAvailable", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilVolumeAvailableWithContext(_param0 aws.Context, _param1 *ec2.DescribeVolumesInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilVolumeAvailableWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilVolumeAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVolumeAvailableWithContext", _s...)
 }
 
 func (_m *MockEC2API) WaitUntilVolumeDeleted(_param0 *ec2.DescribeVolumesInput) error {
@@ -5374,6 +9517,21 @@ func (_mr *_MockEC2APIRecorder) WaitUntilVolumeDeleted(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVolumeDeleted", arg0)
 }
 
+func (_m *MockEC2API) WaitUntilVolumeDeletedWithContext(_param0 aws.Context, _param1 *ec2.DescribeVolumesInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilVolumeDeletedWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilVolumeDeletedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVolumeDeletedWithContext", _s...)
+}
+
 func (_m *MockEC2API) WaitUntilVolumeInUse(_param0 *ec2.DescribeVolumesInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilVolumeInUse", _param0)
 	ret0, _ := ret[0].(error)
@@ -5382,6 +9540,21 @@ func (_m *MockEC2API) WaitUntilVolumeInUse(_param0 *ec2.DescribeVolumesInput) er
 
 func (_mr *_MockEC2APIRecorder) WaitUntilVolumeInUse(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVolumeInUse", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilVolumeInUseWithContext(_param0 aws.Context, _param1 *ec2.DescribeVolumesInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilVolumeInUseWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilVolumeInUseWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVolumeInUseWithContext", _s...)
 }
 
 func (_m *MockEC2API) WaitUntilVpcAvailable(_param0 *ec2.DescribeVpcsInput) error {
@@ -5394,6 +9567,21 @@ func (_mr *_MockEC2APIRecorder) WaitUntilVpcAvailable(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVpcAvailable", arg0)
 }
 
+func (_m *MockEC2API) WaitUntilVpcAvailableWithContext(_param0 aws.Context, _param1 *ec2.DescribeVpcsInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilVpcAvailableWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilVpcAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVpcAvailableWithContext", _s...)
+}
+
 func (_m *MockEC2API) WaitUntilVpcExists(_param0 *ec2.DescribeVpcsInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilVpcExists", _param0)
 	ret0, _ := ret[0].(error)
@@ -5402,6 +9590,21 @@ func (_m *MockEC2API) WaitUntilVpcExists(_param0 *ec2.DescribeVpcsInput) error {
 
 func (_mr *_MockEC2APIRecorder) WaitUntilVpcExists(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVpcExists", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilVpcExistsWithContext(_param0 aws.Context, _param1 *ec2.DescribeVpcsInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilVpcExistsWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilVpcExistsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVpcExistsWithContext", _s...)
 }
 
 func (_m *MockEC2API) WaitUntilVpcPeeringConnectionDeleted(_param0 *ec2.DescribeVpcPeeringConnectionsInput) error {
@@ -5414,6 +9617,21 @@ func (_mr *_MockEC2APIRecorder) WaitUntilVpcPeeringConnectionDeleted(arg0 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVpcPeeringConnectionDeleted", arg0)
 }
 
+func (_m *MockEC2API) WaitUntilVpcPeeringConnectionDeletedWithContext(_param0 aws.Context, _param1 *ec2.DescribeVpcPeeringConnectionsInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilVpcPeeringConnectionDeletedWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilVpcPeeringConnectionDeletedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVpcPeeringConnectionDeletedWithContext", _s...)
+}
+
 func (_m *MockEC2API) WaitUntilVpcPeeringConnectionExists(_param0 *ec2.DescribeVpcPeeringConnectionsInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilVpcPeeringConnectionExists", _param0)
 	ret0, _ := ret[0].(error)
@@ -5422,6 +9640,21 @@ func (_m *MockEC2API) WaitUntilVpcPeeringConnectionExists(_param0 *ec2.DescribeV
 
 func (_mr *_MockEC2APIRecorder) WaitUntilVpcPeeringConnectionExists(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVpcPeeringConnectionExists", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilVpcPeeringConnectionExistsWithContext(_param0 aws.Context, _param1 *ec2.DescribeVpcPeeringConnectionsInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilVpcPeeringConnectionExistsWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilVpcPeeringConnectionExistsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVpcPeeringConnectionExistsWithContext", _s...)
 }
 
 func (_m *MockEC2API) WaitUntilVpnConnectionAvailable(_param0 *ec2.DescribeVpnConnectionsInput) error {
@@ -5434,6 +9667,21 @@ func (_mr *_MockEC2APIRecorder) WaitUntilVpnConnectionAvailable(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVpnConnectionAvailable", arg0)
 }
 
+func (_m *MockEC2API) WaitUntilVpnConnectionAvailableWithContext(_param0 aws.Context, _param1 *ec2.DescribeVpnConnectionsInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilVpnConnectionAvailableWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilVpnConnectionAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVpnConnectionAvailableWithContext", _s...)
+}
+
 func (_m *MockEC2API) WaitUntilVpnConnectionDeleted(_param0 *ec2.DescribeVpnConnectionsInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilVpnConnectionDeleted", _param0)
 	ret0, _ := ret[0].(error)
@@ -5442,4 +9690,19 @@ func (_m *MockEC2API) WaitUntilVpnConnectionDeleted(_param0 *ec2.DescribeVpnConn
 
 func (_mr *_MockEC2APIRecorder) WaitUntilVpnConnectionDeleted(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVpnConnectionDeleted", arg0)
+}
+
+func (_m *MockEC2API) WaitUntilVpnConnectionDeletedWithContext(_param0 aws.Context, _param1 *ec2.DescribeVpnConnectionsInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilVpnConnectionDeletedWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockEC2APIRecorder) WaitUntilVpnConnectionDeletedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilVpnConnectionDeletedWithContext", _s...)
 }

--- a/mock/elasticachemock.go
+++ b/mock/elasticachemock.go
@@ -4,6 +4,7 @@
 package mock
 
 import (
+	aws "github.com/aws/aws-sdk-go/aws"
 	request "github.com/aws/aws-sdk-go/aws/request"
 	elasticache "github.com/aws/aws-sdk-go/service/elasticache"
 	gomock "github.com/golang/mock/gomock"
@@ -30,17 +31,6 @@ func (_m *MockElastiCacheAPI) EXPECT() *_MockElastiCacheAPIRecorder {
 	return _m.recorder
 }
 
-func (_m *MockElastiCacheAPI) AddTagsToResourceRequest(_param0 *elasticache.AddTagsToResourceInput) (*request.Request, *elasticache.TagListMessage) {
-	ret := _m.ctrl.Call(_m, "AddTagsToResourceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.TagListMessage)
-	return ret0, ret1
-}
-
-func (_mr *_MockElastiCacheAPIRecorder) AddTagsToResourceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddTagsToResourceRequest", arg0)
-}
-
 func (_m *MockElastiCacheAPI) AddTagsToResource(_param0 *elasticache.AddTagsToResourceInput) (*elasticache.TagListMessage, error) {
 	ret := _m.ctrl.Call(_m, "AddTagsToResource", _param0)
 	ret0, _ := ret[0].(*elasticache.TagListMessage)
@@ -52,15 +42,31 @@ func (_mr *_MockElastiCacheAPIRecorder) AddTagsToResource(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddTagsToResource", arg0)
 }
 
-func (_m *MockElastiCacheAPI) AuthorizeCacheSecurityGroupIngressRequest(_param0 *elasticache.AuthorizeCacheSecurityGroupIngressInput) (*request.Request, *elasticache.AuthorizeCacheSecurityGroupIngressOutput) {
-	ret := _m.ctrl.Call(_m, "AuthorizeCacheSecurityGroupIngressRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.AuthorizeCacheSecurityGroupIngressOutput)
+func (_m *MockElastiCacheAPI) AddTagsToResourceWithContext(_param0 aws.Context, _param1 *elasticache.AddTagsToResourceInput, _param2 ...request.Option) (*elasticache.TagListMessage, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AddTagsToResourceWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.TagListMessage)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) AuthorizeCacheSecurityGroupIngressRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AuthorizeCacheSecurityGroupIngressRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) AddTagsToResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddTagsToResourceWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) AddTagsToResourceRequest(_param0 *elasticache.AddTagsToResourceInput) (*request.Request, *elasticache.TagListMessage) {
+	ret := _m.ctrl.Call(_m, "AddTagsToResourceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.TagListMessage)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) AddTagsToResourceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddTagsToResourceRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) AuthorizeCacheSecurityGroupIngress(_param0 *elasticache.AuthorizeCacheSecurityGroupIngressInput) (*elasticache.AuthorizeCacheSecurityGroupIngressOutput, error) {
@@ -74,15 +80,31 @@ func (_mr *_MockElastiCacheAPIRecorder) AuthorizeCacheSecurityGroupIngress(arg0 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AuthorizeCacheSecurityGroupIngress", arg0)
 }
 
-func (_m *MockElastiCacheAPI) CopySnapshotRequest(_param0 *elasticache.CopySnapshotInput) (*request.Request, *elasticache.CopySnapshotOutput) {
-	ret := _m.ctrl.Call(_m, "CopySnapshotRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.CopySnapshotOutput)
+func (_m *MockElastiCacheAPI) AuthorizeCacheSecurityGroupIngressWithContext(_param0 aws.Context, _param1 *elasticache.AuthorizeCacheSecurityGroupIngressInput, _param2 ...request.Option) (*elasticache.AuthorizeCacheSecurityGroupIngressOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AuthorizeCacheSecurityGroupIngressWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.AuthorizeCacheSecurityGroupIngressOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) CopySnapshotRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopySnapshotRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) AuthorizeCacheSecurityGroupIngressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AuthorizeCacheSecurityGroupIngressWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) AuthorizeCacheSecurityGroupIngressRequest(_param0 *elasticache.AuthorizeCacheSecurityGroupIngressInput) (*request.Request, *elasticache.AuthorizeCacheSecurityGroupIngressOutput) {
+	ret := _m.ctrl.Call(_m, "AuthorizeCacheSecurityGroupIngressRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.AuthorizeCacheSecurityGroupIngressOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) AuthorizeCacheSecurityGroupIngressRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AuthorizeCacheSecurityGroupIngressRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) CopySnapshot(_param0 *elasticache.CopySnapshotInput) (*elasticache.CopySnapshotOutput, error) {
@@ -96,15 +118,31 @@ func (_mr *_MockElastiCacheAPIRecorder) CopySnapshot(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopySnapshot", arg0)
 }
 
-func (_m *MockElastiCacheAPI) CreateCacheClusterRequest(_param0 *elasticache.CreateCacheClusterInput) (*request.Request, *elasticache.CreateCacheClusterOutput) {
-	ret := _m.ctrl.Call(_m, "CreateCacheClusterRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.CreateCacheClusterOutput)
+func (_m *MockElastiCacheAPI) CopySnapshotWithContext(_param0 aws.Context, _param1 *elasticache.CopySnapshotInput, _param2 ...request.Option) (*elasticache.CopySnapshotOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CopySnapshotWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.CopySnapshotOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) CreateCacheClusterRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCacheClusterRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) CopySnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopySnapshotWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) CopySnapshotRequest(_param0 *elasticache.CopySnapshotInput) (*request.Request, *elasticache.CopySnapshotOutput) {
+	ret := _m.ctrl.Call(_m, "CopySnapshotRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.CopySnapshotOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) CopySnapshotRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopySnapshotRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) CreateCacheCluster(_param0 *elasticache.CreateCacheClusterInput) (*elasticache.CreateCacheClusterOutput, error) {
@@ -118,15 +156,31 @@ func (_mr *_MockElastiCacheAPIRecorder) CreateCacheCluster(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCacheCluster", arg0)
 }
 
-func (_m *MockElastiCacheAPI) CreateCacheParameterGroupRequest(_param0 *elasticache.CreateCacheParameterGroupInput) (*request.Request, *elasticache.CreateCacheParameterGroupOutput) {
-	ret := _m.ctrl.Call(_m, "CreateCacheParameterGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.CreateCacheParameterGroupOutput)
+func (_m *MockElastiCacheAPI) CreateCacheClusterWithContext(_param0 aws.Context, _param1 *elasticache.CreateCacheClusterInput, _param2 ...request.Option) (*elasticache.CreateCacheClusterOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateCacheClusterWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.CreateCacheClusterOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) CreateCacheParameterGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCacheParameterGroupRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) CreateCacheClusterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCacheClusterWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) CreateCacheClusterRequest(_param0 *elasticache.CreateCacheClusterInput) (*request.Request, *elasticache.CreateCacheClusterOutput) {
+	ret := _m.ctrl.Call(_m, "CreateCacheClusterRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.CreateCacheClusterOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) CreateCacheClusterRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCacheClusterRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) CreateCacheParameterGroup(_param0 *elasticache.CreateCacheParameterGroupInput) (*elasticache.CreateCacheParameterGroupOutput, error) {
@@ -140,15 +194,31 @@ func (_mr *_MockElastiCacheAPIRecorder) CreateCacheParameterGroup(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCacheParameterGroup", arg0)
 }
 
-func (_m *MockElastiCacheAPI) CreateCacheSecurityGroupRequest(_param0 *elasticache.CreateCacheSecurityGroupInput) (*request.Request, *elasticache.CreateCacheSecurityGroupOutput) {
-	ret := _m.ctrl.Call(_m, "CreateCacheSecurityGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.CreateCacheSecurityGroupOutput)
+func (_m *MockElastiCacheAPI) CreateCacheParameterGroupWithContext(_param0 aws.Context, _param1 *elasticache.CreateCacheParameterGroupInput, _param2 ...request.Option) (*elasticache.CreateCacheParameterGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateCacheParameterGroupWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.CreateCacheParameterGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) CreateCacheSecurityGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCacheSecurityGroupRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) CreateCacheParameterGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCacheParameterGroupWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) CreateCacheParameterGroupRequest(_param0 *elasticache.CreateCacheParameterGroupInput) (*request.Request, *elasticache.CreateCacheParameterGroupOutput) {
+	ret := _m.ctrl.Call(_m, "CreateCacheParameterGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.CreateCacheParameterGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) CreateCacheParameterGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCacheParameterGroupRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) CreateCacheSecurityGroup(_param0 *elasticache.CreateCacheSecurityGroupInput) (*elasticache.CreateCacheSecurityGroupOutput, error) {
@@ -162,15 +232,31 @@ func (_mr *_MockElastiCacheAPIRecorder) CreateCacheSecurityGroup(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCacheSecurityGroup", arg0)
 }
 
-func (_m *MockElastiCacheAPI) CreateCacheSubnetGroupRequest(_param0 *elasticache.CreateCacheSubnetGroupInput) (*request.Request, *elasticache.CreateCacheSubnetGroupOutput) {
-	ret := _m.ctrl.Call(_m, "CreateCacheSubnetGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.CreateCacheSubnetGroupOutput)
+func (_m *MockElastiCacheAPI) CreateCacheSecurityGroupWithContext(_param0 aws.Context, _param1 *elasticache.CreateCacheSecurityGroupInput, _param2 ...request.Option) (*elasticache.CreateCacheSecurityGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateCacheSecurityGroupWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.CreateCacheSecurityGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) CreateCacheSubnetGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCacheSubnetGroupRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) CreateCacheSecurityGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCacheSecurityGroupWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) CreateCacheSecurityGroupRequest(_param0 *elasticache.CreateCacheSecurityGroupInput) (*request.Request, *elasticache.CreateCacheSecurityGroupOutput) {
+	ret := _m.ctrl.Call(_m, "CreateCacheSecurityGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.CreateCacheSecurityGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) CreateCacheSecurityGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCacheSecurityGroupRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) CreateCacheSubnetGroup(_param0 *elasticache.CreateCacheSubnetGroupInput) (*elasticache.CreateCacheSubnetGroupOutput, error) {
@@ -184,15 +270,31 @@ func (_mr *_MockElastiCacheAPIRecorder) CreateCacheSubnetGroup(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCacheSubnetGroup", arg0)
 }
 
-func (_m *MockElastiCacheAPI) CreateReplicationGroupRequest(_param0 *elasticache.CreateReplicationGroupInput) (*request.Request, *elasticache.CreateReplicationGroupOutput) {
-	ret := _m.ctrl.Call(_m, "CreateReplicationGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.CreateReplicationGroupOutput)
+func (_m *MockElastiCacheAPI) CreateCacheSubnetGroupWithContext(_param0 aws.Context, _param1 *elasticache.CreateCacheSubnetGroupInput, _param2 ...request.Option) (*elasticache.CreateCacheSubnetGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateCacheSubnetGroupWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.CreateCacheSubnetGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) CreateReplicationGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateReplicationGroupRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) CreateCacheSubnetGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCacheSubnetGroupWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) CreateCacheSubnetGroupRequest(_param0 *elasticache.CreateCacheSubnetGroupInput) (*request.Request, *elasticache.CreateCacheSubnetGroupOutput) {
+	ret := _m.ctrl.Call(_m, "CreateCacheSubnetGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.CreateCacheSubnetGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) CreateCacheSubnetGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCacheSubnetGroupRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) CreateReplicationGroup(_param0 *elasticache.CreateReplicationGroupInput) (*elasticache.CreateReplicationGroupOutput, error) {
@@ -206,15 +308,31 @@ func (_mr *_MockElastiCacheAPIRecorder) CreateReplicationGroup(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateReplicationGroup", arg0)
 }
 
-func (_m *MockElastiCacheAPI) CreateSnapshotRequest(_param0 *elasticache.CreateSnapshotInput) (*request.Request, *elasticache.CreateSnapshotOutput) {
-	ret := _m.ctrl.Call(_m, "CreateSnapshotRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.CreateSnapshotOutput)
+func (_m *MockElastiCacheAPI) CreateReplicationGroupWithContext(_param0 aws.Context, _param1 *elasticache.CreateReplicationGroupInput, _param2 ...request.Option) (*elasticache.CreateReplicationGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateReplicationGroupWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.CreateReplicationGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) CreateSnapshotRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSnapshotRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) CreateReplicationGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateReplicationGroupWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) CreateReplicationGroupRequest(_param0 *elasticache.CreateReplicationGroupInput) (*request.Request, *elasticache.CreateReplicationGroupOutput) {
+	ret := _m.ctrl.Call(_m, "CreateReplicationGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.CreateReplicationGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) CreateReplicationGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateReplicationGroupRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) CreateSnapshot(_param0 *elasticache.CreateSnapshotInput) (*elasticache.CreateSnapshotOutput, error) {
@@ -228,15 +346,31 @@ func (_mr *_MockElastiCacheAPIRecorder) CreateSnapshot(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSnapshot", arg0)
 }
 
-func (_m *MockElastiCacheAPI) DeleteCacheClusterRequest(_param0 *elasticache.DeleteCacheClusterInput) (*request.Request, *elasticache.DeleteCacheClusterOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteCacheClusterRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.DeleteCacheClusterOutput)
+func (_m *MockElastiCacheAPI) CreateSnapshotWithContext(_param0 aws.Context, _param1 *elasticache.CreateSnapshotInput, _param2 ...request.Option) (*elasticache.CreateSnapshotOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateSnapshotWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.CreateSnapshotOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) DeleteCacheClusterRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCacheClusterRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) CreateSnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSnapshotWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) CreateSnapshotRequest(_param0 *elasticache.CreateSnapshotInput) (*request.Request, *elasticache.CreateSnapshotOutput) {
+	ret := _m.ctrl.Call(_m, "CreateSnapshotRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.CreateSnapshotOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) CreateSnapshotRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSnapshotRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) DeleteCacheCluster(_param0 *elasticache.DeleteCacheClusterInput) (*elasticache.DeleteCacheClusterOutput, error) {
@@ -250,15 +384,31 @@ func (_mr *_MockElastiCacheAPIRecorder) DeleteCacheCluster(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCacheCluster", arg0)
 }
 
-func (_m *MockElastiCacheAPI) DeleteCacheParameterGroupRequest(_param0 *elasticache.DeleteCacheParameterGroupInput) (*request.Request, *elasticache.DeleteCacheParameterGroupOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteCacheParameterGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.DeleteCacheParameterGroupOutput)
+func (_m *MockElastiCacheAPI) DeleteCacheClusterWithContext(_param0 aws.Context, _param1 *elasticache.DeleteCacheClusterInput, _param2 ...request.Option) (*elasticache.DeleteCacheClusterOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteCacheClusterWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.DeleteCacheClusterOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) DeleteCacheParameterGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCacheParameterGroupRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) DeleteCacheClusterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCacheClusterWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) DeleteCacheClusterRequest(_param0 *elasticache.DeleteCacheClusterInput) (*request.Request, *elasticache.DeleteCacheClusterOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteCacheClusterRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DeleteCacheClusterOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DeleteCacheClusterRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCacheClusterRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) DeleteCacheParameterGroup(_param0 *elasticache.DeleteCacheParameterGroupInput) (*elasticache.DeleteCacheParameterGroupOutput, error) {
@@ -272,15 +422,31 @@ func (_mr *_MockElastiCacheAPIRecorder) DeleteCacheParameterGroup(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCacheParameterGroup", arg0)
 }
 
-func (_m *MockElastiCacheAPI) DeleteCacheSecurityGroupRequest(_param0 *elasticache.DeleteCacheSecurityGroupInput) (*request.Request, *elasticache.DeleteCacheSecurityGroupOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteCacheSecurityGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.DeleteCacheSecurityGroupOutput)
+func (_m *MockElastiCacheAPI) DeleteCacheParameterGroupWithContext(_param0 aws.Context, _param1 *elasticache.DeleteCacheParameterGroupInput, _param2 ...request.Option) (*elasticache.DeleteCacheParameterGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteCacheParameterGroupWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.DeleteCacheParameterGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) DeleteCacheSecurityGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCacheSecurityGroupRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) DeleteCacheParameterGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCacheParameterGroupWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) DeleteCacheParameterGroupRequest(_param0 *elasticache.DeleteCacheParameterGroupInput) (*request.Request, *elasticache.DeleteCacheParameterGroupOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteCacheParameterGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DeleteCacheParameterGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DeleteCacheParameterGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCacheParameterGroupRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) DeleteCacheSecurityGroup(_param0 *elasticache.DeleteCacheSecurityGroupInput) (*elasticache.DeleteCacheSecurityGroupOutput, error) {
@@ -294,15 +460,31 @@ func (_mr *_MockElastiCacheAPIRecorder) DeleteCacheSecurityGroup(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCacheSecurityGroup", arg0)
 }
 
-func (_m *MockElastiCacheAPI) DeleteCacheSubnetGroupRequest(_param0 *elasticache.DeleteCacheSubnetGroupInput) (*request.Request, *elasticache.DeleteCacheSubnetGroupOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteCacheSubnetGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.DeleteCacheSubnetGroupOutput)
+func (_m *MockElastiCacheAPI) DeleteCacheSecurityGroupWithContext(_param0 aws.Context, _param1 *elasticache.DeleteCacheSecurityGroupInput, _param2 ...request.Option) (*elasticache.DeleteCacheSecurityGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteCacheSecurityGroupWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.DeleteCacheSecurityGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) DeleteCacheSubnetGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCacheSubnetGroupRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) DeleteCacheSecurityGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCacheSecurityGroupWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) DeleteCacheSecurityGroupRequest(_param0 *elasticache.DeleteCacheSecurityGroupInput) (*request.Request, *elasticache.DeleteCacheSecurityGroupOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteCacheSecurityGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DeleteCacheSecurityGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DeleteCacheSecurityGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCacheSecurityGroupRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) DeleteCacheSubnetGroup(_param0 *elasticache.DeleteCacheSubnetGroupInput) (*elasticache.DeleteCacheSubnetGroupOutput, error) {
@@ -316,15 +498,31 @@ func (_mr *_MockElastiCacheAPIRecorder) DeleteCacheSubnetGroup(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCacheSubnetGroup", arg0)
 }
 
-func (_m *MockElastiCacheAPI) DeleteReplicationGroupRequest(_param0 *elasticache.DeleteReplicationGroupInput) (*request.Request, *elasticache.DeleteReplicationGroupOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteReplicationGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.DeleteReplicationGroupOutput)
+func (_m *MockElastiCacheAPI) DeleteCacheSubnetGroupWithContext(_param0 aws.Context, _param1 *elasticache.DeleteCacheSubnetGroupInput, _param2 ...request.Option) (*elasticache.DeleteCacheSubnetGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteCacheSubnetGroupWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.DeleteCacheSubnetGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) DeleteReplicationGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteReplicationGroupRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) DeleteCacheSubnetGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCacheSubnetGroupWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) DeleteCacheSubnetGroupRequest(_param0 *elasticache.DeleteCacheSubnetGroupInput) (*request.Request, *elasticache.DeleteCacheSubnetGroupOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteCacheSubnetGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DeleteCacheSubnetGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DeleteCacheSubnetGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteCacheSubnetGroupRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) DeleteReplicationGroup(_param0 *elasticache.DeleteReplicationGroupInput) (*elasticache.DeleteReplicationGroupOutput, error) {
@@ -338,15 +536,31 @@ func (_mr *_MockElastiCacheAPIRecorder) DeleteReplicationGroup(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteReplicationGroup", arg0)
 }
 
-func (_m *MockElastiCacheAPI) DeleteSnapshotRequest(_param0 *elasticache.DeleteSnapshotInput) (*request.Request, *elasticache.DeleteSnapshotOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteSnapshotRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.DeleteSnapshotOutput)
+func (_m *MockElastiCacheAPI) DeleteReplicationGroupWithContext(_param0 aws.Context, _param1 *elasticache.DeleteReplicationGroupInput, _param2 ...request.Option) (*elasticache.DeleteReplicationGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteReplicationGroupWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.DeleteReplicationGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) DeleteSnapshotRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSnapshotRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) DeleteReplicationGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteReplicationGroupWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) DeleteReplicationGroupRequest(_param0 *elasticache.DeleteReplicationGroupInput) (*request.Request, *elasticache.DeleteReplicationGroupOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteReplicationGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DeleteReplicationGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DeleteReplicationGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteReplicationGroupRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) DeleteSnapshot(_param0 *elasticache.DeleteSnapshotInput) (*elasticache.DeleteSnapshotOutput, error) {
@@ -360,15 +574,31 @@ func (_mr *_MockElastiCacheAPIRecorder) DeleteSnapshot(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSnapshot", arg0)
 }
 
-func (_m *MockElastiCacheAPI) DescribeCacheClustersRequest(_param0 *elasticache.DescribeCacheClustersInput) (*request.Request, *elasticache.DescribeCacheClustersOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeCacheClustersRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.DescribeCacheClustersOutput)
+func (_m *MockElastiCacheAPI) DeleteSnapshotWithContext(_param0 aws.Context, _param1 *elasticache.DeleteSnapshotInput, _param2 ...request.Option) (*elasticache.DeleteSnapshotOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteSnapshotWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.DeleteSnapshotOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheClustersRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheClustersRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) DeleteSnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSnapshotWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) DeleteSnapshotRequest(_param0 *elasticache.DeleteSnapshotInput) (*request.Request, *elasticache.DeleteSnapshotOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteSnapshotRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DeleteSnapshotOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DeleteSnapshotRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSnapshotRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) DescribeCacheClusters(_param0 *elasticache.DescribeCacheClustersInput) (*elasticache.DescribeCacheClustersOutput, error) {
@@ -382,6 +612,33 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheClusters(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheClusters", arg0)
 }
 
+func (_m *MockElastiCacheAPI) DescribeCacheClustersWithContext(_param0 aws.Context, _param1 *elasticache.DescribeCacheClustersInput, _param2 ...request.Option) (*elasticache.DescribeCacheClustersOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeCacheClustersWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.DescribeCacheClustersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheClustersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheClustersWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) DescribeCacheClustersRequest(_param0 *elasticache.DescribeCacheClustersInput) (*request.Request, *elasticache.DescribeCacheClustersOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeCacheClustersRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DescribeCacheClustersOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheClustersRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheClustersRequest", arg0)
+}
+
 func (_m *MockElastiCacheAPI) DescribeCacheClustersPages(_param0 *elasticache.DescribeCacheClustersInput, _param1 func(*elasticache.DescribeCacheClustersOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeCacheClustersPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -392,15 +649,19 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheClustersPages(arg0, arg1 in
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheClustersPages", arg0, arg1)
 }
 
-func (_m *MockElastiCacheAPI) DescribeCacheEngineVersionsRequest(_param0 *elasticache.DescribeCacheEngineVersionsInput) (*request.Request, *elasticache.DescribeCacheEngineVersionsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeCacheEngineVersionsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.DescribeCacheEngineVersionsOutput)
-	return ret0, ret1
+func (_m *MockElastiCacheAPI) DescribeCacheClustersPagesWithContext(_param0 aws.Context, _param1 *elasticache.DescribeCacheClustersInput, _param2 func(*elasticache.DescribeCacheClustersOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeCacheClustersPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheEngineVersionsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheEngineVersionsRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheClustersPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheClustersPagesWithContext", _s...)
 }
 
 func (_m *MockElastiCacheAPI) DescribeCacheEngineVersions(_param0 *elasticache.DescribeCacheEngineVersionsInput) (*elasticache.DescribeCacheEngineVersionsOutput, error) {
@@ -414,6 +675,33 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheEngineVersions(arg0 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheEngineVersions", arg0)
 }
 
+func (_m *MockElastiCacheAPI) DescribeCacheEngineVersionsWithContext(_param0 aws.Context, _param1 *elasticache.DescribeCacheEngineVersionsInput, _param2 ...request.Option) (*elasticache.DescribeCacheEngineVersionsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeCacheEngineVersionsWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.DescribeCacheEngineVersionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheEngineVersionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheEngineVersionsWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) DescribeCacheEngineVersionsRequest(_param0 *elasticache.DescribeCacheEngineVersionsInput) (*request.Request, *elasticache.DescribeCacheEngineVersionsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeCacheEngineVersionsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DescribeCacheEngineVersionsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheEngineVersionsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheEngineVersionsRequest", arg0)
+}
+
 func (_m *MockElastiCacheAPI) DescribeCacheEngineVersionsPages(_param0 *elasticache.DescribeCacheEngineVersionsInput, _param1 func(*elasticache.DescribeCacheEngineVersionsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeCacheEngineVersionsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -424,15 +712,19 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheEngineVersionsPages(arg0, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheEngineVersionsPages", arg0, arg1)
 }
 
-func (_m *MockElastiCacheAPI) DescribeCacheParameterGroupsRequest(_param0 *elasticache.DescribeCacheParameterGroupsInput) (*request.Request, *elasticache.DescribeCacheParameterGroupsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeCacheParameterGroupsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.DescribeCacheParameterGroupsOutput)
-	return ret0, ret1
+func (_m *MockElastiCacheAPI) DescribeCacheEngineVersionsPagesWithContext(_param0 aws.Context, _param1 *elasticache.DescribeCacheEngineVersionsInput, _param2 func(*elasticache.DescribeCacheEngineVersionsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeCacheEngineVersionsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheParameterGroupsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheParameterGroupsRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheEngineVersionsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheEngineVersionsPagesWithContext", _s...)
 }
 
 func (_m *MockElastiCacheAPI) DescribeCacheParameterGroups(_param0 *elasticache.DescribeCacheParameterGroupsInput) (*elasticache.DescribeCacheParameterGroupsOutput, error) {
@@ -446,6 +738,33 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheParameterGroups(arg0 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheParameterGroups", arg0)
 }
 
+func (_m *MockElastiCacheAPI) DescribeCacheParameterGroupsWithContext(_param0 aws.Context, _param1 *elasticache.DescribeCacheParameterGroupsInput, _param2 ...request.Option) (*elasticache.DescribeCacheParameterGroupsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeCacheParameterGroupsWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.DescribeCacheParameterGroupsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheParameterGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheParameterGroupsWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) DescribeCacheParameterGroupsRequest(_param0 *elasticache.DescribeCacheParameterGroupsInput) (*request.Request, *elasticache.DescribeCacheParameterGroupsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeCacheParameterGroupsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DescribeCacheParameterGroupsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheParameterGroupsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheParameterGroupsRequest", arg0)
+}
+
 func (_m *MockElastiCacheAPI) DescribeCacheParameterGroupsPages(_param0 *elasticache.DescribeCacheParameterGroupsInput, _param1 func(*elasticache.DescribeCacheParameterGroupsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeCacheParameterGroupsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -456,15 +775,19 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheParameterGroupsPages(arg0, 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheParameterGroupsPages", arg0, arg1)
 }
 
-func (_m *MockElastiCacheAPI) DescribeCacheParametersRequest(_param0 *elasticache.DescribeCacheParametersInput) (*request.Request, *elasticache.DescribeCacheParametersOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeCacheParametersRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.DescribeCacheParametersOutput)
-	return ret0, ret1
+func (_m *MockElastiCacheAPI) DescribeCacheParameterGroupsPagesWithContext(_param0 aws.Context, _param1 *elasticache.DescribeCacheParameterGroupsInput, _param2 func(*elasticache.DescribeCacheParameterGroupsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeCacheParameterGroupsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheParametersRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheParametersRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheParameterGroupsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheParameterGroupsPagesWithContext", _s...)
 }
 
 func (_m *MockElastiCacheAPI) DescribeCacheParameters(_param0 *elasticache.DescribeCacheParametersInput) (*elasticache.DescribeCacheParametersOutput, error) {
@@ -478,6 +801,33 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheParameters(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheParameters", arg0)
 }
 
+func (_m *MockElastiCacheAPI) DescribeCacheParametersWithContext(_param0 aws.Context, _param1 *elasticache.DescribeCacheParametersInput, _param2 ...request.Option) (*elasticache.DescribeCacheParametersOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeCacheParametersWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.DescribeCacheParametersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheParametersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheParametersWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) DescribeCacheParametersRequest(_param0 *elasticache.DescribeCacheParametersInput) (*request.Request, *elasticache.DescribeCacheParametersOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeCacheParametersRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DescribeCacheParametersOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheParametersRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheParametersRequest", arg0)
+}
+
 func (_m *MockElastiCacheAPI) DescribeCacheParametersPages(_param0 *elasticache.DescribeCacheParametersInput, _param1 func(*elasticache.DescribeCacheParametersOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeCacheParametersPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -488,15 +838,19 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheParametersPages(arg0, arg1 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheParametersPages", arg0, arg1)
 }
 
-func (_m *MockElastiCacheAPI) DescribeCacheSecurityGroupsRequest(_param0 *elasticache.DescribeCacheSecurityGroupsInput) (*request.Request, *elasticache.DescribeCacheSecurityGroupsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeCacheSecurityGroupsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.DescribeCacheSecurityGroupsOutput)
-	return ret0, ret1
+func (_m *MockElastiCacheAPI) DescribeCacheParametersPagesWithContext(_param0 aws.Context, _param1 *elasticache.DescribeCacheParametersInput, _param2 func(*elasticache.DescribeCacheParametersOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeCacheParametersPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheSecurityGroupsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheSecurityGroupsRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheParametersPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheParametersPagesWithContext", _s...)
 }
 
 func (_m *MockElastiCacheAPI) DescribeCacheSecurityGroups(_param0 *elasticache.DescribeCacheSecurityGroupsInput) (*elasticache.DescribeCacheSecurityGroupsOutput, error) {
@@ -510,6 +864,33 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheSecurityGroups(arg0 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheSecurityGroups", arg0)
 }
 
+func (_m *MockElastiCacheAPI) DescribeCacheSecurityGroupsWithContext(_param0 aws.Context, _param1 *elasticache.DescribeCacheSecurityGroupsInput, _param2 ...request.Option) (*elasticache.DescribeCacheSecurityGroupsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeCacheSecurityGroupsWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.DescribeCacheSecurityGroupsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheSecurityGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheSecurityGroupsWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) DescribeCacheSecurityGroupsRequest(_param0 *elasticache.DescribeCacheSecurityGroupsInput) (*request.Request, *elasticache.DescribeCacheSecurityGroupsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeCacheSecurityGroupsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DescribeCacheSecurityGroupsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheSecurityGroupsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheSecurityGroupsRequest", arg0)
+}
+
 func (_m *MockElastiCacheAPI) DescribeCacheSecurityGroupsPages(_param0 *elasticache.DescribeCacheSecurityGroupsInput, _param1 func(*elasticache.DescribeCacheSecurityGroupsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeCacheSecurityGroupsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -520,15 +901,19 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheSecurityGroupsPages(arg0, a
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheSecurityGroupsPages", arg0, arg1)
 }
 
-func (_m *MockElastiCacheAPI) DescribeCacheSubnetGroupsRequest(_param0 *elasticache.DescribeCacheSubnetGroupsInput) (*request.Request, *elasticache.DescribeCacheSubnetGroupsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeCacheSubnetGroupsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.DescribeCacheSubnetGroupsOutput)
-	return ret0, ret1
+func (_m *MockElastiCacheAPI) DescribeCacheSecurityGroupsPagesWithContext(_param0 aws.Context, _param1 *elasticache.DescribeCacheSecurityGroupsInput, _param2 func(*elasticache.DescribeCacheSecurityGroupsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeCacheSecurityGroupsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheSubnetGroupsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheSubnetGroupsRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheSecurityGroupsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheSecurityGroupsPagesWithContext", _s...)
 }
 
 func (_m *MockElastiCacheAPI) DescribeCacheSubnetGroups(_param0 *elasticache.DescribeCacheSubnetGroupsInput) (*elasticache.DescribeCacheSubnetGroupsOutput, error) {
@@ -542,6 +927,33 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheSubnetGroups(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheSubnetGroups", arg0)
 }
 
+func (_m *MockElastiCacheAPI) DescribeCacheSubnetGroupsWithContext(_param0 aws.Context, _param1 *elasticache.DescribeCacheSubnetGroupsInput, _param2 ...request.Option) (*elasticache.DescribeCacheSubnetGroupsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeCacheSubnetGroupsWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.DescribeCacheSubnetGroupsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheSubnetGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheSubnetGroupsWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) DescribeCacheSubnetGroupsRequest(_param0 *elasticache.DescribeCacheSubnetGroupsInput) (*request.Request, *elasticache.DescribeCacheSubnetGroupsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeCacheSubnetGroupsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DescribeCacheSubnetGroupsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheSubnetGroupsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheSubnetGroupsRequest", arg0)
+}
+
 func (_m *MockElastiCacheAPI) DescribeCacheSubnetGroupsPages(_param0 *elasticache.DescribeCacheSubnetGroupsInput, _param1 func(*elasticache.DescribeCacheSubnetGroupsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeCacheSubnetGroupsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -552,15 +964,19 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheSubnetGroupsPages(arg0, arg
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheSubnetGroupsPages", arg0, arg1)
 }
 
-func (_m *MockElastiCacheAPI) DescribeEngineDefaultParametersRequest(_param0 *elasticache.DescribeEngineDefaultParametersInput) (*request.Request, *elasticache.DescribeEngineDefaultParametersOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeEngineDefaultParametersRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.DescribeEngineDefaultParametersOutput)
-	return ret0, ret1
+func (_m *MockElastiCacheAPI) DescribeCacheSubnetGroupsPagesWithContext(_param0 aws.Context, _param1 *elasticache.DescribeCacheSubnetGroupsInput, _param2 func(*elasticache.DescribeCacheSubnetGroupsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeCacheSubnetGroupsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) DescribeEngineDefaultParametersRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEngineDefaultParametersRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) DescribeCacheSubnetGroupsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCacheSubnetGroupsPagesWithContext", _s...)
 }
 
 func (_m *MockElastiCacheAPI) DescribeEngineDefaultParameters(_param0 *elasticache.DescribeEngineDefaultParametersInput) (*elasticache.DescribeEngineDefaultParametersOutput, error) {
@@ -574,6 +990,33 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeEngineDefaultParameters(arg0 int
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEngineDefaultParameters", arg0)
 }
 
+func (_m *MockElastiCacheAPI) DescribeEngineDefaultParametersWithContext(_param0 aws.Context, _param1 *elasticache.DescribeEngineDefaultParametersInput, _param2 ...request.Option) (*elasticache.DescribeEngineDefaultParametersOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeEngineDefaultParametersWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.DescribeEngineDefaultParametersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeEngineDefaultParametersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEngineDefaultParametersWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) DescribeEngineDefaultParametersRequest(_param0 *elasticache.DescribeEngineDefaultParametersInput) (*request.Request, *elasticache.DescribeEngineDefaultParametersOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeEngineDefaultParametersRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DescribeEngineDefaultParametersOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeEngineDefaultParametersRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEngineDefaultParametersRequest", arg0)
+}
+
 func (_m *MockElastiCacheAPI) DescribeEngineDefaultParametersPages(_param0 *elasticache.DescribeEngineDefaultParametersInput, _param1 func(*elasticache.DescribeEngineDefaultParametersOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeEngineDefaultParametersPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -584,15 +1027,19 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeEngineDefaultParametersPages(arg
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEngineDefaultParametersPages", arg0, arg1)
 }
 
-func (_m *MockElastiCacheAPI) DescribeEventsRequest(_param0 *elasticache.DescribeEventsInput) (*request.Request, *elasticache.DescribeEventsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeEventsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.DescribeEventsOutput)
-	return ret0, ret1
+func (_m *MockElastiCacheAPI) DescribeEngineDefaultParametersPagesWithContext(_param0 aws.Context, _param1 *elasticache.DescribeEngineDefaultParametersInput, _param2 func(*elasticache.DescribeEngineDefaultParametersOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeEngineDefaultParametersPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) DescribeEventsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventsRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) DescribeEngineDefaultParametersPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEngineDefaultParametersPagesWithContext", _s...)
 }
 
 func (_m *MockElastiCacheAPI) DescribeEvents(_param0 *elasticache.DescribeEventsInput) (*elasticache.DescribeEventsOutput, error) {
@@ -606,6 +1053,33 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeEvents(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEvents", arg0)
 }
 
+func (_m *MockElastiCacheAPI) DescribeEventsWithContext(_param0 aws.Context, _param1 *elasticache.DescribeEventsInput, _param2 ...request.Option) (*elasticache.DescribeEventsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeEventsWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.DescribeEventsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeEventsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventsWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) DescribeEventsRequest(_param0 *elasticache.DescribeEventsInput) (*request.Request, *elasticache.DescribeEventsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeEventsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DescribeEventsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeEventsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventsRequest", arg0)
+}
+
 func (_m *MockElastiCacheAPI) DescribeEventsPages(_param0 *elasticache.DescribeEventsInput, _param1 func(*elasticache.DescribeEventsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeEventsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -616,15 +1090,19 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeEventsPages(arg0, arg1 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventsPages", arg0, arg1)
 }
 
-func (_m *MockElastiCacheAPI) DescribeReplicationGroupsRequest(_param0 *elasticache.DescribeReplicationGroupsInput) (*request.Request, *elasticache.DescribeReplicationGroupsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeReplicationGroupsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.DescribeReplicationGroupsOutput)
-	return ret0, ret1
+func (_m *MockElastiCacheAPI) DescribeEventsPagesWithContext(_param0 aws.Context, _param1 *elasticache.DescribeEventsInput, _param2 func(*elasticache.DescribeEventsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeEventsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) DescribeReplicationGroupsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReplicationGroupsRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) DescribeEventsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventsPagesWithContext", _s...)
 }
 
 func (_m *MockElastiCacheAPI) DescribeReplicationGroups(_param0 *elasticache.DescribeReplicationGroupsInput) (*elasticache.DescribeReplicationGroupsOutput, error) {
@@ -638,6 +1116,33 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeReplicationGroups(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReplicationGroups", arg0)
 }
 
+func (_m *MockElastiCacheAPI) DescribeReplicationGroupsWithContext(_param0 aws.Context, _param1 *elasticache.DescribeReplicationGroupsInput, _param2 ...request.Option) (*elasticache.DescribeReplicationGroupsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeReplicationGroupsWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.DescribeReplicationGroupsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeReplicationGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReplicationGroupsWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) DescribeReplicationGroupsRequest(_param0 *elasticache.DescribeReplicationGroupsInput) (*request.Request, *elasticache.DescribeReplicationGroupsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeReplicationGroupsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DescribeReplicationGroupsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeReplicationGroupsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReplicationGroupsRequest", arg0)
+}
+
 func (_m *MockElastiCacheAPI) DescribeReplicationGroupsPages(_param0 *elasticache.DescribeReplicationGroupsInput, _param1 func(*elasticache.DescribeReplicationGroupsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeReplicationGroupsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -648,15 +1153,19 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeReplicationGroupsPages(arg0, arg
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReplicationGroupsPages", arg0, arg1)
 }
 
-func (_m *MockElastiCacheAPI) DescribeReservedCacheNodesRequest(_param0 *elasticache.DescribeReservedCacheNodesInput) (*request.Request, *elasticache.DescribeReservedCacheNodesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeReservedCacheNodesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.DescribeReservedCacheNodesOutput)
-	return ret0, ret1
+func (_m *MockElastiCacheAPI) DescribeReplicationGroupsPagesWithContext(_param0 aws.Context, _param1 *elasticache.DescribeReplicationGroupsInput, _param2 func(*elasticache.DescribeReplicationGroupsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeReplicationGroupsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) DescribeReservedCacheNodesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedCacheNodesRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) DescribeReplicationGroupsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReplicationGroupsPagesWithContext", _s...)
 }
 
 func (_m *MockElastiCacheAPI) DescribeReservedCacheNodes(_param0 *elasticache.DescribeReservedCacheNodesInput) (*elasticache.DescribeReservedCacheNodesOutput, error) {
@@ -670,6 +1179,33 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeReservedCacheNodes(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedCacheNodes", arg0)
 }
 
+func (_m *MockElastiCacheAPI) DescribeReservedCacheNodesWithContext(_param0 aws.Context, _param1 *elasticache.DescribeReservedCacheNodesInput, _param2 ...request.Option) (*elasticache.DescribeReservedCacheNodesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeReservedCacheNodesWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.DescribeReservedCacheNodesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeReservedCacheNodesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedCacheNodesWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) DescribeReservedCacheNodesRequest(_param0 *elasticache.DescribeReservedCacheNodesInput) (*request.Request, *elasticache.DescribeReservedCacheNodesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeReservedCacheNodesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DescribeReservedCacheNodesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeReservedCacheNodesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedCacheNodesRequest", arg0)
+}
+
 func (_m *MockElastiCacheAPI) DescribeReservedCacheNodesPages(_param0 *elasticache.DescribeReservedCacheNodesInput, _param1 func(*elasticache.DescribeReservedCacheNodesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeReservedCacheNodesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -680,15 +1216,19 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeReservedCacheNodesPages(arg0, ar
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedCacheNodesPages", arg0, arg1)
 }
 
-func (_m *MockElastiCacheAPI) DescribeReservedCacheNodesOfferingsRequest(_param0 *elasticache.DescribeReservedCacheNodesOfferingsInput) (*request.Request, *elasticache.DescribeReservedCacheNodesOfferingsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeReservedCacheNodesOfferingsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.DescribeReservedCacheNodesOfferingsOutput)
-	return ret0, ret1
+func (_m *MockElastiCacheAPI) DescribeReservedCacheNodesPagesWithContext(_param0 aws.Context, _param1 *elasticache.DescribeReservedCacheNodesInput, _param2 func(*elasticache.DescribeReservedCacheNodesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeReservedCacheNodesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) DescribeReservedCacheNodesOfferingsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedCacheNodesOfferingsRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) DescribeReservedCacheNodesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedCacheNodesPagesWithContext", _s...)
 }
 
 func (_m *MockElastiCacheAPI) DescribeReservedCacheNodesOfferings(_param0 *elasticache.DescribeReservedCacheNodesOfferingsInput) (*elasticache.DescribeReservedCacheNodesOfferingsOutput, error) {
@@ -702,6 +1242,33 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeReservedCacheNodesOfferings(arg0
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedCacheNodesOfferings", arg0)
 }
 
+func (_m *MockElastiCacheAPI) DescribeReservedCacheNodesOfferingsWithContext(_param0 aws.Context, _param1 *elasticache.DescribeReservedCacheNodesOfferingsInput, _param2 ...request.Option) (*elasticache.DescribeReservedCacheNodesOfferingsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeReservedCacheNodesOfferingsWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.DescribeReservedCacheNodesOfferingsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeReservedCacheNodesOfferingsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedCacheNodesOfferingsWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) DescribeReservedCacheNodesOfferingsRequest(_param0 *elasticache.DescribeReservedCacheNodesOfferingsInput) (*request.Request, *elasticache.DescribeReservedCacheNodesOfferingsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeReservedCacheNodesOfferingsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DescribeReservedCacheNodesOfferingsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeReservedCacheNodesOfferingsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedCacheNodesOfferingsRequest", arg0)
+}
+
 func (_m *MockElastiCacheAPI) DescribeReservedCacheNodesOfferingsPages(_param0 *elasticache.DescribeReservedCacheNodesOfferingsInput, _param1 func(*elasticache.DescribeReservedCacheNodesOfferingsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeReservedCacheNodesOfferingsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -712,15 +1279,19 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeReservedCacheNodesOfferingsPages
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedCacheNodesOfferingsPages", arg0, arg1)
 }
 
-func (_m *MockElastiCacheAPI) DescribeSnapshotsRequest(_param0 *elasticache.DescribeSnapshotsInput) (*request.Request, *elasticache.DescribeSnapshotsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeSnapshotsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.DescribeSnapshotsOutput)
-	return ret0, ret1
+func (_m *MockElastiCacheAPI) DescribeReservedCacheNodesOfferingsPagesWithContext(_param0 aws.Context, _param1 *elasticache.DescribeReservedCacheNodesOfferingsInput, _param2 func(*elasticache.DescribeReservedCacheNodesOfferingsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeReservedCacheNodesOfferingsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) DescribeSnapshotsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSnapshotsRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) DescribeReservedCacheNodesOfferingsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedCacheNodesOfferingsPagesWithContext", _s...)
 }
 
 func (_m *MockElastiCacheAPI) DescribeSnapshots(_param0 *elasticache.DescribeSnapshotsInput) (*elasticache.DescribeSnapshotsOutput, error) {
@@ -734,6 +1305,33 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeSnapshots(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSnapshots", arg0)
 }
 
+func (_m *MockElastiCacheAPI) DescribeSnapshotsWithContext(_param0 aws.Context, _param1 *elasticache.DescribeSnapshotsInput, _param2 ...request.Option) (*elasticache.DescribeSnapshotsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeSnapshotsWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.DescribeSnapshotsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeSnapshotsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSnapshotsWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) DescribeSnapshotsRequest(_param0 *elasticache.DescribeSnapshotsInput) (*request.Request, *elasticache.DescribeSnapshotsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeSnapshotsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.DescribeSnapshotsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) DescribeSnapshotsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSnapshotsRequest", arg0)
+}
+
 func (_m *MockElastiCacheAPI) DescribeSnapshotsPages(_param0 *elasticache.DescribeSnapshotsInput, _param1 func(*elasticache.DescribeSnapshotsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeSnapshotsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -744,15 +1342,19 @@ func (_mr *_MockElastiCacheAPIRecorder) DescribeSnapshotsPages(arg0, arg1 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSnapshotsPages", arg0, arg1)
 }
 
-func (_m *MockElastiCacheAPI) ListAllowedNodeTypeModificationsRequest(_param0 *elasticache.ListAllowedNodeTypeModificationsInput) (*request.Request, *elasticache.ListAllowedNodeTypeModificationsOutput) {
-	ret := _m.ctrl.Call(_m, "ListAllowedNodeTypeModificationsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.ListAllowedNodeTypeModificationsOutput)
-	return ret0, ret1
+func (_m *MockElastiCacheAPI) DescribeSnapshotsPagesWithContext(_param0 aws.Context, _param1 *elasticache.DescribeSnapshotsInput, _param2 func(*elasticache.DescribeSnapshotsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeSnapshotsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) ListAllowedNodeTypeModificationsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAllowedNodeTypeModificationsRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) DescribeSnapshotsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSnapshotsPagesWithContext", _s...)
 }
 
 func (_m *MockElastiCacheAPI) ListAllowedNodeTypeModifications(_param0 *elasticache.ListAllowedNodeTypeModificationsInput) (*elasticache.ListAllowedNodeTypeModificationsOutput, error) {
@@ -766,15 +1368,31 @@ func (_mr *_MockElastiCacheAPIRecorder) ListAllowedNodeTypeModifications(arg0 in
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAllowedNodeTypeModifications", arg0)
 }
 
-func (_m *MockElastiCacheAPI) ListTagsForResourceRequest(_param0 *elasticache.ListTagsForResourceInput) (*request.Request, *elasticache.TagListMessage) {
-	ret := _m.ctrl.Call(_m, "ListTagsForResourceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.TagListMessage)
+func (_m *MockElastiCacheAPI) ListAllowedNodeTypeModificationsWithContext(_param0 aws.Context, _param1 *elasticache.ListAllowedNodeTypeModificationsInput, _param2 ...request.Option) (*elasticache.ListAllowedNodeTypeModificationsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListAllowedNodeTypeModificationsWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.ListAllowedNodeTypeModificationsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) ListTagsForResourceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListTagsForResourceRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) ListAllowedNodeTypeModificationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAllowedNodeTypeModificationsWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) ListAllowedNodeTypeModificationsRequest(_param0 *elasticache.ListAllowedNodeTypeModificationsInput) (*request.Request, *elasticache.ListAllowedNodeTypeModificationsOutput) {
+	ret := _m.ctrl.Call(_m, "ListAllowedNodeTypeModificationsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.ListAllowedNodeTypeModificationsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) ListAllowedNodeTypeModificationsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAllowedNodeTypeModificationsRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) ListTagsForResource(_param0 *elasticache.ListTagsForResourceInput) (*elasticache.TagListMessage, error) {
@@ -788,15 +1406,31 @@ func (_mr *_MockElastiCacheAPIRecorder) ListTagsForResource(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListTagsForResource", arg0)
 }
 
-func (_m *MockElastiCacheAPI) ModifyCacheClusterRequest(_param0 *elasticache.ModifyCacheClusterInput) (*request.Request, *elasticache.ModifyCacheClusterOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyCacheClusterRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.ModifyCacheClusterOutput)
+func (_m *MockElastiCacheAPI) ListTagsForResourceWithContext(_param0 aws.Context, _param1 *elasticache.ListTagsForResourceInput, _param2 ...request.Option) (*elasticache.TagListMessage, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListTagsForResourceWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.TagListMessage)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) ModifyCacheClusterRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyCacheClusterRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) ListTagsForResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListTagsForResourceWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) ListTagsForResourceRequest(_param0 *elasticache.ListTagsForResourceInput) (*request.Request, *elasticache.TagListMessage) {
+	ret := _m.ctrl.Call(_m, "ListTagsForResourceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.TagListMessage)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) ListTagsForResourceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListTagsForResourceRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) ModifyCacheCluster(_param0 *elasticache.ModifyCacheClusterInput) (*elasticache.ModifyCacheClusterOutput, error) {
@@ -810,15 +1444,31 @@ func (_mr *_MockElastiCacheAPIRecorder) ModifyCacheCluster(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyCacheCluster", arg0)
 }
 
-func (_m *MockElastiCacheAPI) ModifyCacheParameterGroupRequest(_param0 *elasticache.ModifyCacheParameterGroupInput) (*request.Request, *elasticache.CacheParameterGroupNameMessage) {
-	ret := _m.ctrl.Call(_m, "ModifyCacheParameterGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.CacheParameterGroupNameMessage)
+func (_m *MockElastiCacheAPI) ModifyCacheClusterWithContext(_param0 aws.Context, _param1 *elasticache.ModifyCacheClusterInput, _param2 ...request.Option) (*elasticache.ModifyCacheClusterOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyCacheClusterWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.ModifyCacheClusterOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) ModifyCacheParameterGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyCacheParameterGroupRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) ModifyCacheClusterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyCacheClusterWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) ModifyCacheClusterRequest(_param0 *elasticache.ModifyCacheClusterInput) (*request.Request, *elasticache.ModifyCacheClusterOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyCacheClusterRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.ModifyCacheClusterOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) ModifyCacheClusterRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyCacheClusterRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) ModifyCacheParameterGroup(_param0 *elasticache.ModifyCacheParameterGroupInput) (*elasticache.CacheParameterGroupNameMessage, error) {
@@ -832,15 +1482,31 @@ func (_mr *_MockElastiCacheAPIRecorder) ModifyCacheParameterGroup(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyCacheParameterGroup", arg0)
 }
 
-func (_m *MockElastiCacheAPI) ModifyCacheSubnetGroupRequest(_param0 *elasticache.ModifyCacheSubnetGroupInput) (*request.Request, *elasticache.ModifyCacheSubnetGroupOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyCacheSubnetGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.ModifyCacheSubnetGroupOutput)
+func (_m *MockElastiCacheAPI) ModifyCacheParameterGroupWithContext(_param0 aws.Context, _param1 *elasticache.ModifyCacheParameterGroupInput, _param2 ...request.Option) (*elasticache.CacheParameterGroupNameMessage, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyCacheParameterGroupWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.CacheParameterGroupNameMessage)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) ModifyCacheSubnetGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyCacheSubnetGroupRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) ModifyCacheParameterGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyCacheParameterGroupWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) ModifyCacheParameterGroupRequest(_param0 *elasticache.ModifyCacheParameterGroupInput) (*request.Request, *elasticache.CacheParameterGroupNameMessage) {
+	ret := _m.ctrl.Call(_m, "ModifyCacheParameterGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.CacheParameterGroupNameMessage)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) ModifyCacheParameterGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyCacheParameterGroupRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) ModifyCacheSubnetGroup(_param0 *elasticache.ModifyCacheSubnetGroupInput) (*elasticache.ModifyCacheSubnetGroupOutput, error) {
@@ -854,15 +1520,31 @@ func (_mr *_MockElastiCacheAPIRecorder) ModifyCacheSubnetGroup(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyCacheSubnetGroup", arg0)
 }
 
-func (_m *MockElastiCacheAPI) ModifyReplicationGroupRequest(_param0 *elasticache.ModifyReplicationGroupInput) (*request.Request, *elasticache.ModifyReplicationGroupOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyReplicationGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.ModifyReplicationGroupOutput)
+func (_m *MockElastiCacheAPI) ModifyCacheSubnetGroupWithContext(_param0 aws.Context, _param1 *elasticache.ModifyCacheSubnetGroupInput, _param2 ...request.Option) (*elasticache.ModifyCacheSubnetGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyCacheSubnetGroupWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.ModifyCacheSubnetGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) ModifyReplicationGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyReplicationGroupRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) ModifyCacheSubnetGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyCacheSubnetGroupWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) ModifyCacheSubnetGroupRequest(_param0 *elasticache.ModifyCacheSubnetGroupInput) (*request.Request, *elasticache.ModifyCacheSubnetGroupOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyCacheSubnetGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.ModifyCacheSubnetGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) ModifyCacheSubnetGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyCacheSubnetGroupRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) ModifyReplicationGroup(_param0 *elasticache.ModifyReplicationGroupInput) (*elasticache.ModifyReplicationGroupOutput, error) {
@@ -876,15 +1558,31 @@ func (_mr *_MockElastiCacheAPIRecorder) ModifyReplicationGroup(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyReplicationGroup", arg0)
 }
 
-func (_m *MockElastiCacheAPI) PurchaseReservedCacheNodesOfferingRequest(_param0 *elasticache.PurchaseReservedCacheNodesOfferingInput) (*request.Request, *elasticache.PurchaseReservedCacheNodesOfferingOutput) {
-	ret := _m.ctrl.Call(_m, "PurchaseReservedCacheNodesOfferingRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.PurchaseReservedCacheNodesOfferingOutput)
+func (_m *MockElastiCacheAPI) ModifyReplicationGroupWithContext(_param0 aws.Context, _param1 *elasticache.ModifyReplicationGroupInput, _param2 ...request.Option) (*elasticache.ModifyReplicationGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyReplicationGroupWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.ModifyReplicationGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) PurchaseReservedCacheNodesOfferingRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseReservedCacheNodesOfferingRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) ModifyReplicationGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyReplicationGroupWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) ModifyReplicationGroupRequest(_param0 *elasticache.ModifyReplicationGroupInput) (*request.Request, *elasticache.ModifyReplicationGroupOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyReplicationGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.ModifyReplicationGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) ModifyReplicationGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyReplicationGroupRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) PurchaseReservedCacheNodesOffering(_param0 *elasticache.PurchaseReservedCacheNodesOfferingInput) (*elasticache.PurchaseReservedCacheNodesOfferingOutput, error) {
@@ -898,15 +1596,31 @@ func (_mr *_MockElastiCacheAPIRecorder) PurchaseReservedCacheNodesOffering(arg0 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseReservedCacheNodesOffering", arg0)
 }
 
-func (_m *MockElastiCacheAPI) RebootCacheClusterRequest(_param0 *elasticache.RebootCacheClusterInput) (*request.Request, *elasticache.RebootCacheClusterOutput) {
-	ret := _m.ctrl.Call(_m, "RebootCacheClusterRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.RebootCacheClusterOutput)
+func (_m *MockElastiCacheAPI) PurchaseReservedCacheNodesOfferingWithContext(_param0 aws.Context, _param1 *elasticache.PurchaseReservedCacheNodesOfferingInput, _param2 ...request.Option) (*elasticache.PurchaseReservedCacheNodesOfferingOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "PurchaseReservedCacheNodesOfferingWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.PurchaseReservedCacheNodesOfferingOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) RebootCacheClusterRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RebootCacheClusterRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) PurchaseReservedCacheNodesOfferingWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseReservedCacheNodesOfferingWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) PurchaseReservedCacheNodesOfferingRequest(_param0 *elasticache.PurchaseReservedCacheNodesOfferingInput) (*request.Request, *elasticache.PurchaseReservedCacheNodesOfferingOutput) {
+	ret := _m.ctrl.Call(_m, "PurchaseReservedCacheNodesOfferingRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.PurchaseReservedCacheNodesOfferingOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) PurchaseReservedCacheNodesOfferingRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseReservedCacheNodesOfferingRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) RebootCacheCluster(_param0 *elasticache.RebootCacheClusterInput) (*elasticache.RebootCacheClusterOutput, error) {
@@ -920,15 +1634,31 @@ func (_mr *_MockElastiCacheAPIRecorder) RebootCacheCluster(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RebootCacheCluster", arg0)
 }
 
-func (_m *MockElastiCacheAPI) RemoveTagsFromResourceRequest(_param0 *elasticache.RemoveTagsFromResourceInput) (*request.Request, *elasticache.TagListMessage) {
-	ret := _m.ctrl.Call(_m, "RemoveTagsFromResourceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.TagListMessage)
+func (_m *MockElastiCacheAPI) RebootCacheClusterWithContext(_param0 aws.Context, _param1 *elasticache.RebootCacheClusterInput, _param2 ...request.Option) (*elasticache.RebootCacheClusterOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RebootCacheClusterWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.RebootCacheClusterOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) RemoveTagsFromResourceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveTagsFromResourceRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) RebootCacheClusterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RebootCacheClusterWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) RebootCacheClusterRequest(_param0 *elasticache.RebootCacheClusterInput) (*request.Request, *elasticache.RebootCacheClusterOutput) {
+	ret := _m.ctrl.Call(_m, "RebootCacheClusterRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.RebootCacheClusterOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) RebootCacheClusterRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RebootCacheClusterRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) RemoveTagsFromResource(_param0 *elasticache.RemoveTagsFromResourceInput) (*elasticache.TagListMessage, error) {
@@ -942,15 +1672,31 @@ func (_mr *_MockElastiCacheAPIRecorder) RemoveTagsFromResource(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveTagsFromResource", arg0)
 }
 
-func (_m *MockElastiCacheAPI) ResetCacheParameterGroupRequest(_param0 *elasticache.ResetCacheParameterGroupInput) (*request.Request, *elasticache.CacheParameterGroupNameMessage) {
-	ret := _m.ctrl.Call(_m, "ResetCacheParameterGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.CacheParameterGroupNameMessage)
+func (_m *MockElastiCacheAPI) RemoveTagsFromResourceWithContext(_param0 aws.Context, _param1 *elasticache.RemoveTagsFromResourceInput, _param2 ...request.Option) (*elasticache.TagListMessage, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RemoveTagsFromResourceWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.TagListMessage)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) ResetCacheParameterGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetCacheParameterGroupRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) RemoveTagsFromResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveTagsFromResourceWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) RemoveTagsFromResourceRequest(_param0 *elasticache.RemoveTagsFromResourceInput) (*request.Request, *elasticache.TagListMessage) {
+	ret := _m.ctrl.Call(_m, "RemoveTagsFromResourceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.TagListMessage)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) RemoveTagsFromResourceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveTagsFromResourceRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) ResetCacheParameterGroup(_param0 *elasticache.ResetCacheParameterGroupInput) (*elasticache.CacheParameterGroupNameMessage, error) {
@@ -964,15 +1710,31 @@ func (_mr *_MockElastiCacheAPIRecorder) ResetCacheParameterGroup(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetCacheParameterGroup", arg0)
 }
 
-func (_m *MockElastiCacheAPI) RevokeCacheSecurityGroupIngressRequest(_param0 *elasticache.RevokeCacheSecurityGroupIngressInput) (*request.Request, *elasticache.RevokeCacheSecurityGroupIngressOutput) {
-	ret := _m.ctrl.Call(_m, "RevokeCacheSecurityGroupIngressRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elasticache.RevokeCacheSecurityGroupIngressOutput)
+func (_m *MockElastiCacheAPI) ResetCacheParameterGroupWithContext(_param0 aws.Context, _param1 *elasticache.ResetCacheParameterGroupInput, _param2 ...request.Option) (*elasticache.CacheParameterGroupNameMessage, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ResetCacheParameterGroupWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.CacheParameterGroupNameMessage)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockElastiCacheAPIRecorder) RevokeCacheSecurityGroupIngressRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevokeCacheSecurityGroupIngressRequest", arg0)
+func (_mr *_MockElastiCacheAPIRecorder) ResetCacheParameterGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetCacheParameterGroupWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) ResetCacheParameterGroupRequest(_param0 *elasticache.ResetCacheParameterGroupInput) (*request.Request, *elasticache.CacheParameterGroupNameMessage) {
+	ret := _m.ctrl.Call(_m, "ResetCacheParameterGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.CacheParameterGroupNameMessage)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) ResetCacheParameterGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetCacheParameterGroupRequest", arg0)
 }
 
 func (_m *MockElastiCacheAPI) RevokeCacheSecurityGroupIngress(_param0 *elasticache.RevokeCacheSecurityGroupIngressInput) (*elasticache.RevokeCacheSecurityGroupIngressOutput, error) {
@@ -986,6 +1748,33 @@ func (_mr *_MockElastiCacheAPIRecorder) RevokeCacheSecurityGroupIngress(arg0 int
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevokeCacheSecurityGroupIngress", arg0)
 }
 
+func (_m *MockElastiCacheAPI) RevokeCacheSecurityGroupIngressWithContext(_param0 aws.Context, _param1 *elasticache.RevokeCacheSecurityGroupIngressInput, _param2 ...request.Option) (*elasticache.RevokeCacheSecurityGroupIngressOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RevokeCacheSecurityGroupIngressWithContext", _s...)
+	ret0, _ := ret[0].(*elasticache.RevokeCacheSecurityGroupIngressOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) RevokeCacheSecurityGroupIngressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevokeCacheSecurityGroupIngressWithContext", _s...)
+}
+
+func (_m *MockElastiCacheAPI) RevokeCacheSecurityGroupIngressRequest(_param0 *elasticache.RevokeCacheSecurityGroupIngressInput) (*request.Request, *elasticache.RevokeCacheSecurityGroupIngressOutput) {
+	ret := _m.ctrl.Call(_m, "RevokeCacheSecurityGroupIngressRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elasticache.RevokeCacheSecurityGroupIngressOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) RevokeCacheSecurityGroupIngressRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevokeCacheSecurityGroupIngressRequest", arg0)
+}
+
 func (_m *MockElastiCacheAPI) WaitUntilCacheClusterAvailable(_param0 *elasticache.DescribeCacheClustersInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilCacheClusterAvailable", _param0)
 	ret0, _ := ret[0].(error)
@@ -994,6 +1783,21 @@ func (_m *MockElastiCacheAPI) WaitUntilCacheClusterAvailable(_param0 *elasticach
 
 func (_mr *_MockElastiCacheAPIRecorder) WaitUntilCacheClusterAvailable(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilCacheClusterAvailable", arg0)
+}
+
+func (_m *MockElastiCacheAPI) WaitUntilCacheClusterAvailableWithContext(_param0 aws.Context, _param1 *elasticache.DescribeCacheClustersInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilCacheClusterAvailableWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) WaitUntilCacheClusterAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilCacheClusterAvailableWithContext", _s...)
 }
 
 func (_m *MockElastiCacheAPI) WaitUntilCacheClusterDeleted(_param0 *elasticache.DescribeCacheClustersInput) error {
@@ -1006,6 +1810,21 @@ func (_mr *_MockElastiCacheAPIRecorder) WaitUntilCacheClusterDeleted(arg0 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilCacheClusterDeleted", arg0)
 }
 
+func (_m *MockElastiCacheAPI) WaitUntilCacheClusterDeletedWithContext(_param0 aws.Context, _param1 *elasticache.DescribeCacheClustersInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilCacheClusterDeletedWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) WaitUntilCacheClusterDeletedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilCacheClusterDeletedWithContext", _s...)
+}
+
 func (_m *MockElastiCacheAPI) WaitUntilReplicationGroupAvailable(_param0 *elasticache.DescribeReplicationGroupsInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilReplicationGroupAvailable", _param0)
 	ret0, _ := ret[0].(error)
@@ -1016,6 +1835,21 @@ func (_mr *_MockElastiCacheAPIRecorder) WaitUntilReplicationGroupAvailable(arg0 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilReplicationGroupAvailable", arg0)
 }
 
+func (_m *MockElastiCacheAPI) WaitUntilReplicationGroupAvailableWithContext(_param0 aws.Context, _param1 *elasticache.DescribeReplicationGroupsInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilReplicationGroupAvailableWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) WaitUntilReplicationGroupAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilReplicationGroupAvailableWithContext", _s...)
+}
+
 func (_m *MockElastiCacheAPI) WaitUntilReplicationGroupDeleted(_param0 *elasticache.DescribeReplicationGroupsInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilReplicationGroupDeleted", _param0)
 	ret0, _ := ret[0].(error)
@@ -1024,4 +1858,19 @@ func (_m *MockElastiCacheAPI) WaitUntilReplicationGroupDeleted(_param0 *elastica
 
 func (_mr *_MockElastiCacheAPIRecorder) WaitUntilReplicationGroupDeleted(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilReplicationGroupDeleted", arg0)
+}
+
+func (_m *MockElastiCacheAPI) WaitUntilReplicationGroupDeletedWithContext(_param0 aws.Context, _param1 *elasticache.DescribeReplicationGroupsInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilReplicationGroupDeletedWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockElastiCacheAPIRecorder) WaitUntilReplicationGroupDeletedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilReplicationGroupDeletedWithContext", _s...)
 }

--- a/mock/elbmock.go
+++ b/mock/elbmock.go
@@ -4,6 +4,7 @@
 package mock
 
 import (
+	aws "github.com/aws/aws-sdk-go/aws"
 	request "github.com/aws/aws-sdk-go/aws/request"
 	elb "github.com/aws/aws-sdk-go/service/elb"
 	gomock "github.com/golang/mock/gomock"
@@ -30,17 +31,6 @@ func (_m *MockELBAPI) EXPECT() *_MockELBAPIRecorder {
 	return _m.recorder
 }
 
-func (_m *MockELBAPI) AddTagsRequest(_param0 *elb.AddTagsInput) (*request.Request, *elb.AddTagsOutput) {
-	ret := _m.ctrl.Call(_m, "AddTagsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.AddTagsOutput)
-	return ret0, ret1
-}
-
-func (_mr *_MockELBAPIRecorder) AddTagsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddTagsRequest", arg0)
-}
-
 func (_m *MockELBAPI) AddTags(_param0 *elb.AddTagsInput) (*elb.AddTagsOutput, error) {
 	ret := _m.ctrl.Call(_m, "AddTags", _param0)
 	ret0, _ := ret[0].(*elb.AddTagsOutput)
@@ -52,15 +42,31 @@ func (_mr *_MockELBAPIRecorder) AddTags(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddTags", arg0)
 }
 
-func (_m *MockELBAPI) ApplySecurityGroupsToLoadBalancerRequest(_param0 *elb.ApplySecurityGroupsToLoadBalancerInput) (*request.Request, *elb.ApplySecurityGroupsToLoadBalancerOutput) {
-	ret := _m.ctrl.Call(_m, "ApplySecurityGroupsToLoadBalancerRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.ApplySecurityGroupsToLoadBalancerOutput)
+func (_m *MockELBAPI) AddTagsWithContext(_param0 aws.Context, _param1 *elb.AddTagsInput, _param2 ...request.Option) (*elb.AddTagsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AddTagsWithContext", _s...)
+	ret0, _ := ret[0].(*elb.AddTagsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) ApplySecurityGroupsToLoadBalancerRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ApplySecurityGroupsToLoadBalancerRequest", arg0)
+func (_mr *_MockELBAPIRecorder) AddTagsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddTagsWithContext", _s...)
+}
+
+func (_m *MockELBAPI) AddTagsRequest(_param0 *elb.AddTagsInput) (*request.Request, *elb.AddTagsOutput) {
+	ret := _m.ctrl.Call(_m, "AddTagsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.AddTagsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) AddTagsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddTagsRequest", arg0)
 }
 
 func (_m *MockELBAPI) ApplySecurityGroupsToLoadBalancer(_param0 *elb.ApplySecurityGroupsToLoadBalancerInput) (*elb.ApplySecurityGroupsToLoadBalancerOutput, error) {
@@ -74,15 +80,31 @@ func (_mr *_MockELBAPIRecorder) ApplySecurityGroupsToLoadBalancer(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ApplySecurityGroupsToLoadBalancer", arg0)
 }
 
-func (_m *MockELBAPI) AttachLoadBalancerToSubnetsRequest(_param0 *elb.AttachLoadBalancerToSubnetsInput) (*request.Request, *elb.AttachLoadBalancerToSubnetsOutput) {
-	ret := _m.ctrl.Call(_m, "AttachLoadBalancerToSubnetsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.AttachLoadBalancerToSubnetsOutput)
+func (_m *MockELBAPI) ApplySecurityGroupsToLoadBalancerWithContext(_param0 aws.Context, _param1 *elb.ApplySecurityGroupsToLoadBalancerInput, _param2 ...request.Option) (*elb.ApplySecurityGroupsToLoadBalancerOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ApplySecurityGroupsToLoadBalancerWithContext", _s...)
+	ret0, _ := ret[0].(*elb.ApplySecurityGroupsToLoadBalancerOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) AttachLoadBalancerToSubnetsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachLoadBalancerToSubnetsRequest", arg0)
+func (_mr *_MockELBAPIRecorder) ApplySecurityGroupsToLoadBalancerWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ApplySecurityGroupsToLoadBalancerWithContext", _s...)
+}
+
+func (_m *MockELBAPI) ApplySecurityGroupsToLoadBalancerRequest(_param0 *elb.ApplySecurityGroupsToLoadBalancerInput) (*request.Request, *elb.ApplySecurityGroupsToLoadBalancerOutput) {
+	ret := _m.ctrl.Call(_m, "ApplySecurityGroupsToLoadBalancerRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.ApplySecurityGroupsToLoadBalancerOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) ApplySecurityGroupsToLoadBalancerRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ApplySecurityGroupsToLoadBalancerRequest", arg0)
 }
 
 func (_m *MockELBAPI) AttachLoadBalancerToSubnets(_param0 *elb.AttachLoadBalancerToSubnetsInput) (*elb.AttachLoadBalancerToSubnetsOutput, error) {
@@ -96,15 +118,31 @@ func (_mr *_MockELBAPIRecorder) AttachLoadBalancerToSubnets(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachLoadBalancerToSubnets", arg0)
 }
 
-func (_m *MockELBAPI) ConfigureHealthCheckRequest(_param0 *elb.ConfigureHealthCheckInput) (*request.Request, *elb.ConfigureHealthCheckOutput) {
-	ret := _m.ctrl.Call(_m, "ConfigureHealthCheckRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.ConfigureHealthCheckOutput)
+func (_m *MockELBAPI) AttachLoadBalancerToSubnetsWithContext(_param0 aws.Context, _param1 *elb.AttachLoadBalancerToSubnetsInput, _param2 ...request.Option) (*elb.AttachLoadBalancerToSubnetsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AttachLoadBalancerToSubnetsWithContext", _s...)
+	ret0, _ := ret[0].(*elb.AttachLoadBalancerToSubnetsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) ConfigureHealthCheckRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigureHealthCheckRequest", arg0)
+func (_mr *_MockELBAPIRecorder) AttachLoadBalancerToSubnetsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachLoadBalancerToSubnetsWithContext", _s...)
+}
+
+func (_m *MockELBAPI) AttachLoadBalancerToSubnetsRequest(_param0 *elb.AttachLoadBalancerToSubnetsInput) (*request.Request, *elb.AttachLoadBalancerToSubnetsOutput) {
+	ret := _m.ctrl.Call(_m, "AttachLoadBalancerToSubnetsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.AttachLoadBalancerToSubnetsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) AttachLoadBalancerToSubnetsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachLoadBalancerToSubnetsRequest", arg0)
 }
 
 func (_m *MockELBAPI) ConfigureHealthCheck(_param0 *elb.ConfigureHealthCheckInput) (*elb.ConfigureHealthCheckOutput, error) {
@@ -118,15 +156,31 @@ func (_mr *_MockELBAPIRecorder) ConfigureHealthCheck(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigureHealthCheck", arg0)
 }
 
-func (_m *MockELBAPI) CreateAppCookieStickinessPolicyRequest(_param0 *elb.CreateAppCookieStickinessPolicyInput) (*request.Request, *elb.CreateAppCookieStickinessPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "CreateAppCookieStickinessPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.CreateAppCookieStickinessPolicyOutput)
+func (_m *MockELBAPI) ConfigureHealthCheckWithContext(_param0 aws.Context, _param1 *elb.ConfigureHealthCheckInput, _param2 ...request.Option) (*elb.ConfigureHealthCheckOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ConfigureHealthCheckWithContext", _s...)
+	ret0, _ := ret[0].(*elb.ConfigureHealthCheckOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) CreateAppCookieStickinessPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateAppCookieStickinessPolicyRequest", arg0)
+func (_mr *_MockELBAPIRecorder) ConfigureHealthCheckWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigureHealthCheckWithContext", _s...)
+}
+
+func (_m *MockELBAPI) ConfigureHealthCheckRequest(_param0 *elb.ConfigureHealthCheckInput) (*request.Request, *elb.ConfigureHealthCheckOutput) {
+	ret := _m.ctrl.Call(_m, "ConfigureHealthCheckRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.ConfigureHealthCheckOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) ConfigureHealthCheckRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigureHealthCheckRequest", arg0)
 }
 
 func (_m *MockELBAPI) CreateAppCookieStickinessPolicy(_param0 *elb.CreateAppCookieStickinessPolicyInput) (*elb.CreateAppCookieStickinessPolicyOutput, error) {
@@ -140,15 +194,31 @@ func (_mr *_MockELBAPIRecorder) CreateAppCookieStickinessPolicy(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateAppCookieStickinessPolicy", arg0)
 }
 
-func (_m *MockELBAPI) CreateLBCookieStickinessPolicyRequest(_param0 *elb.CreateLBCookieStickinessPolicyInput) (*request.Request, *elb.CreateLBCookieStickinessPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "CreateLBCookieStickinessPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.CreateLBCookieStickinessPolicyOutput)
+func (_m *MockELBAPI) CreateAppCookieStickinessPolicyWithContext(_param0 aws.Context, _param1 *elb.CreateAppCookieStickinessPolicyInput, _param2 ...request.Option) (*elb.CreateAppCookieStickinessPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateAppCookieStickinessPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*elb.CreateAppCookieStickinessPolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) CreateLBCookieStickinessPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLBCookieStickinessPolicyRequest", arg0)
+func (_mr *_MockELBAPIRecorder) CreateAppCookieStickinessPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateAppCookieStickinessPolicyWithContext", _s...)
+}
+
+func (_m *MockELBAPI) CreateAppCookieStickinessPolicyRequest(_param0 *elb.CreateAppCookieStickinessPolicyInput) (*request.Request, *elb.CreateAppCookieStickinessPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "CreateAppCookieStickinessPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.CreateAppCookieStickinessPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) CreateAppCookieStickinessPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateAppCookieStickinessPolicyRequest", arg0)
 }
 
 func (_m *MockELBAPI) CreateLBCookieStickinessPolicy(_param0 *elb.CreateLBCookieStickinessPolicyInput) (*elb.CreateLBCookieStickinessPolicyOutput, error) {
@@ -162,15 +232,31 @@ func (_mr *_MockELBAPIRecorder) CreateLBCookieStickinessPolicy(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLBCookieStickinessPolicy", arg0)
 }
 
-func (_m *MockELBAPI) CreateLoadBalancerRequest(_param0 *elb.CreateLoadBalancerInput) (*request.Request, *elb.CreateLoadBalancerOutput) {
-	ret := _m.ctrl.Call(_m, "CreateLoadBalancerRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.CreateLoadBalancerOutput)
+func (_m *MockELBAPI) CreateLBCookieStickinessPolicyWithContext(_param0 aws.Context, _param1 *elb.CreateLBCookieStickinessPolicyInput, _param2 ...request.Option) (*elb.CreateLBCookieStickinessPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateLBCookieStickinessPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*elb.CreateLBCookieStickinessPolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) CreateLoadBalancerRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancerRequest", arg0)
+func (_mr *_MockELBAPIRecorder) CreateLBCookieStickinessPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLBCookieStickinessPolicyWithContext", _s...)
+}
+
+func (_m *MockELBAPI) CreateLBCookieStickinessPolicyRequest(_param0 *elb.CreateLBCookieStickinessPolicyInput) (*request.Request, *elb.CreateLBCookieStickinessPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "CreateLBCookieStickinessPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.CreateLBCookieStickinessPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) CreateLBCookieStickinessPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLBCookieStickinessPolicyRequest", arg0)
 }
 
 func (_m *MockELBAPI) CreateLoadBalancer(_param0 *elb.CreateLoadBalancerInput) (*elb.CreateLoadBalancerOutput, error) {
@@ -184,15 +270,31 @@ func (_mr *_MockELBAPIRecorder) CreateLoadBalancer(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancer", arg0)
 }
 
-func (_m *MockELBAPI) CreateLoadBalancerListenersRequest(_param0 *elb.CreateLoadBalancerListenersInput) (*request.Request, *elb.CreateLoadBalancerListenersOutput) {
-	ret := _m.ctrl.Call(_m, "CreateLoadBalancerListenersRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.CreateLoadBalancerListenersOutput)
+func (_m *MockELBAPI) CreateLoadBalancerWithContext(_param0 aws.Context, _param1 *elb.CreateLoadBalancerInput, _param2 ...request.Option) (*elb.CreateLoadBalancerOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateLoadBalancerWithContext", _s...)
+	ret0, _ := ret[0].(*elb.CreateLoadBalancerOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) CreateLoadBalancerListenersRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancerListenersRequest", arg0)
+func (_mr *_MockELBAPIRecorder) CreateLoadBalancerWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancerWithContext", _s...)
+}
+
+func (_m *MockELBAPI) CreateLoadBalancerRequest(_param0 *elb.CreateLoadBalancerInput) (*request.Request, *elb.CreateLoadBalancerOutput) {
+	ret := _m.ctrl.Call(_m, "CreateLoadBalancerRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.CreateLoadBalancerOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) CreateLoadBalancerRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancerRequest", arg0)
 }
 
 func (_m *MockELBAPI) CreateLoadBalancerListeners(_param0 *elb.CreateLoadBalancerListenersInput) (*elb.CreateLoadBalancerListenersOutput, error) {
@@ -206,15 +308,31 @@ func (_mr *_MockELBAPIRecorder) CreateLoadBalancerListeners(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancerListeners", arg0)
 }
 
-func (_m *MockELBAPI) CreateLoadBalancerPolicyRequest(_param0 *elb.CreateLoadBalancerPolicyInput) (*request.Request, *elb.CreateLoadBalancerPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "CreateLoadBalancerPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.CreateLoadBalancerPolicyOutput)
+func (_m *MockELBAPI) CreateLoadBalancerListenersWithContext(_param0 aws.Context, _param1 *elb.CreateLoadBalancerListenersInput, _param2 ...request.Option) (*elb.CreateLoadBalancerListenersOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateLoadBalancerListenersWithContext", _s...)
+	ret0, _ := ret[0].(*elb.CreateLoadBalancerListenersOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) CreateLoadBalancerPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancerPolicyRequest", arg0)
+func (_mr *_MockELBAPIRecorder) CreateLoadBalancerListenersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancerListenersWithContext", _s...)
+}
+
+func (_m *MockELBAPI) CreateLoadBalancerListenersRequest(_param0 *elb.CreateLoadBalancerListenersInput) (*request.Request, *elb.CreateLoadBalancerListenersOutput) {
+	ret := _m.ctrl.Call(_m, "CreateLoadBalancerListenersRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.CreateLoadBalancerListenersOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) CreateLoadBalancerListenersRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancerListenersRequest", arg0)
 }
 
 func (_m *MockELBAPI) CreateLoadBalancerPolicy(_param0 *elb.CreateLoadBalancerPolicyInput) (*elb.CreateLoadBalancerPolicyOutput, error) {
@@ -228,15 +346,31 @@ func (_mr *_MockELBAPIRecorder) CreateLoadBalancerPolicy(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancerPolicy", arg0)
 }
 
-func (_m *MockELBAPI) DeleteLoadBalancerRequest(_param0 *elb.DeleteLoadBalancerInput) (*request.Request, *elb.DeleteLoadBalancerOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteLoadBalancerRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.DeleteLoadBalancerOutput)
+func (_m *MockELBAPI) CreateLoadBalancerPolicyWithContext(_param0 aws.Context, _param1 *elb.CreateLoadBalancerPolicyInput, _param2 ...request.Option) (*elb.CreateLoadBalancerPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateLoadBalancerPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*elb.CreateLoadBalancerPolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) DeleteLoadBalancerRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoadBalancerRequest", arg0)
+func (_mr *_MockELBAPIRecorder) CreateLoadBalancerPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancerPolicyWithContext", _s...)
+}
+
+func (_m *MockELBAPI) CreateLoadBalancerPolicyRequest(_param0 *elb.CreateLoadBalancerPolicyInput) (*request.Request, *elb.CreateLoadBalancerPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "CreateLoadBalancerPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.CreateLoadBalancerPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) CreateLoadBalancerPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancerPolicyRequest", arg0)
 }
 
 func (_m *MockELBAPI) DeleteLoadBalancer(_param0 *elb.DeleteLoadBalancerInput) (*elb.DeleteLoadBalancerOutput, error) {
@@ -250,15 +384,31 @@ func (_mr *_MockELBAPIRecorder) DeleteLoadBalancer(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoadBalancer", arg0)
 }
 
-func (_m *MockELBAPI) DeleteLoadBalancerListenersRequest(_param0 *elb.DeleteLoadBalancerListenersInput) (*request.Request, *elb.DeleteLoadBalancerListenersOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteLoadBalancerListenersRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.DeleteLoadBalancerListenersOutput)
+func (_m *MockELBAPI) DeleteLoadBalancerWithContext(_param0 aws.Context, _param1 *elb.DeleteLoadBalancerInput, _param2 ...request.Option) (*elb.DeleteLoadBalancerOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteLoadBalancerWithContext", _s...)
+	ret0, _ := ret[0].(*elb.DeleteLoadBalancerOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) DeleteLoadBalancerListenersRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoadBalancerListenersRequest", arg0)
+func (_mr *_MockELBAPIRecorder) DeleteLoadBalancerWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoadBalancerWithContext", _s...)
+}
+
+func (_m *MockELBAPI) DeleteLoadBalancerRequest(_param0 *elb.DeleteLoadBalancerInput) (*request.Request, *elb.DeleteLoadBalancerOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteLoadBalancerRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.DeleteLoadBalancerOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) DeleteLoadBalancerRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoadBalancerRequest", arg0)
 }
 
 func (_m *MockELBAPI) DeleteLoadBalancerListeners(_param0 *elb.DeleteLoadBalancerListenersInput) (*elb.DeleteLoadBalancerListenersOutput, error) {
@@ -272,15 +422,31 @@ func (_mr *_MockELBAPIRecorder) DeleteLoadBalancerListeners(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoadBalancerListeners", arg0)
 }
 
-func (_m *MockELBAPI) DeleteLoadBalancerPolicyRequest(_param0 *elb.DeleteLoadBalancerPolicyInput) (*request.Request, *elb.DeleteLoadBalancerPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteLoadBalancerPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.DeleteLoadBalancerPolicyOutput)
+func (_m *MockELBAPI) DeleteLoadBalancerListenersWithContext(_param0 aws.Context, _param1 *elb.DeleteLoadBalancerListenersInput, _param2 ...request.Option) (*elb.DeleteLoadBalancerListenersOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteLoadBalancerListenersWithContext", _s...)
+	ret0, _ := ret[0].(*elb.DeleteLoadBalancerListenersOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) DeleteLoadBalancerPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoadBalancerPolicyRequest", arg0)
+func (_mr *_MockELBAPIRecorder) DeleteLoadBalancerListenersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoadBalancerListenersWithContext", _s...)
+}
+
+func (_m *MockELBAPI) DeleteLoadBalancerListenersRequest(_param0 *elb.DeleteLoadBalancerListenersInput) (*request.Request, *elb.DeleteLoadBalancerListenersOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteLoadBalancerListenersRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.DeleteLoadBalancerListenersOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) DeleteLoadBalancerListenersRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoadBalancerListenersRequest", arg0)
 }
 
 func (_m *MockELBAPI) DeleteLoadBalancerPolicy(_param0 *elb.DeleteLoadBalancerPolicyInput) (*elb.DeleteLoadBalancerPolicyOutput, error) {
@@ -294,15 +460,31 @@ func (_mr *_MockELBAPIRecorder) DeleteLoadBalancerPolicy(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoadBalancerPolicy", arg0)
 }
 
-func (_m *MockELBAPI) DeregisterInstancesFromLoadBalancerRequest(_param0 *elb.DeregisterInstancesFromLoadBalancerInput) (*request.Request, *elb.DeregisterInstancesFromLoadBalancerOutput) {
-	ret := _m.ctrl.Call(_m, "DeregisterInstancesFromLoadBalancerRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.DeregisterInstancesFromLoadBalancerOutput)
+func (_m *MockELBAPI) DeleteLoadBalancerPolicyWithContext(_param0 aws.Context, _param1 *elb.DeleteLoadBalancerPolicyInput, _param2 ...request.Option) (*elb.DeleteLoadBalancerPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteLoadBalancerPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*elb.DeleteLoadBalancerPolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) DeregisterInstancesFromLoadBalancerRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeregisterInstancesFromLoadBalancerRequest", arg0)
+func (_mr *_MockELBAPIRecorder) DeleteLoadBalancerPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoadBalancerPolicyWithContext", _s...)
+}
+
+func (_m *MockELBAPI) DeleteLoadBalancerPolicyRequest(_param0 *elb.DeleteLoadBalancerPolicyInput) (*request.Request, *elb.DeleteLoadBalancerPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteLoadBalancerPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.DeleteLoadBalancerPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) DeleteLoadBalancerPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoadBalancerPolicyRequest", arg0)
 }
 
 func (_m *MockELBAPI) DeregisterInstancesFromLoadBalancer(_param0 *elb.DeregisterInstancesFromLoadBalancerInput) (*elb.DeregisterInstancesFromLoadBalancerOutput, error) {
@@ -316,15 +498,31 @@ func (_mr *_MockELBAPIRecorder) DeregisterInstancesFromLoadBalancer(arg0 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeregisterInstancesFromLoadBalancer", arg0)
 }
 
-func (_m *MockELBAPI) DescribeInstanceHealthRequest(_param0 *elb.DescribeInstanceHealthInput) (*request.Request, *elb.DescribeInstanceHealthOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeInstanceHealthRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.DescribeInstanceHealthOutput)
+func (_m *MockELBAPI) DeregisterInstancesFromLoadBalancerWithContext(_param0 aws.Context, _param1 *elb.DeregisterInstancesFromLoadBalancerInput, _param2 ...request.Option) (*elb.DeregisterInstancesFromLoadBalancerOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeregisterInstancesFromLoadBalancerWithContext", _s...)
+	ret0, _ := ret[0].(*elb.DeregisterInstancesFromLoadBalancerOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) DescribeInstanceHealthRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstanceHealthRequest", arg0)
+func (_mr *_MockELBAPIRecorder) DeregisterInstancesFromLoadBalancerWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeregisterInstancesFromLoadBalancerWithContext", _s...)
+}
+
+func (_m *MockELBAPI) DeregisterInstancesFromLoadBalancerRequest(_param0 *elb.DeregisterInstancesFromLoadBalancerInput) (*request.Request, *elb.DeregisterInstancesFromLoadBalancerOutput) {
+	ret := _m.ctrl.Call(_m, "DeregisterInstancesFromLoadBalancerRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.DeregisterInstancesFromLoadBalancerOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) DeregisterInstancesFromLoadBalancerRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeregisterInstancesFromLoadBalancerRequest", arg0)
 }
 
 func (_m *MockELBAPI) DescribeInstanceHealth(_param0 *elb.DescribeInstanceHealthInput) (*elb.DescribeInstanceHealthOutput, error) {
@@ -338,15 +536,31 @@ func (_mr *_MockELBAPIRecorder) DescribeInstanceHealth(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstanceHealth", arg0)
 }
 
-func (_m *MockELBAPI) DescribeLoadBalancerAttributesRequest(_param0 *elb.DescribeLoadBalancerAttributesInput) (*request.Request, *elb.DescribeLoadBalancerAttributesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeLoadBalancerAttributesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.DescribeLoadBalancerAttributesOutput)
+func (_m *MockELBAPI) DescribeInstanceHealthWithContext(_param0 aws.Context, _param1 *elb.DescribeInstanceHealthInput, _param2 ...request.Option) (*elb.DescribeInstanceHealthOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeInstanceHealthWithContext", _s...)
+	ret0, _ := ret[0].(*elb.DescribeInstanceHealthOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) DescribeLoadBalancerAttributesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancerAttributesRequest", arg0)
+func (_mr *_MockELBAPIRecorder) DescribeInstanceHealthWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstanceHealthWithContext", _s...)
+}
+
+func (_m *MockELBAPI) DescribeInstanceHealthRequest(_param0 *elb.DescribeInstanceHealthInput) (*request.Request, *elb.DescribeInstanceHealthOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeInstanceHealthRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.DescribeInstanceHealthOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) DescribeInstanceHealthRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstanceHealthRequest", arg0)
 }
 
 func (_m *MockELBAPI) DescribeLoadBalancerAttributes(_param0 *elb.DescribeLoadBalancerAttributesInput) (*elb.DescribeLoadBalancerAttributesOutput, error) {
@@ -360,15 +574,31 @@ func (_mr *_MockELBAPIRecorder) DescribeLoadBalancerAttributes(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancerAttributes", arg0)
 }
 
-func (_m *MockELBAPI) DescribeLoadBalancerPoliciesRequest(_param0 *elb.DescribeLoadBalancerPoliciesInput) (*request.Request, *elb.DescribeLoadBalancerPoliciesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeLoadBalancerPoliciesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.DescribeLoadBalancerPoliciesOutput)
+func (_m *MockELBAPI) DescribeLoadBalancerAttributesWithContext(_param0 aws.Context, _param1 *elb.DescribeLoadBalancerAttributesInput, _param2 ...request.Option) (*elb.DescribeLoadBalancerAttributesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeLoadBalancerAttributesWithContext", _s...)
+	ret0, _ := ret[0].(*elb.DescribeLoadBalancerAttributesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) DescribeLoadBalancerPoliciesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancerPoliciesRequest", arg0)
+func (_mr *_MockELBAPIRecorder) DescribeLoadBalancerAttributesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancerAttributesWithContext", _s...)
+}
+
+func (_m *MockELBAPI) DescribeLoadBalancerAttributesRequest(_param0 *elb.DescribeLoadBalancerAttributesInput) (*request.Request, *elb.DescribeLoadBalancerAttributesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeLoadBalancerAttributesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.DescribeLoadBalancerAttributesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) DescribeLoadBalancerAttributesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancerAttributesRequest", arg0)
 }
 
 func (_m *MockELBAPI) DescribeLoadBalancerPolicies(_param0 *elb.DescribeLoadBalancerPoliciesInput) (*elb.DescribeLoadBalancerPoliciesOutput, error) {
@@ -382,15 +612,31 @@ func (_mr *_MockELBAPIRecorder) DescribeLoadBalancerPolicies(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancerPolicies", arg0)
 }
 
-func (_m *MockELBAPI) DescribeLoadBalancerPolicyTypesRequest(_param0 *elb.DescribeLoadBalancerPolicyTypesInput) (*request.Request, *elb.DescribeLoadBalancerPolicyTypesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeLoadBalancerPolicyTypesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.DescribeLoadBalancerPolicyTypesOutput)
+func (_m *MockELBAPI) DescribeLoadBalancerPoliciesWithContext(_param0 aws.Context, _param1 *elb.DescribeLoadBalancerPoliciesInput, _param2 ...request.Option) (*elb.DescribeLoadBalancerPoliciesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeLoadBalancerPoliciesWithContext", _s...)
+	ret0, _ := ret[0].(*elb.DescribeLoadBalancerPoliciesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) DescribeLoadBalancerPolicyTypesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancerPolicyTypesRequest", arg0)
+func (_mr *_MockELBAPIRecorder) DescribeLoadBalancerPoliciesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancerPoliciesWithContext", _s...)
+}
+
+func (_m *MockELBAPI) DescribeLoadBalancerPoliciesRequest(_param0 *elb.DescribeLoadBalancerPoliciesInput) (*request.Request, *elb.DescribeLoadBalancerPoliciesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeLoadBalancerPoliciesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.DescribeLoadBalancerPoliciesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) DescribeLoadBalancerPoliciesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancerPoliciesRequest", arg0)
 }
 
 func (_m *MockELBAPI) DescribeLoadBalancerPolicyTypes(_param0 *elb.DescribeLoadBalancerPolicyTypesInput) (*elb.DescribeLoadBalancerPolicyTypesOutput, error) {
@@ -404,15 +650,31 @@ func (_mr *_MockELBAPIRecorder) DescribeLoadBalancerPolicyTypes(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancerPolicyTypes", arg0)
 }
 
-func (_m *MockELBAPI) DescribeLoadBalancersRequest(_param0 *elb.DescribeLoadBalancersInput) (*request.Request, *elb.DescribeLoadBalancersOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeLoadBalancersRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.DescribeLoadBalancersOutput)
+func (_m *MockELBAPI) DescribeLoadBalancerPolicyTypesWithContext(_param0 aws.Context, _param1 *elb.DescribeLoadBalancerPolicyTypesInput, _param2 ...request.Option) (*elb.DescribeLoadBalancerPolicyTypesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeLoadBalancerPolicyTypesWithContext", _s...)
+	ret0, _ := ret[0].(*elb.DescribeLoadBalancerPolicyTypesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) DescribeLoadBalancersRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancersRequest", arg0)
+func (_mr *_MockELBAPIRecorder) DescribeLoadBalancerPolicyTypesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancerPolicyTypesWithContext", _s...)
+}
+
+func (_m *MockELBAPI) DescribeLoadBalancerPolicyTypesRequest(_param0 *elb.DescribeLoadBalancerPolicyTypesInput) (*request.Request, *elb.DescribeLoadBalancerPolicyTypesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeLoadBalancerPolicyTypesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.DescribeLoadBalancerPolicyTypesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) DescribeLoadBalancerPolicyTypesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancerPolicyTypesRequest", arg0)
 }
 
 func (_m *MockELBAPI) DescribeLoadBalancers(_param0 *elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error) {
@@ -426,6 +688,33 @@ func (_mr *_MockELBAPIRecorder) DescribeLoadBalancers(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancers", arg0)
 }
 
+func (_m *MockELBAPI) DescribeLoadBalancersWithContext(_param0 aws.Context, _param1 *elb.DescribeLoadBalancersInput, _param2 ...request.Option) (*elb.DescribeLoadBalancersOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeLoadBalancersWithContext", _s...)
+	ret0, _ := ret[0].(*elb.DescribeLoadBalancersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) DescribeLoadBalancersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancersWithContext", _s...)
+}
+
+func (_m *MockELBAPI) DescribeLoadBalancersRequest(_param0 *elb.DescribeLoadBalancersInput) (*request.Request, *elb.DescribeLoadBalancersOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeLoadBalancersRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.DescribeLoadBalancersOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) DescribeLoadBalancersRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancersRequest", arg0)
+}
+
 func (_m *MockELBAPI) DescribeLoadBalancersPages(_param0 *elb.DescribeLoadBalancersInput, _param1 func(*elb.DescribeLoadBalancersOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeLoadBalancersPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -436,15 +725,19 @@ func (_mr *_MockELBAPIRecorder) DescribeLoadBalancersPages(arg0, arg1 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancersPages", arg0, arg1)
 }
 
-func (_m *MockELBAPI) DescribeTagsRequest(_param0 *elb.DescribeTagsInput) (*request.Request, *elb.DescribeTagsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeTagsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.DescribeTagsOutput)
-	return ret0, ret1
+func (_m *MockELBAPI) DescribeLoadBalancersPagesWithContext(_param0 aws.Context, _param1 *elb.DescribeLoadBalancersInput, _param2 func(*elb.DescribeLoadBalancersOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeLoadBalancersPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockELBAPIRecorder) DescribeTagsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTagsRequest", arg0)
+func (_mr *_MockELBAPIRecorder) DescribeLoadBalancersPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancersPagesWithContext", _s...)
 }
 
 func (_m *MockELBAPI) DescribeTags(_param0 *elb.DescribeTagsInput) (*elb.DescribeTagsOutput, error) {
@@ -458,15 +751,31 @@ func (_mr *_MockELBAPIRecorder) DescribeTags(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTags", arg0)
 }
 
-func (_m *MockELBAPI) DetachLoadBalancerFromSubnetsRequest(_param0 *elb.DetachLoadBalancerFromSubnetsInput) (*request.Request, *elb.DetachLoadBalancerFromSubnetsOutput) {
-	ret := _m.ctrl.Call(_m, "DetachLoadBalancerFromSubnetsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.DetachLoadBalancerFromSubnetsOutput)
+func (_m *MockELBAPI) DescribeTagsWithContext(_param0 aws.Context, _param1 *elb.DescribeTagsInput, _param2 ...request.Option) (*elb.DescribeTagsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeTagsWithContext", _s...)
+	ret0, _ := ret[0].(*elb.DescribeTagsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) DetachLoadBalancerFromSubnetsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachLoadBalancerFromSubnetsRequest", arg0)
+func (_mr *_MockELBAPIRecorder) DescribeTagsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTagsWithContext", _s...)
+}
+
+func (_m *MockELBAPI) DescribeTagsRequest(_param0 *elb.DescribeTagsInput) (*request.Request, *elb.DescribeTagsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeTagsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.DescribeTagsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) DescribeTagsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTagsRequest", arg0)
 }
 
 func (_m *MockELBAPI) DetachLoadBalancerFromSubnets(_param0 *elb.DetachLoadBalancerFromSubnetsInput) (*elb.DetachLoadBalancerFromSubnetsOutput, error) {
@@ -480,15 +789,31 @@ func (_mr *_MockELBAPIRecorder) DetachLoadBalancerFromSubnets(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachLoadBalancerFromSubnets", arg0)
 }
 
-func (_m *MockELBAPI) DisableAvailabilityZonesForLoadBalancerRequest(_param0 *elb.DisableAvailabilityZonesForLoadBalancerInput) (*request.Request, *elb.DisableAvailabilityZonesForLoadBalancerOutput) {
-	ret := _m.ctrl.Call(_m, "DisableAvailabilityZonesForLoadBalancerRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.DisableAvailabilityZonesForLoadBalancerOutput)
+func (_m *MockELBAPI) DetachLoadBalancerFromSubnetsWithContext(_param0 aws.Context, _param1 *elb.DetachLoadBalancerFromSubnetsInput, _param2 ...request.Option) (*elb.DetachLoadBalancerFromSubnetsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DetachLoadBalancerFromSubnetsWithContext", _s...)
+	ret0, _ := ret[0].(*elb.DetachLoadBalancerFromSubnetsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) DisableAvailabilityZonesForLoadBalancerRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisableAvailabilityZonesForLoadBalancerRequest", arg0)
+func (_mr *_MockELBAPIRecorder) DetachLoadBalancerFromSubnetsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachLoadBalancerFromSubnetsWithContext", _s...)
+}
+
+func (_m *MockELBAPI) DetachLoadBalancerFromSubnetsRequest(_param0 *elb.DetachLoadBalancerFromSubnetsInput) (*request.Request, *elb.DetachLoadBalancerFromSubnetsOutput) {
+	ret := _m.ctrl.Call(_m, "DetachLoadBalancerFromSubnetsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.DetachLoadBalancerFromSubnetsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) DetachLoadBalancerFromSubnetsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachLoadBalancerFromSubnetsRequest", arg0)
 }
 
 func (_m *MockELBAPI) DisableAvailabilityZonesForLoadBalancer(_param0 *elb.DisableAvailabilityZonesForLoadBalancerInput) (*elb.DisableAvailabilityZonesForLoadBalancerOutput, error) {
@@ -502,15 +827,31 @@ func (_mr *_MockELBAPIRecorder) DisableAvailabilityZonesForLoadBalancer(arg0 int
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisableAvailabilityZonesForLoadBalancer", arg0)
 }
 
-func (_m *MockELBAPI) EnableAvailabilityZonesForLoadBalancerRequest(_param0 *elb.EnableAvailabilityZonesForLoadBalancerInput) (*request.Request, *elb.EnableAvailabilityZonesForLoadBalancerOutput) {
-	ret := _m.ctrl.Call(_m, "EnableAvailabilityZonesForLoadBalancerRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.EnableAvailabilityZonesForLoadBalancerOutput)
+func (_m *MockELBAPI) DisableAvailabilityZonesForLoadBalancerWithContext(_param0 aws.Context, _param1 *elb.DisableAvailabilityZonesForLoadBalancerInput, _param2 ...request.Option) (*elb.DisableAvailabilityZonesForLoadBalancerOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DisableAvailabilityZonesForLoadBalancerWithContext", _s...)
+	ret0, _ := ret[0].(*elb.DisableAvailabilityZonesForLoadBalancerOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) EnableAvailabilityZonesForLoadBalancerRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableAvailabilityZonesForLoadBalancerRequest", arg0)
+func (_mr *_MockELBAPIRecorder) DisableAvailabilityZonesForLoadBalancerWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisableAvailabilityZonesForLoadBalancerWithContext", _s...)
+}
+
+func (_m *MockELBAPI) DisableAvailabilityZonesForLoadBalancerRequest(_param0 *elb.DisableAvailabilityZonesForLoadBalancerInput) (*request.Request, *elb.DisableAvailabilityZonesForLoadBalancerOutput) {
+	ret := _m.ctrl.Call(_m, "DisableAvailabilityZonesForLoadBalancerRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.DisableAvailabilityZonesForLoadBalancerOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) DisableAvailabilityZonesForLoadBalancerRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisableAvailabilityZonesForLoadBalancerRequest", arg0)
 }
 
 func (_m *MockELBAPI) EnableAvailabilityZonesForLoadBalancer(_param0 *elb.EnableAvailabilityZonesForLoadBalancerInput) (*elb.EnableAvailabilityZonesForLoadBalancerOutput, error) {
@@ -524,15 +865,31 @@ func (_mr *_MockELBAPIRecorder) EnableAvailabilityZonesForLoadBalancer(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableAvailabilityZonesForLoadBalancer", arg0)
 }
 
-func (_m *MockELBAPI) ModifyLoadBalancerAttributesRequest(_param0 *elb.ModifyLoadBalancerAttributesInput) (*request.Request, *elb.ModifyLoadBalancerAttributesOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyLoadBalancerAttributesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.ModifyLoadBalancerAttributesOutput)
+func (_m *MockELBAPI) EnableAvailabilityZonesForLoadBalancerWithContext(_param0 aws.Context, _param1 *elb.EnableAvailabilityZonesForLoadBalancerInput, _param2 ...request.Option) (*elb.EnableAvailabilityZonesForLoadBalancerOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "EnableAvailabilityZonesForLoadBalancerWithContext", _s...)
+	ret0, _ := ret[0].(*elb.EnableAvailabilityZonesForLoadBalancerOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) ModifyLoadBalancerAttributesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyLoadBalancerAttributesRequest", arg0)
+func (_mr *_MockELBAPIRecorder) EnableAvailabilityZonesForLoadBalancerWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableAvailabilityZonesForLoadBalancerWithContext", _s...)
+}
+
+func (_m *MockELBAPI) EnableAvailabilityZonesForLoadBalancerRequest(_param0 *elb.EnableAvailabilityZonesForLoadBalancerInput) (*request.Request, *elb.EnableAvailabilityZonesForLoadBalancerOutput) {
+	ret := _m.ctrl.Call(_m, "EnableAvailabilityZonesForLoadBalancerRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.EnableAvailabilityZonesForLoadBalancerOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) EnableAvailabilityZonesForLoadBalancerRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableAvailabilityZonesForLoadBalancerRequest", arg0)
 }
 
 func (_m *MockELBAPI) ModifyLoadBalancerAttributes(_param0 *elb.ModifyLoadBalancerAttributesInput) (*elb.ModifyLoadBalancerAttributesOutput, error) {
@@ -546,15 +903,31 @@ func (_mr *_MockELBAPIRecorder) ModifyLoadBalancerAttributes(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyLoadBalancerAttributes", arg0)
 }
 
-func (_m *MockELBAPI) RegisterInstancesWithLoadBalancerRequest(_param0 *elb.RegisterInstancesWithLoadBalancerInput) (*request.Request, *elb.RegisterInstancesWithLoadBalancerOutput) {
-	ret := _m.ctrl.Call(_m, "RegisterInstancesWithLoadBalancerRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.RegisterInstancesWithLoadBalancerOutput)
+func (_m *MockELBAPI) ModifyLoadBalancerAttributesWithContext(_param0 aws.Context, _param1 *elb.ModifyLoadBalancerAttributesInput, _param2 ...request.Option) (*elb.ModifyLoadBalancerAttributesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyLoadBalancerAttributesWithContext", _s...)
+	ret0, _ := ret[0].(*elb.ModifyLoadBalancerAttributesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) RegisterInstancesWithLoadBalancerRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RegisterInstancesWithLoadBalancerRequest", arg0)
+func (_mr *_MockELBAPIRecorder) ModifyLoadBalancerAttributesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyLoadBalancerAttributesWithContext", _s...)
+}
+
+func (_m *MockELBAPI) ModifyLoadBalancerAttributesRequest(_param0 *elb.ModifyLoadBalancerAttributesInput) (*request.Request, *elb.ModifyLoadBalancerAttributesOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyLoadBalancerAttributesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.ModifyLoadBalancerAttributesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) ModifyLoadBalancerAttributesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyLoadBalancerAttributesRequest", arg0)
 }
 
 func (_m *MockELBAPI) RegisterInstancesWithLoadBalancer(_param0 *elb.RegisterInstancesWithLoadBalancerInput) (*elb.RegisterInstancesWithLoadBalancerOutput, error) {
@@ -568,15 +941,31 @@ func (_mr *_MockELBAPIRecorder) RegisterInstancesWithLoadBalancer(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RegisterInstancesWithLoadBalancer", arg0)
 }
 
-func (_m *MockELBAPI) RemoveTagsRequest(_param0 *elb.RemoveTagsInput) (*request.Request, *elb.RemoveTagsOutput) {
-	ret := _m.ctrl.Call(_m, "RemoveTagsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.RemoveTagsOutput)
+func (_m *MockELBAPI) RegisterInstancesWithLoadBalancerWithContext(_param0 aws.Context, _param1 *elb.RegisterInstancesWithLoadBalancerInput, _param2 ...request.Option) (*elb.RegisterInstancesWithLoadBalancerOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RegisterInstancesWithLoadBalancerWithContext", _s...)
+	ret0, _ := ret[0].(*elb.RegisterInstancesWithLoadBalancerOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) RemoveTagsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveTagsRequest", arg0)
+func (_mr *_MockELBAPIRecorder) RegisterInstancesWithLoadBalancerWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RegisterInstancesWithLoadBalancerWithContext", _s...)
+}
+
+func (_m *MockELBAPI) RegisterInstancesWithLoadBalancerRequest(_param0 *elb.RegisterInstancesWithLoadBalancerInput) (*request.Request, *elb.RegisterInstancesWithLoadBalancerOutput) {
+	ret := _m.ctrl.Call(_m, "RegisterInstancesWithLoadBalancerRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.RegisterInstancesWithLoadBalancerOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) RegisterInstancesWithLoadBalancerRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RegisterInstancesWithLoadBalancerRequest", arg0)
 }
 
 func (_m *MockELBAPI) RemoveTags(_param0 *elb.RemoveTagsInput) (*elb.RemoveTagsOutput, error) {
@@ -590,15 +979,31 @@ func (_mr *_MockELBAPIRecorder) RemoveTags(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveTags", arg0)
 }
 
-func (_m *MockELBAPI) SetLoadBalancerListenerSSLCertificateRequest(_param0 *elb.SetLoadBalancerListenerSSLCertificateInput) (*request.Request, *elb.SetLoadBalancerListenerSSLCertificateOutput) {
-	ret := _m.ctrl.Call(_m, "SetLoadBalancerListenerSSLCertificateRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.SetLoadBalancerListenerSSLCertificateOutput)
+func (_m *MockELBAPI) RemoveTagsWithContext(_param0 aws.Context, _param1 *elb.RemoveTagsInput, _param2 ...request.Option) (*elb.RemoveTagsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RemoveTagsWithContext", _s...)
+	ret0, _ := ret[0].(*elb.RemoveTagsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) SetLoadBalancerListenerSSLCertificateRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetLoadBalancerListenerSSLCertificateRequest", arg0)
+func (_mr *_MockELBAPIRecorder) RemoveTagsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveTagsWithContext", _s...)
+}
+
+func (_m *MockELBAPI) RemoveTagsRequest(_param0 *elb.RemoveTagsInput) (*request.Request, *elb.RemoveTagsOutput) {
+	ret := _m.ctrl.Call(_m, "RemoveTagsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.RemoveTagsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) RemoveTagsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveTagsRequest", arg0)
 }
 
 func (_m *MockELBAPI) SetLoadBalancerListenerSSLCertificate(_param0 *elb.SetLoadBalancerListenerSSLCertificateInput) (*elb.SetLoadBalancerListenerSSLCertificateOutput, error) {
@@ -612,15 +1017,31 @@ func (_mr *_MockELBAPIRecorder) SetLoadBalancerListenerSSLCertificate(arg0 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetLoadBalancerListenerSSLCertificate", arg0)
 }
 
-func (_m *MockELBAPI) SetLoadBalancerPoliciesForBackendServerRequest(_param0 *elb.SetLoadBalancerPoliciesForBackendServerInput) (*request.Request, *elb.SetLoadBalancerPoliciesForBackendServerOutput) {
-	ret := _m.ctrl.Call(_m, "SetLoadBalancerPoliciesForBackendServerRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.SetLoadBalancerPoliciesForBackendServerOutput)
+func (_m *MockELBAPI) SetLoadBalancerListenerSSLCertificateWithContext(_param0 aws.Context, _param1 *elb.SetLoadBalancerListenerSSLCertificateInput, _param2 ...request.Option) (*elb.SetLoadBalancerListenerSSLCertificateOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "SetLoadBalancerListenerSSLCertificateWithContext", _s...)
+	ret0, _ := ret[0].(*elb.SetLoadBalancerListenerSSLCertificateOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) SetLoadBalancerPoliciesForBackendServerRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetLoadBalancerPoliciesForBackendServerRequest", arg0)
+func (_mr *_MockELBAPIRecorder) SetLoadBalancerListenerSSLCertificateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetLoadBalancerListenerSSLCertificateWithContext", _s...)
+}
+
+func (_m *MockELBAPI) SetLoadBalancerListenerSSLCertificateRequest(_param0 *elb.SetLoadBalancerListenerSSLCertificateInput) (*request.Request, *elb.SetLoadBalancerListenerSSLCertificateOutput) {
+	ret := _m.ctrl.Call(_m, "SetLoadBalancerListenerSSLCertificateRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.SetLoadBalancerListenerSSLCertificateOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) SetLoadBalancerListenerSSLCertificateRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetLoadBalancerListenerSSLCertificateRequest", arg0)
 }
 
 func (_m *MockELBAPI) SetLoadBalancerPoliciesForBackendServer(_param0 *elb.SetLoadBalancerPoliciesForBackendServerInput) (*elb.SetLoadBalancerPoliciesForBackendServerOutput, error) {
@@ -634,15 +1055,31 @@ func (_mr *_MockELBAPIRecorder) SetLoadBalancerPoliciesForBackendServer(arg0 int
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetLoadBalancerPoliciesForBackendServer", arg0)
 }
 
-func (_m *MockELBAPI) SetLoadBalancerPoliciesOfListenerRequest(_param0 *elb.SetLoadBalancerPoliciesOfListenerInput) (*request.Request, *elb.SetLoadBalancerPoliciesOfListenerOutput) {
-	ret := _m.ctrl.Call(_m, "SetLoadBalancerPoliciesOfListenerRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elb.SetLoadBalancerPoliciesOfListenerOutput)
+func (_m *MockELBAPI) SetLoadBalancerPoliciesForBackendServerWithContext(_param0 aws.Context, _param1 *elb.SetLoadBalancerPoliciesForBackendServerInput, _param2 ...request.Option) (*elb.SetLoadBalancerPoliciesForBackendServerOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "SetLoadBalancerPoliciesForBackendServerWithContext", _s...)
+	ret0, _ := ret[0].(*elb.SetLoadBalancerPoliciesForBackendServerOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBAPIRecorder) SetLoadBalancerPoliciesOfListenerRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetLoadBalancerPoliciesOfListenerRequest", arg0)
+func (_mr *_MockELBAPIRecorder) SetLoadBalancerPoliciesForBackendServerWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetLoadBalancerPoliciesForBackendServerWithContext", _s...)
+}
+
+func (_m *MockELBAPI) SetLoadBalancerPoliciesForBackendServerRequest(_param0 *elb.SetLoadBalancerPoliciesForBackendServerInput) (*request.Request, *elb.SetLoadBalancerPoliciesForBackendServerOutput) {
+	ret := _m.ctrl.Call(_m, "SetLoadBalancerPoliciesForBackendServerRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.SetLoadBalancerPoliciesForBackendServerOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) SetLoadBalancerPoliciesForBackendServerRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetLoadBalancerPoliciesForBackendServerRequest", arg0)
 }
 
 func (_m *MockELBAPI) SetLoadBalancerPoliciesOfListener(_param0 *elb.SetLoadBalancerPoliciesOfListenerInput) (*elb.SetLoadBalancerPoliciesOfListenerOutput, error) {
@@ -656,6 +1093,33 @@ func (_mr *_MockELBAPIRecorder) SetLoadBalancerPoliciesOfListener(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetLoadBalancerPoliciesOfListener", arg0)
 }
 
+func (_m *MockELBAPI) SetLoadBalancerPoliciesOfListenerWithContext(_param0 aws.Context, _param1 *elb.SetLoadBalancerPoliciesOfListenerInput, _param2 ...request.Option) (*elb.SetLoadBalancerPoliciesOfListenerOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "SetLoadBalancerPoliciesOfListenerWithContext", _s...)
+	ret0, _ := ret[0].(*elb.SetLoadBalancerPoliciesOfListenerOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) SetLoadBalancerPoliciesOfListenerWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetLoadBalancerPoliciesOfListenerWithContext", _s...)
+}
+
+func (_m *MockELBAPI) SetLoadBalancerPoliciesOfListenerRequest(_param0 *elb.SetLoadBalancerPoliciesOfListenerInput) (*request.Request, *elb.SetLoadBalancerPoliciesOfListenerOutput) {
+	ret := _m.ctrl.Call(_m, "SetLoadBalancerPoliciesOfListenerRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elb.SetLoadBalancerPoliciesOfListenerOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBAPIRecorder) SetLoadBalancerPoliciesOfListenerRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetLoadBalancerPoliciesOfListenerRequest", arg0)
+}
+
 func (_m *MockELBAPI) WaitUntilAnyInstanceInService(_param0 *elb.DescribeInstanceHealthInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilAnyInstanceInService", _param0)
 	ret0, _ := ret[0].(error)
@@ -664,6 +1128,21 @@ func (_m *MockELBAPI) WaitUntilAnyInstanceInService(_param0 *elb.DescribeInstanc
 
 func (_mr *_MockELBAPIRecorder) WaitUntilAnyInstanceInService(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilAnyInstanceInService", arg0)
+}
+
+func (_m *MockELBAPI) WaitUntilAnyInstanceInServiceWithContext(_param0 aws.Context, _param1 *elb.DescribeInstanceHealthInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilAnyInstanceInServiceWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockELBAPIRecorder) WaitUntilAnyInstanceInServiceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilAnyInstanceInServiceWithContext", _s...)
 }
 
 func (_m *MockELBAPI) WaitUntilInstanceDeregistered(_param0 *elb.DescribeInstanceHealthInput) error {
@@ -676,6 +1155,21 @@ func (_mr *_MockELBAPIRecorder) WaitUntilInstanceDeregistered(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceDeregistered", arg0)
 }
 
+func (_m *MockELBAPI) WaitUntilInstanceDeregisteredWithContext(_param0 aws.Context, _param1 *elb.DescribeInstanceHealthInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilInstanceDeregisteredWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockELBAPIRecorder) WaitUntilInstanceDeregisteredWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceDeregisteredWithContext", _s...)
+}
+
 func (_m *MockELBAPI) WaitUntilInstanceInService(_param0 *elb.DescribeInstanceHealthInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilInstanceInService", _param0)
 	ret0, _ := ret[0].(error)
@@ -684,4 +1178,19 @@ func (_m *MockELBAPI) WaitUntilInstanceInService(_param0 *elb.DescribeInstanceHe
 
 func (_mr *_MockELBAPIRecorder) WaitUntilInstanceInService(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceInService", arg0)
+}
+
+func (_m *MockELBAPI) WaitUntilInstanceInServiceWithContext(_param0 aws.Context, _param1 *elb.DescribeInstanceHealthInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilInstanceInServiceWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockELBAPIRecorder) WaitUntilInstanceInServiceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceInServiceWithContext", _s...)
 }

--- a/mock/elbv2mock.go
+++ b/mock/elbv2mock.go
@@ -4,6 +4,7 @@
 package mock
 
 import (
+	aws "github.com/aws/aws-sdk-go/aws"
 	request "github.com/aws/aws-sdk-go/aws/request"
 	elbv2 "github.com/aws/aws-sdk-go/service/elbv2"
 	gomock "github.com/golang/mock/gomock"
@@ -30,17 +31,6 @@ func (_m *MockELBV2API) EXPECT() *_MockELBV2APIRecorder {
 	return _m.recorder
 }
 
-func (_m *MockELBV2API) AddTagsRequest(_param0 *elbv2.AddTagsInput) (*request.Request, *elbv2.AddTagsOutput) {
-	ret := _m.ctrl.Call(_m, "AddTagsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.AddTagsOutput)
-	return ret0, ret1
-}
-
-func (_mr *_MockELBV2APIRecorder) AddTagsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddTagsRequest", arg0)
-}
-
 func (_m *MockELBV2API) AddTags(_param0 *elbv2.AddTagsInput) (*elbv2.AddTagsOutput, error) {
 	ret := _m.ctrl.Call(_m, "AddTags", _param0)
 	ret0, _ := ret[0].(*elbv2.AddTagsOutput)
@@ -52,15 +42,31 @@ func (_mr *_MockELBV2APIRecorder) AddTags(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddTags", arg0)
 }
 
-func (_m *MockELBV2API) CreateListenerRequest(_param0 *elbv2.CreateListenerInput) (*request.Request, *elbv2.CreateListenerOutput) {
-	ret := _m.ctrl.Call(_m, "CreateListenerRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.CreateListenerOutput)
+func (_m *MockELBV2API) AddTagsWithContext(_param0 aws.Context, _param1 *elbv2.AddTagsInput, _param2 ...request.Option) (*elbv2.AddTagsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AddTagsWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.AddTagsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) CreateListenerRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateListenerRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) AddTagsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddTagsWithContext", _s...)
+}
+
+func (_m *MockELBV2API) AddTagsRequest(_param0 *elbv2.AddTagsInput) (*request.Request, *elbv2.AddTagsOutput) {
+	ret := _m.ctrl.Call(_m, "AddTagsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.AddTagsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) AddTagsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddTagsRequest", arg0)
 }
 
 func (_m *MockELBV2API) CreateListener(_param0 *elbv2.CreateListenerInput) (*elbv2.CreateListenerOutput, error) {
@@ -74,15 +80,31 @@ func (_mr *_MockELBV2APIRecorder) CreateListener(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateListener", arg0)
 }
 
-func (_m *MockELBV2API) CreateLoadBalancerRequest(_param0 *elbv2.CreateLoadBalancerInput) (*request.Request, *elbv2.CreateLoadBalancerOutput) {
-	ret := _m.ctrl.Call(_m, "CreateLoadBalancerRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.CreateLoadBalancerOutput)
+func (_m *MockELBV2API) CreateListenerWithContext(_param0 aws.Context, _param1 *elbv2.CreateListenerInput, _param2 ...request.Option) (*elbv2.CreateListenerOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateListenerWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.CreateListenerOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) CreateLoadBalancerRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancerRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) CreateListenerWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateListenerWithContext", _s...)
+}
+
+func (_m *MockELBV2API) CreateListenerRequest(_param0 *elbv2.CreateListenerInput) (*request.Request, *elbv2.CreateListenerOutput) {
+	ret := _m.ctrl.Call(_m, "CreateListenerRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.CreateListenerOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) CreateListenerRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateListenerRequest", arg0)
 }
 
 func (_m *MockELBV2API) CreateLoadBalancer(_param0 *elbv2.CreateLoadBalancerInput) (*elbv2.CreateLoadBalancerOutput, error) {
@@ -96,15 +118,31 @@ func (_mr *_MockELBV2APIRecorder) CreateLoadBalancer(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancer", arg0)
 }
 
-func (_m *MockELBV2API) CreateRuleRequest(_param0 *elbv2.CreateRuleInput) (*request.Request, *elbv2.CreateRuleOutput) {
-	ret := _m.ctrl.Call(_m, "CreateRuleRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.CreateRuleOutput)
+func (_m *MockELBV2API) CreateLoadBalancerWithContext(_param0 aws.Context, _param1 *elbv2.CreateLoadBalancerInput, _param2 ...request.Option) (*elbv2.CreateLoadBalancerOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateLoadBalancerWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.CreateLoadBalancerOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) CreateRuleRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateRuleRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) CreateLoadBalancerWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancerWithContext", _s...)
+}
+
+func (_m *MockELBV2API) CreateLoadBalancerRequest(_param0 *elbv2.CreateLoadBalancerInput) (*request.Request, *elbv2.CreateLoadBalancerOutput) {
+	ret := _m.ctrl.Call(_m, "CreateLoadBalancerRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.CreateLoadBalancerOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) CreateLoadBalancerRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoadBalancerRequest", arg0)
 }
 
 func (_m *MockELBV2API) CreateRule(_param0 *elbv2.CreateRuleInput) (*elbv2.CreateRuleOutput, error) {
@@ -118,15 +156,31 @@ func (_mr *_MockELBV2APIRecorder) CreateRule(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateRule", arg0)
 }
 
-func (_m *MockELBV2API) CreateTargetGroupRequest(_param0 *elbv2.CreateTargetGroupInput) (*request.Request, *elbv2.CreateTargetGroupOutput) {
-	ret := _m.ctrl.Call(_m, "CreateTargetGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.CreateTargetGroupOutput)
+func (_m *MockELBV2API) CreateRuleWithContext(_param0 aws.Context, _param1 *elbv2.CreateRuleInput, _param2 ...request.Option) (*elbv2.CreateRuleOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateRuleWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.CreateRuleOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) CreateTargetGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateTargetGroupRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) CreateRuleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateRuleWithContext", _s...)
+}
+
+func (_m *MockELBV2API) CreateRuleRequest(_param0 *elbv2.CreateRuleInput) (*request.Request, *elbv2.CreateRuleOutput) {
+	ret := _m.ctrl.Call(_m, "CreateRuleRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.CreateRuleOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) CreateRuleRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateRuleRequest", arg0)
 }
 
 func (_m *MockELBV2API) CreateTargetGroup(_param0 *elbv2.CreateTargetGroupInput) (*elbv2.CreateTargetGroupOutput, error) {
@@ -140,15 +194,31 @@ func (_mr *_MockELBV2APIRecorder) CreateTargetGroup(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateTargetGroup", arg0)
 }
 
-func (_m *MockELBV2API) DeleteListenerRequest(_param0 *elbv2.DeleteListenerInput) (*request.Request, *elbv2.DeleteListenerOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteListenerRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.DeleteListenerOutput)
+func (_m *MockELBV2API) CreateTargetGroupWithContext(_param0 aws.Context, _param1 *elbv2.CreateTargetGroupInput, _param2 ...request.Option) (*elbv2.CreateTargetGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateTargetGroupWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.CreateTargetGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) DeleteListenerRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteListenerRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) CreateTargetGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateTargetGroupWithContext", _s...)
+}
+
+func (_m *MockELBV2API) CreateTargetGroupRequest(_param0 *elbv2.CreateTargetGroupInput) (*request.Request, *elbv2.CreateTargetGroupOutput) {
+	ret := _m.ctrl.Call(_m, "CreateTargetGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.CreateTargetGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) CreateTargetGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateTargetGroupRequest", arg0)
 }
 
 func (_m *MockELBV2API) DeleteListener(_param0 *elbv2.DeleteListenerInput) (*elbv2.DeleteListenerOutput, error) {
@@ -162,15 +232,31 @@ func (_mr *_MockELBV2APIRecorder) DeleteListener(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteListener", arg0)
 }
 
-func (_m *MockELBV2API) DeleteLoadBalancerRequest(_param0 *elbv2.DeleteLoadBalancerInput) (*request.Request, *elbv2.DeleteLoadBalancerOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteLoadBalancerRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.DeleteLoadBalancerOutput)
+func (_m *MockELBV2API) DeleteListenerWithContext(_param0 aws.Context, _param1 *elbv2.DeleteListenerInput, _param2 ...request.Option) (*elbv2.DeleteListenerOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteListenerWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.DeleteListenerOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) DeleteLoadBalancerRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoadBalancerRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) DeleteListenerWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteListenerWithContext", _s...)
+}
+
+func (_m *MockELBV2API) DeleteListenerRequest(_param0 *elbv2.DeleteListenerInput) (*request.Request, *elbv2.DeleteListenerOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteListenerRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.DeleteListenerOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) DeleteListenerRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteListenerRequest", arg0)
 }
 
 func (_m *MockELBV2API) DeleteLoadBalancer(_param0 *elbv2.DeleteLoadBalancerInput) (*elbv2.DeleteLoadBalancerOutput, error) {
@@ -184,15 +270,31 @@ func (_mr *_MockELBV2APIRecorder) DeleteLoadBalancer(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoadBalancer", arg0)
 }
 
-func (_m *MockELBV2API) DeleteRuleRequest(_param0 *elbv2.DeleteRuleInput) (*request.Request, *elbv2.DeleteRuleOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteRuleRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.DeleteRuleOutput)
+func (_m *MockELBV2API) DeleteLoadBalancerWithContext(_param0 aws.Context, _param1 *elbv2.DeleteLoadBalancerInput, _param2 ...request.Option) (*elbv2.DeleteLoadBalancerOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteLoadBalancerWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.DeleteLoadBalancerOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) DeleteRuleRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRuleRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) DeleteLoadBalancerWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoadBalancerWithContext", _s...)
+}
+
+func (_m *MockELBV2API) DeleteLoadBalancerRequest(_param0 *elbv2.DeleteLoadBalancerInput) (*request.Request, *elbv2.DeleteLoadBalancerOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteLoadBalancerRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.DeleteLoadBalancerOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) DeleteLoadBalancerRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoadBalancerRequest", arg0)
 }
 
 func (_m *MockELBV2API) DeleteRule(_param0 *elbv2.DeleteRuleInput) (*elbv2.DeleteRuleOutput, error) {
@@ -206,15 +308,31 @@ func (_mr *_MockELBV2APIRecorder) DeleteRule(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRule", arg0)
 }
 
-func (_m *MockELBV2API) DeleteTargetGroupRequest(_param0 *elbv2.DeleteTargetGroupInput) (*request.Request, *elbv2.DeleteTargetGroupOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteTargetGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.DeleteTargetGroupOutput)
+func (_m *MockELBV2API) DeleteRuleWithContext(_param0 aws.Context, _param1 *elbv2.DeleteRuleInput, _param2 ...request.Option) (*elbv2.DeleteRuleOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteRuleWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.DeleteRuleOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) DeleteTargetGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteTargetGroupRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) DeleteRuleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRuleWithContext", _s...)
+}
+
+func (_m *MockELBV2API) DeleteRuleRequest(_param0 *elbv2.DeleteRuleInput) (*request.Request, *elbv2.DeleteRuleOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteRuleRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.DeleteRuleOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) DeleteRuleRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRuleRequest", arg0)
 }
 
 func (_m *MockELBV2API) DeleteTargetGroup(_param0 *elbv2.DeleteTargetGroupInput) (*elbv2.DeleteTargetGroupOutput, error) {
@@ -228,15 +346,31 @@ func (_mr *_MockELBV2APIRecorder) DeleteTargetGroup(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteTargetGroup", arg0)
 }
 
-func (_m *MockELBV2API) DeregisterTargetsRequest(_param0 *elbv2.DeregisterTargetsInput) (*request.Request, *elbv2.DeregisterTargetsOutput) {
-	ret := _m.ctrl.Call(_m, "DeregisterTargetsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.DeregisterTargetsOutput)
+func (_m *MockELBV2API) DeleteTargetGroupWithContext(_param0 aws.Context, _param1 *elbv2.DeleteTargetGroupInput, _param2 ...request.Option) (*elbv2.DeleteTargetGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteTargetGroupWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.DeleteTargetGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) DeregisterTargetsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeregisterTargetsRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) DeleteTargetGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteTargetGroupWithContext", _s...)
+}
+
+func (_m *MockELBV2API) DeleteTargetGroupRequest(_param0 *elbv2.DeleteTargetGroupInput) (*request.Request, *elbv2.DeleteTargetGroupOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteTargetGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.DeleteTargetGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) DeleteTargetGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteTargetGroupRequest", arg0)
 }
 
 func (_m *MockELBV2API) DeregisterTargets(_param0 *elbv2.DeregisterTargetsInput) (*elbv2.DeregisterTargetsOutput, error) {
@@ -250,15 +384,31 @@ func (_mr *_MockELBV2APIRecorder) DeregisterTargets(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeregisterTargets", arg0)
 }
 
-func (_m *MockELBV2API) DescribeListenersRequest(_param0 *elbv2.DescribeListenersInput) (*request.Request, *elbv2.DescribeListenersOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeListenersRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.DescribeListenersOutput)
+func (_m *MockELBV2API) DeregisterTargetsWithContext(_param0 aws.Context, _param1 *elbv2.DeregisterTargetsInput, _param2 ...request.Option) (*elbv2.DeregisterTargetsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeregisterTargetsWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.DeregisterTargetsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) DescribeListenersRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeListenersRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) DeregisterTargetsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeregisterTargetsWithContext", _s...)
+}
+
+func (_m *MockELBV2API) DeregisterTargetsRequest(_param0 *elbv2.DeregisterTargetsInput) (*request.Request, *elbv2.DeregisterTargetsOutput) {
+	ret := _m.ctrl.Call(_m, "DeregisterTargetsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.DeregisterTargetsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) DeregisterTargetsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeregisterTargetsRequest", arg0)
 }
 
 func (_m *MockELBV2API) DescribeListeners(_param0 *elbv2.DescribeListenersInput) (*elbv2.DescribeListenersOutput, error) {
@@ -272,6 +422,33 @@ func (_mr *_MockELBV2APIRecorder) DescribeListeners(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeListeners", arg0)
 }
 
+func (_m *MockELBV2API) DescribeListenersWithContext(_param0 aws.Context, _param1 *elbv2.DescribeListenersInput, _param2 ...request.Option) (*elbv2.DescribeListenersOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeListenersWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.DescribeListenersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) DescribeListenersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeListenersWithContext", _s...)
+}
+
+func (_m *MockELBV2API) DescribeListenersRequest(_param0 *elbv2.DescribeListenersInput) (*request.Request, *elbv2.DescribeListenersOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeListenersRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.DescribeListenersOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) DescribeListenersRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeListenersRequest", arg0)
+}
+
 func (_m *MockELBV2API) DescribeListenersPages(_param0 *elbv2.DescribeListenersInput, _param1 func(*elbv2.DescribeListenersOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeListenersPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -282,15 +459,19 @@ func (_mr *_MockELBV2APIRecorder) DescribeListenersPages(arg0, arg1 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeListenersPages", arg0, arg1)
 }
 
-func (_m *MockELBV2API) DescribeLoadBalancerAttributesRequest(_param0 *elbv2.DescribeLoadBalancerAttributesInput) (*request.Request, *elbv2.DescribeLoadBalancerAttributesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeLoadBalancerAttributesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.DescribeLoadBalancerAttributesOutput)
-	return ret0, ret1
+func (_m *MockELBV2API) DescribeListenersPagesWithContext(_param0 aws.Context, _param1 *elbv2.DescribeListenersInput, _param2 func(*elbv2.DescribeListenersOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeListenersPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockELBV2APIRecorder) DescribeLoadBalancerAttributesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancerAttributesRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) DescribeListenersPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeListenersPagesWithContext", _s...)
 }
 
 func (_m *MockELBV2API) DescribeLoadBalancerAttributes(_param0 *elbv2.DescribeLoadBalancerAttributesInput) (*elbv2.DescribeLoadBalancerAttributesOutput, error) {
@@ -304,15 +485,31 @@ func (_mr *_MockELBV2APIRecorder) DescribeLoadBalancerAttributes(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancerAttributes", arg0)
 }
 
-func (_m *MockELBV2API) DescribeLoadBalancersRequest(_param0 *elbv2.DescribeLoadBalancersInput) (*request.Request, *elbv2.DescribeLoadBalancersOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeLoadBalancersRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.DescribeLoadBalancersOutput)
+func (_m *MockELBV2API) DescribeLoadBalancerAttributesWithContext(_param0 aws.Context, _param1 *elbv2.DescribeLoadBalancerAttributesInput, _param2 ...request.Option) (*elbv2.DescribeLoadBalancerAttributesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeLoadBalancerAttributesWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.DescribeLoadBalancerAttributesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) DescribeLoadBalancersRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancersRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) DescribeLoadBalancerAttributesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancerAttributesWithContext", _s...)
+}
+
+func (_m *MockELBV2API) DescribeLoadBalancerAttributesRequest(_param0 *elbv2.DescribeLoadBalancerAttributesInput) (*request.Request, *elbv2.DescribeLoadBalancerAttributesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeLoadBalancerAttributesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.DescribeLoadBalancerAttributesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) DescribeLoadBalancerAttributesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancerAttributesRequest", arg0)
 }
 
 func (_m *MockELBV2API) DescribeLoadBalancers(_param0 *elbv2.DescribeLoadBalancersInput) (*elbv2.DescribeLoadBalancersOutput, error) {
@@ -326,6 +523,33 @@ func (_mr *_MockELBV2APIRecorder) DescribeLoadBalancers(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancers", arg0)
 }
 
+func (_m *MockELBV2API) DescribeLoadBalancersWithContext(_param0 aws.Context, _param1 *elbv2.DescribeLoadBalancersInput, _param2 ...request.Option) (*elbv2.DescribeLoadBalancersOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeLoadBalancersWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.DescribeLoadBalancersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) DescribeLoadBalancersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancersWithContext", _s...)
+}
+
+func (_m *MockELBV2API) DescribeLoadBalancersRequest(_param0 *elbv2.DescribeLoadBalancersInput) (*request.Request, *elbv2.DescribeLoadBalancersOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeLoadBalancersRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.DescribeLoadBalancersOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) DescribeLoadBalancersRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancersRequest", arg0)
+}
+
 func (_m *MockELBV2API) DescribeLoadBalancersPages(_param0 *elbv2.DescribeLoadBalancersInput, _param1 func(*elbv2.DescribeLoadBalancersOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeLoadBalancersPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -336,15 +560,19 @@ func (_mr *_MockELBV2APIRecorder) DescribeLoadBalancersPages(arg0, arg1 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancersPages", arg0, arg1)
 }
 
-func (_m *MockELBV2API) DescribeRulesRequest(_param0 *elbv2.DescribeRulesInput) (*request.Request, *elbv2.DescribeRulesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeRulesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.DescribeRulesOutput)
-	return ret0, ret1
+func (_m *MockELBV2API) DescribeLoadBalancersPagesWithContext(_param0 aws.Context, _param1 *elbv2.DescribeLoadBalancersInput, _param2 func(*elbv2.DescribeLoadBalancersOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeLoadBalancersPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockELBV2APIRecorder) DescribeRulesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeRulesRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) DescribeLoadBalancersPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeLoadBalancersPagesWithContext", _s...)
 }
 
 func (_m *MockELBV2API) DescribeRules(_param0 *elbv2.DescribeRulesInput) (*elbv2.DescribeRulesOutput, error) {
@@ -358,15 +586,31 @@ func (_mr *_MockELBV2APIRecorder) DescribeRules(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeRules", arg0)
 }
 
-func (_m *MockELBV2API) DescribeSSLPoliciesRequest(_param0 *elbv2.DescribeSSLPoliciesInput) (*request.Request, *elbv2.DescribeSSLPoliciesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeSSLPoliciesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.DescribeSSLPoliciesOutput)
+func (_m *MockELBV2API) DescribeRulesWithContext(_param0 aws.Context, _param1 *elbv2.DescribeRulesInput, _param2 ...request.Option) (*elbv2.DescribeRulesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeRulesWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.DescribeRulesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) DescribeSSLPoliciesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSSLPoliciesRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) DescribeRulesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeRulesWithContext", _s...)
+}
+
+func (_m *MockELBV2API) DescribeRulesRequest(_param0 *elbv2.DescribeRulesInput) (*request.Request, *elbv2.DescribeRulesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeRulesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.DescribeRulesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) DescribeRulesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeRulesRequest", arg0)
 }
 
 func (_m *MockELBV2API) DescribeSSLPolicies(_param0 *elbv2.DescribeSSLPoliciesInput) (*elbv2.DescribeSSLPoliciesOutput, error) {
@@ -380,15 +624,31 @@ func (_mr *_MockELBV2APIRecorder) DescribeSSLPolicies(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSSLPolicies", arg0)
 }
 
-func (_m *MockELBV2API) DescribeTagsRequest(_param0 *elbv2.DescribeTagsInput) (*request.Request, *elbv2.DescribeTagsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeTagsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.DescribeTagsOutput)
+func (_m *MockELBV2API) DescribeSSLPoliciesWithContext(_param0 aws.Context, _param1 *elbv2.DescribeSSLPoliciesInput, _param2 ...request.Option) (*elbv2.DescribeSSLPoliciesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeSSLPoliciesWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.DescribeSSLPoliciesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) DescribeTagsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTagsRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) DescribeSSLPoliciesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSSLPoliciesWithContext", _s...)
+}
+
+func (_m *MockELBV2API) DescribeSSLPoliciesRequest(_param0 *elbv2.DescribeSSLPoliciesInput) (*request.Request, *elbv2.DescribeSSLPoliciesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeSSLPoliciesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.DescribeSSLPoliciesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) DescribeSSLPoliciesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSSLPoliciesRequest", arg0)
 }
 
 func (_m *MockELBV2API) DescribeTags(_param0 *elbv2.DescribeTagsInput) (*elbv2.DescribeTagsOutput, error) {
@@ -402,15 +662,31 @@ func (_mr *_MockELBV2APIRecorder) DescribeTags(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTags", arg0)
 }
 
-func (_m *MockELBV2API) DescribeTargetGroupAttributesRequest(_param0 *elbv2.DescribeTargetGroupAttributesInput) (*request.Request, *elbv2.DescribeTargetGroupAttributesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeTargetGroupAttributesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.DescribeTargetGroupAttributesOutput)
+func (_m *MockELBV2API) DescribeTagsWithContext(_param0 aws.Context, _param1 *elbv2.DescribeTagsInput, _param2 ...request.Option) (*elbv2.DescribeTagsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeTagsWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.DescribeTagsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) DescribeTargetGroupAttributesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTargetGroupAttributesRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) DescribeTagsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTagsWithContext", _s...)
+}
+
+func (_m *MockELBV2API) DescribeTagsRequest(_param0 *elbv2.DescribeTagsInput) (*request.Request, *elbv2.DescribeTagsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeTagsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.DescribeTagsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) DescribeTagsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTagsRequest", arg0)
 }
 
 func (_m *MockELBV2API) DescribeTargetGroupAttributes(_param0 *elbv2.DescribeTargetGroupAttributesInput) (*elbv2.DescribeTargetGroupAttributesOutput, error) {
@@ -424,15 +700,31 @@ func (_mr *_MockELBV2APIRecorder) DescribeTargetGroupAttributes(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTargetGroupAttributes", arg0)
 }
 
-func (_m *MockELBV2API) DescribeTargetGroupsRequest(_param0 *elbv2.DescribeTargetGroupsInput) (*request.Request, *elbv2.DescribeTargetGroupsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeTargetGroupsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.DescribeTargetGroupsOutput)
+func (_m *MockELBV2API) DescribeTargetGroupAttributesWithContext(_param0 aws.Context, _param1 *elbv2.DescribeTargetGroupAttributesInput, _param2 ...request.Option) (*elbv2.DescribeTargetGroupAttributesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeTargetGroupAttributesWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.DescribeTargetGroupAttributesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) DescribeTargetGroupsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTargetGroupsRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) DescribeTargetGroupAttributesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTargetGroupAttributesWithContext", _s...)
+}
+
+func (_m *MockELBV2API) DescribeTargetGroupAttributesRequest(_param0 *elbv2.DescribeTargetGroupAttributesInput) (*request.Request, *elbv2.DescribeTargetGroupAttributesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeTargetGroupAttributesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.DescribeTargetGroupAttributesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) DescribeTargetGroupAttributesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTargetGroupAttributesRequest", arg0)
 }
 
 func (_m *MockELBV2API) DescribeTargetGroups(_param0 *elbv2.DescribeTargetGroupsInput) (*elbv2.DescribeTargetGroupsOutput, error) {
@@ -446,6 +738,33 @@ func (_mr *_MockELBV2APIRecorder) DescribeTargetGroups(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTargetGroups", arg0)
 }
 
+func (_m *MockELBV2API) DescribeTargetGroupsWithContext(_param0 aws.Context, _param1 *elbv2.DescribeTargetGroupsInput, _param2 ...request.Option) (*elbv2.DescribeTargetGroupsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeTargetGroupsWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.DescribeTargetGroupsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) DescribeTargetGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTargetGroupsWithContext", _s...)
+}
+
+func (_m *MockELBV2API) DescribeTargetGroupsRequest(_param0 *elbv2.DescribeTargetGroupsInput) (*request.Request, *elbv2.DescribeTargetGroupsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeTargetGroupsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.DescribeTargetGroupsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) DescribeTargetGroupsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTargetGroupsRequest", arg0)
+}
+
 func (_m *MockELBV2API) DescribeTargetGroupsPages(_param0 *elbv2.DescribeTargetGroupsInput, _param1 func(*elbv2.DescribeTargetGroupsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeTargetGroupsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -456,15 +775,19 @@ func (_mr *_MockELBV2APIRecorder) DescribeTargetGroupsPages(arg0, arg1 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTargetGroupsPages", arg0, arg1)
 }
 
-func (_m *MockELBV2API) DescribeTargetHealthRequest(_param0 *elbv2.DescribeTargetHealthInput) (*request.Request, *elbv2.DescribeTargetHealthOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeTargetHealthRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.DescribeTargetHealthOutput)
-	return ret0, ret1
+func (_m *MockELBV2API) DescribeTargetGroupsPagesWithContext(_param0 aws.Context, _param1 *elbv2.DescribeTargetGroupsInput, _param2 func(*elbv2.DescribeTargetGroupsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeTargetGroupsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockELBV2APIRecorder) DescribeTargetHealthRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTargetHealthRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) DescribeTargetGroupsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTargetGroupsPagesWithContext", _s...)
 }
 
 func (_m *MockELBV2API) DescribeTargetHealth(_param0 *elbv2.DescribeTargetHealthInput) (*elbv2.DescribeTargetHealthOutput, error) {
@@ -478,15 +801,31 @@ func (_mr *_MockELBV2APIRecorder) DescribeTargetHealth(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTargetHealth", arg0)
 }
 
-func (_m *MockELBV2API) ModifyListenerRequest(_param0 *elbv2.ModifyListenerInput) (*request.Request, *elbv2.ModifyListenerOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyListenerRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.ModifyListenerOutput)
+func (_m *MockELBV2API) DescribeTargetHealthWithContext(_param0 aws.Context, _param1 *elbv2.DescribeTargetHealthInput, _param2 ...request.Option) (*elbv2.DescribeTargetHealthOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeTargetHealthWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.DescribeTargetHealthOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) ModifyListenerRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyListenerRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) DescribeTargetHealthWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTargetHealthWithContext", _s...)
+}
+
+func (_m *MockELBV2API) DescribeTargetHealthRequest(_param0 *elbv2.DescribeTargetHealthInput) (*request.Request, *elbv2.DescribeTargetHealthOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeTargetHealthRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.DescribeTargetHealthOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) DescribeTargetHealthRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeTargetHealthRequest", arg0)
 }
 
 func (_m *MockELBV2API) ModifyListener(_param0 *elbv2.ModifyListenerInput) (*elbv2.ModifyListenerOutput, error) {
@@ -500,15 +839,31 @@ func (_mr *_MockELBV2APIRecorder) ModifyListener(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyListener", arg0)
 }
 
-func (_m *MockELBV2API) ModifyLoadBalancerAttributesRequest(_param0 *elbv2.ModifyLoadBalancerAttributesInput) (*request.Request, *elbv2.ModifyLoadBalancerAttributesOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyLoadBalancerAttributesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.ModifyLoadBalancerAttributesOutput)
+func (_m *MockELBV2API) ModifyListenerWithContext(_param0 aws.Context, _param1 *elbv2.ModifyListenerInput, _param2 ...request.Option) (*elbv2.ModifyListenerOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyListenerWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.ModifyListenerOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) ModifyLoadBalancerAttributesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyLoadBalancerAttributesRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) ModifyListenerWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyListenerWithContext", _s...)
+}
+
+func (_m *MockELBV2API) ModifyListenerRequest(_param0 *elbv2.ModifyListenerInput) (*request.Request, *elbv2.ModifyListenerOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyListenerRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.ModifyListenerOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) ModifyListenerRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyListenerRequest", arg0)
 }
 
 func (_m *MockELBV2API) ModifyLoadBalancerAttributes(_param0 *elbv2.ModifyLoadBalancerAttributesInput) (*elbv2.ModifyLoadBalancerAttributesOutput, error) {
@@ -522,15 +877,31 @@ func (_mr *_MockELBV2APIRecorder) ModifyLoadBalancerAttributes(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyLoadBalancerAttributes", arg0)
 }
 
-func (_m *MockELBV2API) ModifyRuleRequest(_param0 *elbv2.ModifyRuleInput) (*request.Request, *elbv2.ModifyRuleOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyRuleRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.ModifyRuleOutput)
+func (_m *MockELBV2API) ModifyLoadBalancerAttributesWithContext(_param0 aws.Context, _param1 *elbv2.ModifyLoadBalancerAttributesInput, _param2 ...request.Option) (*elbv2.ModifyLoadBalancerAttributesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyLoadBalancerAttributesWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.ModifyLoadBalancerAttributesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) ModifyRuleRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyRuleRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) ModifyLoadBalancerAttributesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyLoadBalancerAttributesWithContext", _s...)
+}
+
+func (_m *MockELBV2API) ModifyLoadBalancerAttributesRequest(_param0 *elbv2.ModifyLoadBalancerAttributesInput) (*request.Request, *elbv2.ModifyLoadBalancerAttributesOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyLoadBalancerAttributesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.ModifyLoadBalancerAttributesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) ModifyLoadBalancerAttributesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyLoadBalancerAttributesRequest", arg0)
 }
 
 func (_m *MockELBV2API) ModifyRule(_param0 *elbv2.ModifyRuleInput) (*elbv2.ModifyRuleOutput, error) {
@@ -544,15 +915,31 @@ func (_mr *_MockELBV2APIRecorder) ModifyRule(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyRule", arg0)
 }
 
-func (_m *MockELBV2API) ModifyTargetGroupRequest(_param0 *elbv2.ModifyTargetGroupInput) (*request.Request, *elbv2.ModifyTargetGroupOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyTargetGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.ModifyTargetGroupOutput)
+func (_m *MockELBV2API) ModifyRuleWithContext(_param0 aws.Context, _param1 *elbv2.ModifyRuleInput, _param2 ...request.Option) (*elbv2.ModifyRuleOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyRuleWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.ModifyRuleOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) ModifyTargetGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyTargetGroupRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) ModifyRuleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyRuleWithContext", _s...)
+}
+
+func (_m *MockELBV2API) ModifyRuleRequest(_param0 *elbv2.ModifyRuleInput) (*request.Request, *elbv2.ModifyRuleOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyRuleRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.ModifyRuleOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) ModifyRuleRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyRuleRequest", arg0)
 }
 
 func (_m *MockELBV2API) ModifyTargetGroup(_param0 *elbv2.ModifyTargetGroupInput) (*elbv2.ModifyTargetGroupOutput, error) {
@@ -566,15 +953,31 @@ func (_mr *_MockELBV2APIRecorder) ModifyTargetGroup(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyTargetGroup", arg0)
 }
 
-func (_m *MockELBV2API) ModifyTargetGroupAttributesRequest(_param0 *elbv2.ModifyTargetGroupAttributesInput) (*request.Request, *elbv2.ModifyTargetGroupAttributesOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyTargetGroupAttributesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.ModifyTargetGroupAttributesOutput)
+func (_m *MockELBV2API) ModifyTargetGroupWithContext(_param0 aws.Context, _param1 *elbv2.ModifyTargetGroupInput, _param2 ...request.Option) (*elbv2.ModifyTargetGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyTargetGroupWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.ModifyTargetGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) ModifyTargetGroupAttributesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyTargetGroupAttributesRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) ModifyTargetGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyTargetGroupWithContext", _s...)
+}
+
+func (_m *MockELBV2API) ModifyTargetGroupRequest(_param0 *elbv2.ModifyTargetGroupInput) (*request.Request, *elbv2.ModifyTargetGroupOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyTargetGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.ModifyTargetGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) ModifyTargetGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyTargetGroupRequest", arg0)
 }
 
 func (_m *MockELBV2API) ModifyTargetGroupAttributes(_param0 *elbv2.ModifyTargetGroupAttributesInput) (*elbv2.ModifyTargetGroupAttributesOutput, error) {
@@ -588,15 +991,31 @@ func (_mr *_MockELBV2APIRecorder) ModifyTargetGroupAttributes(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyTargetGroupAttributes", arg0)
 }
 
-func (_m *MockELBV2API) RegisterTargetsRequest(_param0 *elbv2.RegisterTargetsInput) (*request.Request, *elbv2.RegisterTargetsOutput) {
-	ret := _m.ctrl.Call(_m, "RegisterTargetsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.RegisterTargetsOutput)
+func (_m *MockELBV2API) ModifyTargetGroupAttributesWithContext(_param0 aws.Context, _param1 *elbv2.ModifyTargetGroupAttributesInput, _param2 ...request.Option) (*elbv2.ModifyTargetGroupAttributesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyTargetGroupAttributesWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.ModifyTargetGroupAttributesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) RegisterTargetsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RegisterTargetsRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) ModifyTargetGroupAttributesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyTargetGroupAttributesWithContext", _s...)
+}
+
+func (_m *MockELBV2API) ModifyTargetGroupAttributesRequest(_param0 *elbv2.ModifyTargetGroupAttributesInput) (*request.Request, *elbv2.ModifyTargetGroupAttributesOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyTargetGroupAttributesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.ModifyTargetGroupAttributesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) ModifyTargetGroupAttributesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyTargetGroupAttributesRequest", arg0)
 }
 
 func (_m *MockELBV2API) RegisterTargets(_param0 *elbv2.RegisterTargetsInput) (*elbv2.RegisterTargetsOutput, error) {
@@ -610,15 +1029,31 @@ func (_mr *_MockELBV2APIRecorder) RegisterTargets(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RegisterTargets", arg0)
 }
 
-func (_m *MockELBV2API) RemoveTagsRequest(_param0 *elbv2.RemoveTagsInput) (*request.Request, *elbv2.RemoveTagsOutput) {
-	ret := _m.ctrl.Call(_m, "RemoveTagsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.RemoveTagsOutput)
+func (_m *MockELBV2API) RegisterTargetsWithContext(_param0 aws.Context, _param1 *elbv2.RegisterTargetsInput, _param2 ...request.Option) (*elbv2.RegisterTargetsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RegisterTargetsWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.RegisterTargetsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) RemoveTagsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveTagsRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) RegisterTargetsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RegisterTargetsWithContext", _s...)
+}
+
+func (_m *MockELBV2API) RegisterTargetsRequest(_param0 *elbv2.RegisterTargetsInput) (*request.Request, *elbv2.RegisterTargetsOutput) {
+	ret := _m.ctrl.Call(_m, "RegisterTargetsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.RegisterTargetsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) RegisterTargetsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RegisterTargetsRequest", arg0)
 }
 
 func (_m *MockELBV2API) RemoveTags(_param0 *elbv2.RemoveTagsInput) (*elbv2.RemoveTagsOutput, error) {
@@ -632,15 +1067,31 @@ func (_mr *_MockELBV2APIRecorder) RemoveTags(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveTags", arg0)
 }
 
-func (_m *MockELBV2API) SetIpAddressTypeRequest(_param0 *elbv2.SetIpAddressTypeInput) (*request.Request, *elbv2.SetIpAddressTypeOutput) {
-	ret := _m.ctrl.Call(_m, "SetIpAddressTypeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.SetIpAddressTypeOutput)
+func (_m *MockELBV2API) RemoveTagsWithContext(_param0 aws.Context, _param1 *elbv2.RemoveTagsInput, _param2 ...request.Option) (*elbv2.RemoveTagsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RemoveTagsWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.RemoveTagsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) SetIpAddressTypeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetIpAddressTypeRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) RemoveTagsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveTagsWithContext", _s...)
+}
+
+func (_m *MockELBV2API) RemoveTagsRequest(_param0 *elbv2.RemoveTagsInput) (*request.Request, *elbv2.RemoveTagsOutput) {
+	ret := _m.ctrl.Call(_m, "RemoveTagsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.RemoveTagsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) RemoveTagsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveTagsRequest", arg0)
 }
 
 func (_m *MockELBV2API) SetIpAddressType(_param0 *elbv2.SetIpAddressTypeInput) (*elbv2.SetIpAddressTypeOutput, error) {
@@ -654,15 +1105,31 @@ func (_mr *_MockELBV2APIRecorder) SetIpAddressType(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetIpAddressType", arg0)
 }
 
-func (_m *MockELBV2API) SetRulePrioritiesRequest(_param0 *elbv2.SetRulePrioritiesInput) (*request.Request, *elbv2.SetRulePrioritiesOutput) {
-	ret := _m.ctrl.Call(_m, "SetRulePrioritiesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.SetRulePrioritiesOutput)
+func (_m *MockELBV2API) SetIpAddressTypeWithContext(_param0 aws.Context, _param1 *elbv2.SetIpAddressTypeInput, _param2 ...request.Option) (*elbv2.SetIpAddressTypeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "SetIpAddressTypeWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.SetIpAddressTypeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) SetRulePrioritiesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetRulePrioritiesRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) SetIpAddressTypeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetIpAddressTypeWithContext", _s...)
+}
+
+func (_m *MockELBV2API) SetIpAddressTypeRequest(_param0 *elbv2.SetIpAddressTypeInput) (*request.Request, *elbv2.SetIpAddressTypeOutput) {
+	ret := _m.ctrl.Call(_m, "SetIpAddressTypeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.SetIpAddressTypeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) SetIpAddressTypeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetIpAddressTypeRequest", arg0)
 }
 
 func (_m *MockELBV2API) SetRulePriorities(_param0 *elbv2.SetRulePrioritiesInput) (*elbv2.SetRulePrioritiesOutput, error) {
@@ -676,15 +1143,31 @@ func (_mr *_MockELBV2APIRecorder) SetRulePriorities(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetRulePriorities", arg0)
 }
 
-func (_m *MockELBV2API) SetSecurityGroupsRequest(_param0 *elbv2.SetSecurityGroupsInput) (*request.Request, *elbv2.SetSecurityGroupsOutput) {
-	ret := _m.ctrl.Call(_m, "SetSecurityGroupsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.SetSecurityGroupsOutput)
+func (_m *MockELBV2API) SetRulePrioritiesWithContext(_param0 aws.Context, _param1 *elbv2.SetRulePrioritiesInput, _param2 ...request.Option) (*elbv2.SetRulePrioritiesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "SetRulePrioritiesWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.SetRulePrioritiesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) SetSecurityGroupsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSecurityGroupsRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) SetRulePrioritiesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetRulePrioritiesWithContext", _s...)
+}
+
+func (_m *MockELBV2API) SetRulePrioritiesRequest(_param0 *elbv2.SetRulePrioritiesInput) (*request.Request, *elbv2.SetRulePrioritiesOutput) {
+	ret := _m.ctrl.Call(_m, "SetRulePrioritiesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.SetRulePrioritiesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) SetRulePrioritiesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetRulePrioritiesRequest", arg0)
 }
 
 func (_m *MockELBV2API) SetSecurityGroups(_param0 *elbv2.SetSecurityGroupsInput) (*elbv2.SetSecurityGroupsOutput, error) {
@@ -698,15 +1181,31 @@ func (_mr *_MockELBV2APIRecorder) SetSecurityGroups(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSecurityGroups", arg0)
 }
 
-func (_m *MockELBV2API) SetSubnetsRequest(_param0 *elbv2.SetSubnetsInput) (*request.Request, *elbv2.SetSubnetsOutput) {
-	ret := _m.ctrl.Call(_m, "SetSubnetsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*elbv2.SetSubnetsOutput)
+func (_m *MockELBV2API) SetSecurityGroupsWithContext(_param0 aws.Context, _param1 *elbv2.SetSecurityGroupsInput, _param2 ...request.Option) (*elbv2.SetSecurityGroupsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "SetSecurityGroupsWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.SetSecurityGroupsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockELBV2APIRecorder) SetSubnetsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSubnetsRequest", arg0)
+func (_mr *_MockELBV2APIRecorder) SetSecurityGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSecurityGroupsWithContext", _s...)
+}
+
+func (_m *MockELBV2API) SetSecurityGroupsRequest(_param0 *elbv2.SetSecurityGroupsInput) (*request.Request, *elbv2.SetSecurityGroupsOutput) {
+	ret := _m.ctrl.Call(_m, "SetSecurityGroupsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.SetSecurityGroupsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) SetSecurityGroupsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSecurityGroupsRequest", arg0)
 }
 
 func (_m *MockELBV2API) SetSubnets(_param0 *elbv2.SetSubnetsInput) (*elbv2.SetSubnetsOutput, error) {
@@ -718,4 +1217,81 @@ func (_m *MockELBV2API) SetSubnets(_param0 *elbv2.SetSubnetsInput) (*elbv2.SetSu
 
 func (_mr *_MockELBV2APIRecorder) SetSubnets(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSubnets", arg0)
+}
+
+func (_m *MockELBV2API) SetSubnetsWithContext(_param0 aws.Context, _param1 *elbv2.SetSubnetsInput, _param2 ...request.Option) (*elbv2.SetSubnetsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "SetSubnetsWithContext", _s...)
+	ret0, _ := ret[0].(*elbv2.SetSubnetsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) SetSubnetsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSubnetsWithContext", _s...)
+}
+
+func (_m *MockELBV2API) SetSubnetsRequest(_param0 *elbv2.SetSubnetsInput) (*request.Request, *elbv2.SetSubnetsOutput) {
+	ret := _m.ctrl.Call(_m, "SetSubnetsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*elbv2.SetSubnetsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockELBV2APIRecorder) SetSubnetsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSubnetsRequest", arg0)
+}
+
+func (_m *MockELBV2API) WaitUntilLoadBalancerAvailable(_param0 *elbv2.DescribeLoadBalancersInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilLoadBalancerAvailable", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockELBV2APIRecorder) WaitUntilLoadBalancerAvailable(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilLoadBalancerAvailable", arg0)
+}
+
+func (_m *MockELBV2API) WaitUntilLoadBalancerAvailableWithContext(_param0 aws.Context, _param1 *elbv2.DescribeLoadBalancersInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilLoadBalancerAvailableWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockELBV2APIRecorder) WaitUntilLoadBalancerAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilLoadBalancerAvailableWithContext", _s...)
+}
+
+func (_m *MockELBV2API) WaitUntilLoadBalancerExists(_param0 *elbv2.DescribeLoadBalancersInput) error {
+	ret := _m.ctrl.Call(_m, "WaitUntilLoadBalancerExists", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockELBV2APIRecorder) WaitUntilLoadBalancerExists(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilLoadBalancerExists", arg0)
+}
+
+func (_m *MockELBV2API) WaitUntilLoadBalancerExistsWithContext(_param0 aws.Context, _param1 *elbv2.DescribeLoadBalancersInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilLoadBalancerExistsWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockELBV2APIRecorder) WaitUntilLoadBalancerExistsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilLoadBalancerExistsWithContext", _s...)
 }

--- a/mock/iammock.go
+++ b/mock/iammock.go
@@ -4,6 +4,7 @@
 package mock
 
 import (
+	aws "github.com/aws/aws-sdk-go/aws"
 	request "github.com/aws/aws-sdk-go/aws/request"
 	iam "github.com/aws/aws-sdk-go/service/iam"
 	gomock "github.com/golang/mock/gomock"
@@ -30,17 +31,6 @@ func (_m *MockIAMAPI) EXPECT() *_MockIAMAPIRecorder {
 	return _m.recorder
 }
 
-func (_m *MockIAMAPI) AddClientIDToOpenIDConnectProviderRequest(_param0 *iam.AddClientIDToOpenIDConnectProviderInput) (*request.Request, *iam.AddClientIDToOpenIDConnectProviderOutput) {
-	ret := _m.ctrl.Call(_m, "AddClientIDToOpenIDConnectProviderRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.AddClientIDToOpenIDConnectProviderOutput)
-	return ret0, ret1
-}
-
-func (_mr *_MockIAMAPIRecorder) AddClientIDToOpenIDConnectProviderRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddClientIDToOpenIDConnectProviderRequest", arg0)
-}
-
 func (_m *MockIAMAPI) AddClientIDToOpenIDConnectProvider(_param0 *iam.AddClientIDToOpenIDConnectProviderInput) (*iam.AddClientIDToOpenIDConnectProviderOutput, error) {
 	ret := _m.ctrl.Call(_m, "AddClientIDToOpenIDConnectProvider", _param0)
 	ret0, _ := ret[0].(*iam.AddClientIDToOpenIDConnectProviderOutput)
@@ -52,15 +42,31 @@ func (_mr *_MockIAMAPIRecorder) AddClientIDToOpenIDConnectProvider(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddClientIDToOpenIDConnectProvider", arg0)
 }
 
-func (_m *MockIAMAPI) AddRoleToInstanceProfileRequest(_param0 *iam.AddRoleToInstanceProfileInput) (*request.Request, *iam.AddRoleToInstanceProfileOutput) {
-	ret := _m.ctrl.Call(_m, "AddRoleToInstanceProfileRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.AddRoleToInstanceProfileOutput)
+func (_m *MockIAMAPI) AddClientIDToOpenIDConnectProviderWithContext(_param0 aws.Context, _param1 *iam.AddClientIDToOpenIDConnectProviderInput, _param2 ...request.Option) (*iam.AddClientIDToOpenIDConnectProviderOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AddClientIDToOpenIDConnectProviderWithContext", _s...)
+	ret0, _ := ret[0].(*iam.AddClientIDToOpenIDConnectProviderOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) AddRoleToInstanceProfileRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddRoleToInstanceProfileRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) AddClientIDToOpenIDConnectProviderWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddClientIDToOpenIDConnectProviderWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) AddClientIDToOpenIDConnectProviderRequest(_param0 *iam.AddClientIDToOpenIDConnectProviderInput) (*request.Request, *iam.AddClientIDToOpenIDConnectProviderOutput) {
+	ret := _m.ctrl.Call(_m, "AddClientIDToOpenIDConnectProviderRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.AddClientIDToOpenIDConnectProviderOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) AddClientIDToOpenIDConnectProviderRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddClientIDToOpenIDConnectProviderRequest", arg0)
 }
 
 func (_m *MockIAMAPI) AddRoleToInstanceProfile(_param0 *iam.AddRoleToInstanceProfileInput) (*iam.AddRoleToInstanceProfileOutput, error) {
@@ -74,15 +80,31 @@ func (_mr *_MockIAMAPIRecorder) AddRoleToInstanceProfile(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddRoleToInstanceProfile", arg0)
 }
 
-func (_m *MockIAMAPI) AddUserToGroupRequest(_param0 *iam.AddUserToGroupInput) (*request.Request, *iam.AddUserToGroupOutput) {
-	ret := _m.ctrl.Call(_m, "AddUserToGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.AddUserToGroupOutput)
+func (_m *MockIAMAPI) AddRoleToInstanceProfileWithContext(_param0 aws.Context, _param1 *iam.AddRoleToInstanceProfileInput, _param2 ...request.Option) (*iam.AddRoleToInstanceProfileOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AddRoleToInstanceProfileWithContext", _s...)
+	ret0, _ := ret[0].(*iam.AddRoleToInstanceProfileOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) AddUserToGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddUserToGroupRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) AddRoleToInstanceProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddRoleToInstanceProfileWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) AddRoleToInstanceProfileRequest(_param0 *iam.AddRoleToInstanceProfileInput) (*request.Request, *iam.AddRoleToInstanceProfileOutput) {
+	ret := _m.ctrl.Call(_m, "AddRoleToInstanceProfileRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.AddRoleToInstanceProfileOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) AddRoleToInstanceProfileRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddRoleToInstanceProfileRequest", arg0)
 }
 
 func (_m *MockIAMAPI) AddUserToGroup(_param0 *iam.AddUserToGroupInput) (*iam.AddUserToGroupOutput, error) {
@@ -96,15 +118,31 @@ func (_mr *_MockIAMAPIRecorder) AddUserToGroup(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddUserToGroup", arg0)
 }
 
-func (_m *MockIAMAPI) AttachGroupPolicyRequest(_param0 *iam.AttachGroupPolicyInput) (*request.Request, *iam.AttachGroupPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "AttachGroupPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.AttachGroupPolicyOutput)
+func (_m *MockIAMAPI) AddUserToGroupWithContext(_param0 aws.Context, _param1 *iam.AddUserToGroupInput, _param2 ...request.Option) (*iam.AddUserToGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AddUserToGroupWithContext", _s...)
+	ret0, _ := ret[0].(*iam.AddUserToGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) AttachGroupPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachGroupPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) AddUserToGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddUserToGroupWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) AddUserToGroupRequest(_param0 *iam.AddUserToGroupInput) (*request.Request, *iam.AddUserToGroupOutput) {
+	ret := _m.ctrl.Call(_m, "AddUserToGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.AddUserToGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) AddUserToGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddUserToGroupRequest", arg0)
 }
 
 func (_m *MockIAMAPI) AttachGroupPolicy(_param0 *iam.AttachGroupPolicyInput) (*iam.AttachGroupPolicyOutput, error) {
@@ -118,15 +156,31 @@ func (_mr *_MockIAMAPIRecorder) AttachGroupPolicy(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachGroupPolicy", arg0)
 }
 
-func (_m *MockIAMAPI) AttachRolePolicyRequest(_param0 *iam.AttachRolePolicyInput) (*request.Request, *iam.AttachRolePolicyOutput) {
-	ret := _m.ctrl.Call(_m, "AttachRolePolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.AttachRolePolicyOutput)
+func (_m *MockIAMAPI) AttachGroupPolicyWithContext(_param0 aws.Context, _param1 *iam.AttachGroupPolicyInput, _param2 ...request.Option) (*iam.AttachGroupPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AttachGroupPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.AttachGroupPolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) AttachRolePolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachRolePolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) AttachGroupPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachGroupPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) AttachGroupPolicyRequest(_param0 *iam.AttachGroupPolicyInput) (*request.Request, *iam.AttachGroupPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "AttachGroupPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.AttachGroupPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) AttachGroupPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachGroupPolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) AttachRolePolicy(_param0 *iam.AttachRolePolicyInput) (*iam.AttachRolePolicyOutput, error) {
@@ -140,15 +194,31 @@ func (_mr *_MockIAMAPIRecorder) AttachRolePolicy(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachRolePolicy", arg0)
 }
 
-func (_m *MockIAMAPI) AttachUserPolicyRequest(_param0 *iam.AttachUserPolicyInput) (*request.Request, *iam.AttachUserPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "AttachUserPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.AttachUserPolicyOutput)
+func (_m *MockIAMAPI) AttachRolePolicyWithContext(_param0 aws.Context, _param1 *iam.AttachRolePolicyInput, _param2 ...request.Option) (*iam.AttachRolePolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AttachRolePolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.AttachRolePolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) AttachUserPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachUserPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) AttachRolePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachRolePolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) AttachRolePolicyRequest(_param0 *iam.AttachRolePolicyInput) (*request.Request, *iam.AttachRolePolicyOutput) {
+	ret := _m.ctrl.Call(_m, "AttachRolePolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.AttachRolePolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) AttachRolePolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachRolePolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) AttachUserPolicy(_param0 *iam.AttachUserPolicyInput) (*iam.AttachUserPolicyOutput, error) {
@@ -162,15 +232,31 @@ func (_mr *_MockIAMAPIRecorder) AttachUserPolicy(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachUserPolicy", arg0)
 }
 
-func (_m *MockIAMAPI) ChangePasswordRequest(_param0 *iam.ChangePasswordInput) (*request.Request, *iam.ChangePasswordOutput) {
-	ret := _m.ctrl.Call(_m, "ChangePasswordRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ChangePasswordOutput)
+func (_m *MockIAMAPI) AttachUserPolicyWithContext(_param0 aws.Context, _param1 *iam.AttachUserPolicyInput, _param2 ...request.Option) (*iam.AttachUserPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AttachUserPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.AttachUserPolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) ChangePasswordRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ChangePasswordRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) AttachUserPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachUserPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) AttachUserPolicyRequest(_param0 *iam.AttachUserPolicyInput) (*request.Request, *iam.AttachUserPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "AttachUserPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.AttachUserPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) AttachUserPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachUserPolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) ChangePassword(_param0 *iam.ChangePasswordInput) (*iam.ChangePasswordOutput, error) {
@@ -184,15 +270,31 @@ func (_mr *_MockIAMAPIRecorder) ChangePassword(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ChangePassword", arg0)
 }
 
-func (_m *MockIAMAPI) CreateAccessKeyRequest(_param0 *iam.CreateAccessKeyInput) (*request.Request, *iam.CreateAccessKeyOutput) {
-	ret := _m.ctrl.Call(_m, "CreateAccessKeyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.CreateAccessKeyOutput)
+func (_m *MockIAMAPI) ChangePasswordWithContext(_param0 aws.Context, _param1 *iam.ChangePasswordInput, _param2 ...request.Option) (*iam.ChangePasswordOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ChangePasswordWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ChangePasswordOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) CreateAccessKeyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateAccessKeyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ChangePasswordWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ChangePasswordWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ChangePasswordRequest(_param0 *iam.ChangePasswordInput) (*request.Request, *iam.ChangePasswordOutput) {
+	ret := _m.ctrl.Call(_m, "ChangePasswordRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ChangePasswordOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ChangePasswordRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ChangePasswordRequest", arg0)
 }
 
 func (_m *MockIAMAPI) CreateAccessKey(_param0 *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {
@@ -206,15 +308,31 @@ func (_mr *_MockIAMAPIRecorder) CreateAccessKey(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateAccessKey", arg0)
 }
 
-func (_m *MockIAMAPI) CreateAccountAliasRequest(_param0 *iam.CreateAccountAliasInput) (*request.Request, *iam.CreateAccountAliasOutput) {
-	ret := _m.ctrl.Call(_m, "CreateAccountAliasRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.CreateAccountAliasOutput)
+func (_m *MockIAMAPI) CreateAccessKeyWithContext(_param0 aws.Context, _param1 *iam.CreateAccessKeyInput, _param2 ...request.Option) (*iam.CreateAccessKeyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateAccessKeyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.CreateAccessKeyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) CreateAccountAliasRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateAccountAliasRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) CreateAccessKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateAccessKeyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) CreateAccessKeyRequest(_param0 *iam.CreateAccessKeyInput) (*request.Request, *iam.CreateAccessKeyOutput) {
+	ret := _m.ctrl.Call(_m, "CreateAccessKeyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.CreateAccessKeyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) CreateAccessKeyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateAccessKeyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) CreateAccountAlias(_param0 *iam.CreateAccountAliasInput) (*iam.CreateAccountAliasOutput, error) {
@@ -228,15 +346,31 @@ func (_mr *_MockIAMAPIRecorder) CreateAccountAlias(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateAccountAlias", arg0)
 }
 
-func (_m *MockIAMAPI) CreateGroupRequest(_param0 *iam.CreateGroupInput) (*request.Request, *iam.CreateGroupOutput) {
-	ret := _m.ctrl.Call(_m, "CreateGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.CreateGroupOutput)
+func (_m *MockIAMAPI) CreateAccountAliasWithContext(_param0 aws.Context, _param1 *iam.CreateAccountAliasInput, _param2 ...request.Option) (*iam.CreateAccountAliasOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateAccountAliasWithContext", _s...)
+	ret0, _ := ret[0].(*iam.CreateAccountAliasOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) CreateGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateGroupRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) CreateAccountAliasWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateAccountAliasWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) CreateAccountAliasRequest(_param0 *iam.CreateAccountAliasInput) (*request.Request, *iam.CreateAccountAliasOutput) {
+	ret := _m.ctrl.Call(_m, "CreateAccountAliasRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.CreateAccountAliasOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) CreateAccountAliasRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateAccountAliasRequest", arg0)
 }
 
 func (_m *MockIAMAPI) CreateGroup(_param0 *iam.CreateGroupInput) (*iam.CreateGroupOutput, error) {
@@ -250,15 +384,31 @@ func (_mr *_MockIAMAPIRecorder) CreateGroup(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateGroup", arg0)
 }
 
-func (_m *MockIAMAPI) CreateInstanceProfileRequest(_param0 *iam.CreateInstanceProfileInput) (*request.Request, *iam.CreateInstanceProfileOutput) {
-	ret := _m.ctrl.Call(_m, "CreateInstanceProfileRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.CreateInstanceProfileOutput)
+func (_m *MockIAMAPI) CreateGroupWithContext(_param0 aws.Context, _param1 *iam.CreateGroupInput, _param2 ...request.Option) (*iam.CreateGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateGroupWithContext", _s...)
+	ret0, _ := ret[0].(*iam.CreateGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) CreateInstanceProfileRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateInstanceProfileRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) CreateGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateGroupWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) CreateGroupRequest(_param0 *iam.CreateGroupInput) (*request.Request, *iam.CreateGroupOutput) {
+	ret := _m.ctrl.Call(_m, "CreateGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.CreateGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) CreateGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateGroupRequest", arg0)
 }
 
 func (_m *MockIAMAPI) CreateInstanceProfile(_param0 *iam.CreateInstanceProfileInput) (*iam.CreateInstanceProfileOutput, error) {
@@ -272,15 +422,31 @@ func (_mr *_MockIAMAPIRecorder) CreateInstanceProfile(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateInstanceProfile", arg0)
 }
 
-func (_m *MockIAMAPI) CreateLoginProfileRequest(_param0 *iam.CreateLoginProfileInput) (*request.Request, *iam.CreateLoginProfileOutput) {
-	ret := _m.ctrl.Call(_m, "CreateLoginProfileRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.CreateLoginProfileOutput)
+func (_m *MockIAMAPI) CreateInstanceProfileWithContext(_param0 aws.Context, _param1 *iam.CreateInstanceProfileInput, _param2 ...request.Option) (*iam.CreateInstanceProfileOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateInstanceProfileWithContext", _s...)
+	ret0, _ := ret[0].(*iam.CreateInstanceProfileOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) CreateLoginProfileRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoginProfileRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) CreateInstanceProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateInstanceProfileWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) CreateInstanceProfileRequest(_param0 *iam.CreateInstanceProfileInput) (*request.Request, *iam.CreateInstanceProfileOutput) {
+	ret := _m.ctrl.Call(_m, "CreateInstanceProfileRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.CreateInstanceProfileOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) CreateInstanceProfileRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateInstanceProfileRequest", arg0)
 }
 
 func (_m *MockIAMAPI) CreateLoginProfile(_param0 *iam.CreateLoginProfileInput) (*iam.CreateLoginProfileOutput, error) {
@@ -294,15 +460,31 @@ func (_mr *_MockIAMAPIRecorder) CreateLoginProfile(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoginProfile", arg0)
 }
 
-func (_m *MockIAMAPI) CreateOpenIDConnectProviderRequest(_param0 *iam.CreateOpenIDConnectProviderInput) (*request.Request, *iam.CreateOpenIDConnectProviderOutput) {
-	ret := _m.ctrl.Call(_m, "CreateOpenIDConnectProviderRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.CreateOpenIDConnectProviderOutput)
+func (_m *MockIAMAPI) CreateLoginProfileWithContext(_param0 aws.Context, _param1 *iam.CreateLoginProfileInput, _param2 ...request.Option) (*iam.CreateLoginProfileOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateLoginProfileWithContext", _s...)
+	ret0, _ := ret[0].(*iam.CreateLoginProfileOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) CreateOpenIDConnectProviderRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateOpenIDConnectProviderRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) CreateLoginProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoginProfileWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) CreateLoginProfileRequest(_param0 *iam.CreateLoginProfileInput) (*request.Request, *iam.CreateLoginProfileOutput) {
+	ret := _m.ctrl.Call(_m, "CreateLoginProfileRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.CreateLoginProfileOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) CreateLoginProfileRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateLoginProfileRequest", arg0)
 }
 
 func (_m *MockIAMAPI) CreateOpenIDConnectProvider(_param0 *iam.CreateOpenIDConnectProviderInput) (*iam.CreateOpenIDConnectProviderOutput, error) {
@@ -316,15 +498,31 @@ func (_mr *_MockIAMAPIRecorder) CreateOpenIDConnectProvider(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateOpenIDConnectProvider", arg0)
 }
 
-func (_m *MockIAMAPI) CreatePolicyRequest(_param0 *iam.CreatePolicyInput) (*request.Request, *iam.CreatePolicyOutput) {
-	ret := _m.ctrl.Call(_m, "CreatePolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.CreatePolicyOutput)
+func (_m *MockIAMAPI) CreateOpenIDConnectProviderWithContext(_param0 aws.Context, _param1 *iam.CreateOpenIDConnectProviderInput, _param2 ...request.Option) (*iam.CreateOpenIDConnectProviderOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateOpenIDConnectProviderWithContext", _s...)
+	ret0, _ := ret[0].(*iam.CreateOpenIDConnectProviderOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) CreatePolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreatePolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) CreateOpenIDConnectProviderWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateOpenIDConnectProviderWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) CreateOpenIDConnectProviderRequest(_param0 *iam.CreateOpenIDConnectProviderInput) (*request.Request, *iam.CreateOpenIDConnectProviderOutput) {
+	ret := _m.ctrl.Call(_m, "CreateOpenIDConnectProviderRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.CreateOpenIDConnectProviderOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) CreateOpenIDConnectProviderRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateOpenIDConnectProviderRequest", arg0)
 }
 
 func (_m *MockIAMAPI) CreatePolicy(_param0 *iam.CreatePolicyInput) (*iam.CreatePolicyOutput, error) {
@@ -338,15 +536,31 @@ func (_mr *_MockIAMAPIRecorder) CreatePolicy(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreatePolicy", arg0)
 }
 
-func (_m *MockIAMAPI) CreatePolicyVersionRequest(_param0 *iam.CreatePolicyVersionInput) (*request.Request, *iam.CreatePolicyVersionOutput) {
-	ret := _m.ctrl.Call(_m, "CreatePolicyVersionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.CreatePolicyVersionOutput)
+func (_m *MockIAMAPI) CreatePolicyWithContext(_param0 aws.Context, _param1 *iam.CreatePolicyInput, _param2 ...request.Option) (*iam.CreatePolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreatePolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.CreatePolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) CreatePolicyVersionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreatePolicyVersionRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) CreatePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreatePolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) CreatePolicyRequest(_param0 *iam.CreatePolicyInput) (*request.Request, *iam.CreatePolicyOutput) {
+	ret := _m.ctrl.Call(_m, "CreatePolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.CreatePolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) CreatePolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreatePolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) CreatePolicyVersion(_param0 *iam.CreatePolicyVersionInput) (*iam.CreatePolicyVersionOutput, error) {
@@ -360,15 +574,31 @@ func (_mr *_MockIAMAPIRecorder) CreatePolicyVersion(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreatePolicyVersion", arg0)
 }
 
-func (_m *MockIAMAPI) CreateRoleRequest(_param0 *iam.CreateRoleInput) (*request.Request, *iam.CreateRoleOutput) {
-	ret := _m.ctrl.Call(_m, "CreateRoleRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.CreateRoleOutput)
+func (_m *MockIAMAPI) CreatePolicyVersionWithContext(_param0 aws.Context, _param1 *iam.CreatePolicyVersionInput, _param2 ...request.Option) (*iam.CreatePolicyVersionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreatePolicyVersionWithContext", _s...)
+	ret0, _ := ret[0].(*iam.CreatePolicyVersionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) CreateRoleRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateRoleRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) CreatePolicyVersionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreatePolicyVersionWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) CreatePolicyVersionRequest(_param0 *iam.CreatePolicyVersionInput) (*request.Request, *iam.CreatePolicyVersionOutput) {
+	ret := _m.ctrl.Call(_m, "CreatePolicyVersionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.CreatePolicyVersionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) CreatePolicyVersionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreatePolicyVersionRequest", arg0)
 }
 
 func (_m *MockIAMAPI) CreateRole(_param0 *iam.CreateRoleInput) (*iam.CreateRoleOutput, error) {
@@ -382,15 +612,31 @@ func (_mr *_MockIAMAPIRecorder) CreateRole(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateRole", arg0)
 }
 
-func (_m *MockIAMAPI) CreateSAMLProviderRequest(_param0 *iam.CreateSAMLProviderInput) (*request.Request, *iam.CreateSAMLProviderOutput) {
-	ret := _m.ctrl.Call(_m, "CreateSAMLProviderRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.CreateSAMLProviderOutput)
+func (_m *MockIAMAPI) CreateRoleWithContext(_param0 aws.Context, _param1 *iam.CreateRoleInput, _param2 ...request.Option) (*iam.CreateRoleOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateRoleWithContext", _s...)
+	ret0, _ := ret[0].(*iam.CreateRoleOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) CreateSAMLProviderRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSAMLProviderRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) CreateRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateRoleWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) CreateRoleRequest(_param0 *iam.CreateRoleInput) (*request.Request, *iam.CreateRoleOutput) {
+	ret := _m.ctrl.Call(_m, "CreateRoleRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.CreateRoleOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) CreateRoleRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateRoleRequest", arg0)
 }
 
 func (_m *MockIAMAPI) CreateSAMLProvider(_param0 *iam.CreateSAMLProviderInput) (*iam.CreateSAMLProviderOutput, error) {
@@ -404,15 +650,31 @@ func (_mr *_MockIAMAPIRecorder) CreateSAMLProvider(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSAMLProvider", arg0)
 }
 
-func (_m *MockIAMAPI) CreateServiceSpecificCredentialRequest(_param0 *iam.CreateServiceSpecificCredentialInput) (*request.Request, *iam.CreateServiceSpecificCredentialOutput) {
-	ret := _m.ctrl.Call(_m, "CreateServiceSpecificCredentialRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.CreateServiceSpecificCredentialOutput)
+func (_m *MockIAMAPI) CreateSAMLProviderWithContext(_param0 aws.Context, _param1 *iam.CreateSAMLProviderInput, _param2 ...request.Option) (*iam.CreateSAMLProviderOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateSAMLProviderWithContext", _s...)
+	ret0, _ := ret[0].(*iam.CreateSAMLProviderOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) CreateServiceSpecificCredentialRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateServiceSpecificCredentialRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) CreateSAMLProviderWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSAMLProviderWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) CreateSAMLProviderRequest(_param0 *iam.CreateSAMLProviderInput) (*request.Request, *iam.CreateSAMLProviderOutput) {
+	ret := _m.ctrl.Call(_m, "CreateSAMLProviderRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.CreateSAMLProviderOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) CreateSAMLProviderRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateSAMLProviderRequest", arg0)
 }
 
 func (_m *MockIAMAPI) CreateServiceSpecificCredential(_param0 *iam.CreateServiceSpecificCredentialInput) (*iam.CreateServiceSpecificCredentialOutput, error) {
@@ -426,15 +688,31 @@ func (_mr *_MockIAMAPIRecorder) CreateServiceSpecificCredential(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateServiceSpecificCredential", arg0)
 }
 
-func (_m *MockIAMAPI) CreateUserRequest(_param0 *iam.CreateUserInput) (*request.Request, *iam.CreateUserOutput) {
-	ret := _m.ctrl.Call(_m, "CreateUserRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.CreateUserOutput)
+func (_m *MockIAMAPI) CreateServiceSpecificCredentialWithContext(_param0 aws.Context, _param1 *iam.CreateServiceSpecificCredentialInput, _param2 ...request.Option) (*iam.CreateServiceSpecificCredentialOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateServiceSpecificCredentialWithContext", _s...)
+	ret0, _ := ret[0].(*iam.CreateServiceSpecificCredentialOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) CreateUserRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateUserRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) CreateServiceSpecificCredentialWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateServiceSpecificCredentialWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) CreateServiceSpecificCredentialRequest(_param0 *iam.CreateServiceSpecificCredentialInput) (*request.Request, *iam.CreateServiceSpecificCredentialOutput) {
+	ret := _m.ctrl.Call(_m, "CreateServiceSpecificCredentialRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.CreateServiceSpecificCredentialOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) CreateServiceSpecificCredentialRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateServiceSpecificCredentialRequest", arg0)
 }
 
 func (_m *MockIAMAPI) CreateUser(_param0 *iam.CreateUserInput) (*iam.CreateUserOutput, error) {
@@ -448,15 +726,31 @@ func (_mr *_MockIAMAPIRecorder) CreateUser(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateUser", arg0)
 }
 
-func (_m *MockIAMAPI) CreateVirtualMFADeviceRequest(_param0 *iam.CreateVirtualMFADeviceInput) (*request.Request, *iam.CreateVirtualMFADeviceOutput) {
-	ret := _m.ctrl.Call(_m, "CreateVirtualMFADeviceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.CreateVirtualMFADeviceOutput)
+func (_m *MockIAMAPI) CreateUserWithContext(_param0 aws.Context, _param1 *iam.CreateUserInput, _param2 ...request.Option) (*iam.CreateUserOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateUserWithContext", _s...)
+	ret0, _ := ret[0].(*iam.CreateUserOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) CreateVirtualMFADeviceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVirtualMFADeviceRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) CreateUserWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateUserWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) CreateUserRequest(_param0 *iam.CreateUserInput) (*request.Request, *iam.CreateUserOutput) {
+	ret := _m.ctrl.Call(_m, "CreateUserRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.CreateUserOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) CreateUserRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateUserRequest", arg0)
 }
 
 func (_m *MockIAMAPI) CreateVirtualMFADevice(_param0 *iam.CreateVirtualMFADeviceInput) (*iam.CreateVirtualMFADeviceOutput, error) {
@@ -470,15 +764,31 @@ func (_mr *_MockIAMAPIRecorder) CreateVirtualMFADevice(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVirtualMFADevice", arg0)
 }
 
-func (_m *MockIAMAPI) DeactivateMFADeviceRequest(_param0 *iam.DeactivateMFADeviceInput) (*request.Request, *iam.DeactivateMFADeviceOutput) {
-	ret := _m.ctrl.Call(_m, "DeactivateMFADeviceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeactivateMFADeviceOutput)
+func (_m *MockIAMAPI) CreateVirtualMFADeviceWithContext(_param0 aws.Context, _param1 *iam.CreateVirtualMFADeviceInput, _param2 ...request.Option) (*iam.CreateVirtualMFADeviceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateVirtualMFADeviceWithContext", _s...)
+	ret0, _ := ret[0].(*iam.CreateVirtualMFADeviceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeactivateMFADeviceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeactivateMFADeviceRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) CreateVirtualMFADeviceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVirtualMFADeviceWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) CreateVirtualMFADeviceRequest(_param0 *iam.CreateVirtualMFADeviceInput) (*request.Request, *iam.CreateVirtualMFADeviceOutput) {
+	ret := _m.ctrl.Call(_m, "CreateVirtualMFADeviceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.CreateVirtualMFADeviceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) CreateVirtualMFADeviceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateVirtualMFADeviceRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeactivateMFADevice(_param0 *iam.DeactivateMFADeviceInput) (*iam.DeactivateMFADeviceOutput, error) {
@@ -492,15 +802,31 @@ func (_mr *_MockIAMAPIRecorder) DeactivateMFADevice(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeactivateMFADevice", arg0)
 }
 
-func (_m *MockIAMAPI) DeleteAccessKeyRequest(_param0 *iam.DeleteAccessKeyInput) (*request.Request, *iam.DeleteAccessKeyOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteAccessKeyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeleteAccessKeyOutput)
+func (_m *MockIAMAPI) DeactivateMFADeviceWithContext(_param0 aws.Context, _param1 *iam.DeactivateMFADeviceInput, _param2 ...request.Option) (*iam.DeactivateMFADeviceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeactivateMFADeviceWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeactivateMFADeviceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeleteAccessKeyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteAccessKeyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeactivateMFADeviceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeactivateMFADeviceWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeactivateMFADeviceRequest(_param0 *iam.DeactivateMFADeviceInput) (*request.Request, *iam.DeactivateMFADeviceOutput) {
+	ret := _m.ctrl.Call(_m, "DeactivateMFADeviceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeactivateMFADeviceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeactivateMFADeviceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeactivateMFADeviceRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeleteAccessKey(_param0 *iam.DeleteAccessKeyInput) (*iam.DeleteAccessKeyOutput, error) {
@@ -514,15 +840,31 @@ func (_mr *_MockIAMAPIRecorder) DeleteAccessKey(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteAccessKey", arg0)
 }
 
-func (_m *MockIAMAPI) DeleteAccountAliasRequest(_param0 *iam.DeleteAccountAliasInput) (*request.Request, *iam.DeleteAccountAliasOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteAccountAliasRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeleteAccountAliasOutput)
+func (_m *MockIAMAPI) DeleteAccessKeyWithContext(_param0 aws.Context, _param1 *iam.DeleteAccessKeyInput, _param2 ...request.Option) (*iam.DeleteAccessKeyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteAccessKeyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeleteAccessKeyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeleteAccountAliasRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteAccountAliasRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeleteAccessKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteAccessKeyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeleteAccessKeyRequest(_param0 *iam.DeleteAccessKeyInput) (*request.Request, *iam.DeleteAccessKeyOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteAccessKeyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeleteAccessKeyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeleteAccessKeyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteAccessKeyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeleteAccountAlias(_param0 *iam.DeleteAccountAliasInput) (*iam.DeleteAccountAliasOutput, error) {
@@ -536,15 +878,31 @@ func (_mr *_MockIAMAPIRecorder) DeleteAccountAlias(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteAccountAlias", arg0)
 }
 
-func (_m *MockIAMAPI) DeleteAccountPasswordPolicyRequest(_param0 *iam.DeleteAccountPasswordPolicyInput) (*request.Request, *iam.DeleteAccountPasswordPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteAccountPasswordPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeleteAccountPasswordPolicyOutput)
+func (_m *MockIAMAPI) DeleteAccountAliasWithContext(_param0 aws.Context, _param1 *iam.DeleteAccountAliasInput, _param2 ...request.Option) (*iam.DeleteAccountAliasOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteAccountAliasWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeleteAccountAliasOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeleteAccountPasswordPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteAccountPasswordPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeleteAccountAliasWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteAccountAliasWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeleteAccountAliasRequest(_param0 *iam.DeleteAccountAliasInput) (*request.Request, *iam.DeleteAccountAliasOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteAccountAliasRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeleteAccountAliasOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeleteAccountAliasRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteAccountAliasRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeleteAccountPasswordPolicy(_param0 *iam.DeleteAccountPasswordPolicyInput) (*iam.DeleteAccountPasswordPolicyOutput, error) {
@@ -558,15 +916,31 @@ func (_mr *_MockIAMAPIRecorder) DeleteAccountPasswordPolicy(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteAccountPasswordPolicy", arg0)
 }
 
-func (_m *MockIAMAPI) DeleteGroupRequest(_param0 *iam.DeleteGroupInput) (*request.Request, *iam.DeleteGroupOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeleteGroupOutput)
+func (_m *MockIAMAPI) DeleteAccountPasswordPolicyWithContext(_param0 aws.Context, _param1 *iam.DeleteAccountPasswordPolicyInput, _param2 ...request.Option) (*iam.DeleteAccountPasswordPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteAccountPasswordPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeleteAccountPasswordPolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeleteGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteGroupRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeleteAccountPasswordPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteAccountPasswordPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeleteAccountPasswordPolicyRequest(_param0 *iam.DeleteAccountPasswordPolicyInput) (*request.Request, *iam.DeleteAccountPasswordPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteAccountPasswordPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeleteAccountPasswordPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeleteAccountPasswordPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteAccountPasswordPolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeleteGroup(_param0 *iam.DeleteGroupInput) (*iam.DeleteGroupOutput, error) {
@@ -580,15 +954,31 @@ func (_mr *_MockIAMAPIRecorder) DeleteGroup(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteGroup", arg0)
 }
 
-func (_m *MockIAMAPI) DeleteGroupPolicyRequest(_param0 *iam.DeleteGroupPolicyInput) (*request.Request, *iam.DeleteGroupPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteGroupPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeleteGroupPolicyOutput)
+func (_m *MockIAMAPI) DeleteGroupWithContext(_param0 aws.Context, _param1 *iam.DeleteGroupInput, _param2 ...request.Option) (*iam.DeleteGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteGroupWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeleteGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeleteGroupPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteGroupPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeleteGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteGroupWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeleteGroupRequest(_param0 *iam.DeleteGroupInput) (*request.Request, *iam.DeleteGroupOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeleteGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeleteGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteGroupRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeleteGroupPolicy(_param0 *iam.DeleteGroupPolicyInput) (*iam.DeleteGroupPolicyOutput, error) {
@@ -602,15 +992,31 @@ func (_mr *_MockIAMAPIRecorder) DeleteGroupPolicy(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteGroupPolicy", arg0)
 }
 
-func (_m *MockIAMAPI) DeleteInstanceProfileRequest(_param0 *iam.DeleteInstanceProfileInput) (*request.Request, *iam.DeleteInstanceProfileOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteInstanceProfileRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeleteInstanceProfileOutput)
+func (_m *MockIAMAPI) DeleteGroupPolicyWithContext(_param0 aws.Context, _param1 *iam.DeleteGroupPolicyInput, _param2 ...request.Option) (*iam.DeleteGroupPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteGroupPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeleteGroupPolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeleteInstanceProfileRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteInstanceProfileRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeleteGroupPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteGroupPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeleteGroupPolicyRequest(_param0 *iam.DeleteGroupPolicyInput) (*request.Request, *iam.DeleteGroupPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteGroupPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeleteGroupPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeleteGroupPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteGroupPolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeleteInstanceProfile(_param0 *iam.DeleteInstanceProfileInput) (*iam.DeleteInstanceProfileOutput, error) {
@@ -624,15 +1030,31 @@ func (_mr *_MockIAMAPIRecorder) DeleteInstanceProfile(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteInstanceProfile", arg0)
 }
 
-func (_m *MockIAMAPI) DeleteLoginProfileRequest(_param0 *iam.DeleteLoginProfileInput) (*request.Request, *iam.DeleteLoginProfileOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteLoginProfileRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeleteLoginProfileOutput)
+func (_m *MockIAMAPI) DeleteInstanceProfileWithContext(_param0 aws.Context, _param1 *iam.DeleteInstanceProfileInput, _param2 ...request.Option) (*iam.DeleteInstanceProfileOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteInstanceProfileWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeleteInstanceProfileOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeleteLoginProfileRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoginProfileRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeleteInstanceProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteInstanceProfileWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeleteInstanceProfileRequest(_param0 *iam.DeleteInstanceProfileInput) (*request.Request, *iam.DeleteInstanceProfileOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteInstanceProfileRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeleteInstanceProfileOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeleteInstanceProfileRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteInstanceProfileRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeleteLoginProfile(_param0 *iam.DeleteLoginProfileInput) (*iam.DeleteLoginProfileOutput, error) {
@@ -646,15 +1068,31 @@ func (_mr *_MockIAMAPIRecorder) DeleteLoginProfile(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoginProfile", arg0)
 }
 
-func (_m *MockIAMAPI) DeleteOpenIDConnectProviderRequest(_param0 *iam.DeleteOpenIDConnectProviderInput) (*request.Request, *iam.DeleteOpenIDConnectProviderOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteOpenIDConnectProviderRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeleteOpenIDConnectProviderOutput)
+func (_m *MockIAMAPI) DeleteLoginProfileWithContext(_param0 aws.Context, _param1 *iam.DeleteLoginProfileInput, _param2 ...request.Option) (*iam.DeleteLoginProfileOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteLoginProfileWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeleteLoginProfileOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeleteOpenIDConnectProviderRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteOpenIDConnectProviderRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeleteLoginProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoginProfileWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeleteLoginProfileRequest(_param0 *iam.DeleteLoginProfileInput) (*request.Request, *iam.DeleteLoginProfileOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteLoginProfileRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeleteLoginProfileOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeleteLoginProfileRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteLoginProfileRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeleteOpenIDConnectProvider(_param0 *iam.DeleteOpenIDConnectProviderInput) (*iam.DeleteOpenIDConnectProviderOutput, error) {
@@ -668,15 +1106,31 @@ func (_mr *_MockIAMAPIRecorder) DeleteOpenIDConnectProvider(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteOpenIDConnectProvider", arg0)
 }
 
-func (_m *MockIAMAPI) DeletePolicyRequest(_param0 *iam.DeletePolicyInput) (*request.Request, *iam.DeletePolicyOutput) {
-	ret := _m.ctrl.Call(_m, "DeletePolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeletePolicyOutput)
+func (_m *MockIAMAPI) DeleteOpenIDConnectProviderWithContext(_param0 aws.Context, _param1 *iam.DeleteOpenIDConnectProviderInput, _param2 ...request.Option) (*iam.DeleteOpenIDConnectProviderOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteOpenIDConnectProviderWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeleteOpenIDConnectProviderOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeletePolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeletePolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeleteOpenIDConnectProviderWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteOpenIDConnectProviderWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeleteOpenIDConnectProviderRequest(_param0 *iam.DeleteOpenIDConnectProviderInput) (*request.Request, *iam.DeleteOpenIDConnectProviderOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteOpenIDConnectProviderRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeleteOpenIDConnectProviderOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeleteOpenIDConnectProviderRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteOpenIDConnectProviderRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeletePolicy(_param0 *iam.DeletePolicyInput) (*iam.DeletePolicyOutput, error) {
@@ -690,15 +1144,31 @@ func (_mr *_MockIAMAPIRecorder) DeletePolicy(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeletePolicy", arg0)
 }
 
-func (_m *MockIAMAPI) DeletePolicyVersionRequest(_param0 *iam.DeletePolicyVersionInput) (*request.Request, *iam.DeletePolicyVersionOutput) {
-	ret := _m.ctrl.Call(_m, "DeletePolicyVersionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeletePolicyVersionOutput)
+func (_m *MockIAMAPI) DeletePolicyWithContext(_param0 aws.Context, _param1 *iam.DeletePolicyInput, _param2 ...request.Option) (*iam.DeletePolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeletePolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeletePolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeletePolicyVersionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeletePolicyVersionRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeletePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeletePolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeletePolicyRequest(_param0 *iam.DeletePolicyInput) (*request.Request, *iam.DeletePolicyOutput) {
+	ret := _m.ctrl.Call(_m, "DeletePolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeletePolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeletePolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeletePolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeletePolicyVersion(_param0 *iam.DeletePolicyVersionInput) (*iam.DeletePolicyVersionOutput, error) {
@@ -712,15 +1182,31 @@ func (_mr *_MockIAMAPIRecorder) DeletePolicyVersion(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeletePolicyVersion", arg0)
 }
 
-func (_m *MockIAMAPI) DeleteRoleRequest(_param0 *iam.DeleteRoleInput) (*request.Request, *iam.DeleteRoleOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteRoleRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeleteRoleOutput)
+func (_m *MockIAMAPI) DeletePolicyVersionWithContext(_param0 aws.Context, _param1 *iam.DeletePolicyVersionInput, _param2 ...request.Option) (*iam.DeletePolicyVersionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeletePolicyVersionWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeletePolicyVersionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeleteRoleRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRoleRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeletePolicyVersionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeletePolicyVersionWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeletePolicyVersionRequest(_param0 *iam.DeletePolicyVersionInput) (*request.Request, *iam.DeletePolicyVersionOutput) {
+	ret := _m.ctrl.Call(_m, "DeletePolicyVersionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeletePolicyVersionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeletePolicyVersionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeletePolicyVersionRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeleteRole(_param0 *iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error) {
@@ -734,15 +1220,31 @@ func (_mr *_MockIAMAPIRecorder) DeleteRole(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRole", arg0)
 }
 
-func (_m *MockIAMAPI) DeleteRolePolicyRequest(_param0 *iam.DeleteRolePolicyInput) (*request.Request, *iam.DeleteRolePolicyOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteRolePolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeleteRolePolicyOutput)
+func (_m *MockIAMAPI) DeleteRoleWithContext(_param0 aws.Context, _param1 *iam.DeleteRoleInput, _param2 ...request.Option) (*iam.DeleteRoleOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteRoleWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeleteRoleOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeleteRolePolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRolePolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeleteRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRoleWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeleteRoleRequest(_param0 *iam.DeleteRoleInput) (*request.Request, *iam.DeleteRoleOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteRoleRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeleteRoleOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeleteRoleRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRoleRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeleteRolePolicy(_param0 *iam.DeleteRolePolicyInput) (*iam.DeleteRolePolicyOutput, error) {
@@ -756,15 +1258,31 @@ func (_mr *_MockIAMAPIRecorder) DeleteRolePolicy(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRolePolicy", arg0)
 }
 
-func (_m *MockIAMAPI) DeleteSAMLProviderRequest(_param0 *iam.DeleteSAMLProviderInput) (*request.Request, *iam.DeleteSAMLProviderOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteSAMLProviderRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeleteSAMLProviderOutput)
+func (_m *MockIAMAPI) DeleteRolePolicyWithContext(_param0 aws.Context, _param1 *iam.DeleteRolePolicyInput, _param2 ...request.Option) (*iam.DeleteRolePolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteRolePolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeleteRolePolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeleteSAMLProviderRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSAMLProviderRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeleteRolePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRolePolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeleteRolePolicyRequest(_param0 *iam.DeleteRolePolicyInput) (*request.Request, *iam.DeleteRolePolicyOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteRolePolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeleteRolePolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeleteRolePolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteRolePolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeleteSAMLProvider(_param0 *iam.DeleteSAMLProviderInput) (*iam.DeleteSAMLProviderOutput, error) {
@@ -778,15 +1296,31 @@ func (_mr *_MockIAMAPIRecorder) DeleteSAMLProvider(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSAMLProvider", arg0)
 }
 
-func (_m *MockIAMAPI) DeleteSSHPublicKeyRequest(_param0 *iam.DeleteSSHPublicKeyInput) (*request.Request, *iam.DeleteSSHPublicKeyOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteSSHPublicKeyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeleteSSHPublicKeyOutput)
+func (_m *MockIAMAPI) DeleteSAMLProviderWithContext(_param0 aws.Context, _param1 *iam.DeleteSAMLProviderInput, _param2 ...request.Option) (*iam.DeleteSAMLProviderOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteSAMLProviderWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeleteSAMLProviderOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeleteSSHPublicKeyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSSHPublicKeyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeleteSAMLProviderWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSAMLProviderWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeleteSAMLProviderRequest(_param0 *iam.DeleteSAMLProviderInput) (*request.Request, *iam.DeleteSAMLProviderOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteSAMLProviderRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeleteSAMLProviderOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeleteSAMLProviderRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSAMLProviderRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeleteSSHPublicKey(_param0 *iam.DeleteSSHPublicKeyInput) (*iam.DeleteSSHPublicKeyOutput, error) {
@@ -800,15 +1334,31 @@ func (_mr *_MockIAMAPIRecorder) DeleteSSHPublicKey(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSSHPublicKey", arg0)
 }
 
-func (_m *MockIAMAPI) DeleteServerCertificateRequest(_param0 *iam.DeleteServerCertificateInput) (*request.Request, *iam.DeleteServerCertificateOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteServerCertificateRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeleteServerCertificateOutput)
+func (_m *MockIAMAPI) DeleteSSHPublicKeyWithContext(_param0 aws.Context, _param1 *iam.DeleteSSHPublicKeyInput, _param2 ...request.Option) (*iam.DeleteSSHPublicKeyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteSSHPublicKeyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeleteSSHPublicKeyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeleteServerCertificateRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteServerCertificateRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeleteSSHPublicKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSSHPublicKeyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeleteSSHPublicKeyRequest(_param0 *iam.DeleteSSHPublicKeyInput) (*request.Request, *iam.DeleteSSHPublicKeyOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteSSHPublicKeyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeleteSSHPublicKeyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeleteSSHPublicKeyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSSHPublicKeyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeleteServerCertificate(_param0 *iam.DeleteServerCertificateInput) (*iam.DeleteServerCertificateOutput, error) {
@@ -822,15 +1372,31 @@ func (_mr *_MockIAMAPIRecorder) DeleteServerCertificate(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteServerCertificate", arg0)
 }
 
-func (_m *MockIAMAPI) DeleteServiceSpecificCredentialRequest(_param0 *iam.DeleteServiceSpecificCredentialInput) (*request.Request, *iam.DeleteServiceSpecificCredentialOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteServiceSpecificCredentialRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeleteServiceSpecificCredentialOutput)
+func (_m *MockIAMAPI) DeleteServerCertificateWithContext(_param0 aws.Context, _param1 *iam.DeleteServerCertificateInput, _param2 ...request.Option) (*iam.DeleteServerCertificateOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteServerCertificateWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeleteServerCertificateOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeleteServiceSpecificCredentialRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteServiceSpecificCredentialRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeleteServerCertificateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteServerCertificateWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeleteServerCertificateRequest(_param0 *iam.DeleteServerCertificateInput) (*request.Request, *iam.DeleteServerCertificateOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteServerCertificateRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeleteServerCertificateOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeleteServerCertificateRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteServerCertificateRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeleteServiceSpecificCredential(_param0 *iam.DeleteServiceSpecificCredentialInput) (*iam.DeleteServiceSpecificCredentialOutput, error) {
@@ -844,15 +1410,31 @@ func (_mr *_MockIAMAPIRecorder) DeleteServiceSpecificCredential(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteServiceSpecificCredential", arg0)
 }
 
-func (_m *MockIAMAPI) DeleteSigningCertificateRequest(_param0 *iam.DeleteSigningCertificateInput) (*request.Request, *iam.DeleteSigningCertificateOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteSigningCertificateRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeleteSigningCertificateOutput)
+func (_m *MockIAMAPI) DeleteServiceSpecificCredentialWithContext(_param0 aws.Context, _param1 *iam.DeleteServiceSpecificCredentialInput, _param2 ...request.Option) (*iam.DeleteServiceSpecificCredentialOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteServiceSpecificCredentialWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeleteServiceSpecificCredentialOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeleteSigningCertificateRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSigningCertificateRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeleteServiceSpecificCredentialWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteServiceSpecificCredentialWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeleteServiceSpecificCredentialRequest(_param0 *iam.DeleteServiceSpecificCredentialInput) (*request.Request, *iam.DeleteServiceSpecificCredentialOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteServiceSpecificCredentialRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeleteServiceSpecificCredentialOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeleteServiceSpecificCredentialRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteServiceSpecificCredentialRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeleteSigningCertificate(_param0 *iam.DeleteSigningCertificateInput) (*iam.DeleteSigningCertificateOutput, error) {
@@ -866,15 +1448,31 @@ func (_mr *_MockIAMAPIRecorder) DeleteSigningCertificate(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSigningCertificate", arg0)
 }
 
-func (_m *MockIAMAPI) DeleteUserRequest(_param0 *iam.DeleteUserInput) (*request.Request, *iam.DeleteUserOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteUserRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeleteUserOutput)
+func (_m *MockIAMAPI) DeleteSigningCertificateWithContext(_param0 aws.Context, _param1 *iam.DeleteSigningCertificateInput, _param2 ...request.Option) (*iam.DeleteSigningCertificateOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteSigningCertificateWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeleteSigningCertificateOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeleteUserRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteUserRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeleteSigningCertificateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSigningCertificateWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeleteSigningCertificateRequest(_param0 *iam.DeleteSigningCertificateInput) (*request.Request, *iam.DeleteSigningCertificateOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteSigningCertificateRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeleteSigningCertificateOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeleteSigningCertificateRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteSigningCertificateRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeleteUser(_param0 *iam.DeleteUserInput) (*iam.DeleteUserOutput, error) {
@@ -888,15 +1486,31 @@ func (_mr *_MockIAMAPIRecorder) DeleteUser(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteUser", arg0)
 }
 
-func (_m *MockIAMAPI) DeleteUserPolicyRequest(_param0 *iam.DeleteUserPolicyInput) (*request.Request, *iam.DeleteUserPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteUserPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeleteUserPolicyOutput)
+func (_m *MockIAMAPI) DeleteUserWithContext(_param0 aws.Context, _param1 *iam.DeleteUserInput, _param2 ...request.Option) (*iam.DeleteUserOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteUserWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeleteUserOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeleteUserPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteUserPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeleteUserWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteUserWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeleteUserRequest(_param0 *iam.DeleteUserInput) (*request.Request, *iam.DeleteUserOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteUserRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeleteUserOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeleteUserRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteUserRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeleteUserPolicy(_param0 *iam.DeleteUserPolicyInput) (*iam.DeleteUserPolicyOutput, error) {
@@ -910,15 +1524,31 @@ func (_mr *_MockIAMAPIRecorder) DeleteUserPolicy(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteUserPolicy", arg0)
 }
 
-func (_m *MockIAMAPI) DeleteVirtualMFADeviceRequest(_param0 *iam.DeleteVirtualMFADeviceInput) (*request.Request, *iam.DeleteVirtualMFADeviceOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteVirtualMFADeviceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DeleteVirtualMFADeviceOutput)
+func (_m *MockIAMAPI) DeleteUserPolicyWithContext(_param0 aws.Context, _param1 *iam.DeleteUserPolicyInput, _param2 ...request.Option) (*iam.DeleteUserPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteUserPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeleteUserPolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DeleteVirtualMFADeviceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVirtualMFADeviceRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeleteUserPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteUserPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeleteUserPolicyRequest(_param0 *iam.DeleteUserPolicyInput) (*request.Request, *iam.DeleteUserPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteUserPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeleteUserPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeleteUserPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteUserPolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DeleteVirtualMFADevice(_param0 *iam.DeleteVirtualMFADeviceInput) (*iam.DeleteVirtualMFADeviceOutput, error) {
@@ -932,15 +1562,31 @@ func (_mr *_MockIAMAPIRecorder) DeleteVirtualMFADevice(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVirtualMFADevice", arg0)
 }
 
-func (_m *MockIAMAPI) DetachGroupPolicyRequest(_param0 *iam.DetachGroupPolicyInput) (*request.Request, *iam.DetachGroupPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "DetachGroupPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DetachGroupPolicyOutput)
+func (_m *MockIAMAPI) DeleteVirtualMFADeviceWithContext(_param0 aws.Context, _param1 *iam.DeleteVirtualMFADeviceInput, _param2 ...request.Option) (*iam.DeleteVirtualMFADeviceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteVirtualMFADeviceWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DeleteVirtualMFADeviceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DetachGroupPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachGroupPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DeleteVirtualMFADeviceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVirtualMFADeviceWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DeleteVirtualMFADeviceRequest(_param0 *iam.DeleteVirtualMFADeviceInput) (*request.Request, *iam.DeleteVirtualMFADeviceOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteVirtualMFADeviceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DeleteVirtualMFADeviceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DeleteVirtualMFADeviceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteVirtualMFADeviceRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DetachGroupPolicy(_param0 *iam.DetachGroupPolicyInput) (*iam.DetachGroupPolicyOutput, error) {
@@ -954,15 +1600,31 @@ func (_mr *_MockIAMAPIRecorder) DetachGroupPolicy(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachGroupPolicy", arg0)
 }
 
-func (_m *MockIAMAPI) DetachRolePolicyRequest(_param0 *iam.DetachRolePolicyInput) (*request.Request, *iam.DetachRolePolicyOutput) {
-	ret := _m.ctrl.Call(_m, "DetachRolePolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DetachRolePolicyOutput)
+func (_m *MockIAMAPI) DetachGroupPolicyWithContext(_param0 aws.Context, _param1 *iam.DetachGroupPolicyInput, _param2 ...request.Option) (*iam.DetachGroupPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DetachGroupPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DetachGroupPolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DetachRolePolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachRolePolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DetachGroupPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachGroupPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DetachGroupPolicyRequest(_param0 *iam.DetachGroupPolicyInput) (*request.Request, *iam.DetachGroupPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "DetachGroupPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DetachGroupPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DetachGroupPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachGroupPolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DetachRolePolicy(_param0 *iam.DetachRolePolicyInput) (*iam.DetachRolePolicyOutput, error) {
@@ -976,15 +1638,31 @@ func (_mr *_MockIAMAPIRecorder) DetachRolePolicy(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachRolePolicy", arg0)
 }
 
-func (_m *MockIAMAPI) DetachUserPolicyRequest(_param0 *iam.DetachUserPolicyInput) (*request.Request, *iam.DetachUserPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "DetachUserPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.DetachUserPolicyOutput)
+func (_m *MockIAMAPI) DetachRolePolicyWithContext(_param0 aws.Context, _param1 *iam.DetachRolePolicyInput, _param2 ...request.Option) (*iam.DetachRolePolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DetachRolePolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DetachRolePolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) DetachUserPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachUserPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DetachRolePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachRolePolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DetachRolePolicyRequest(_param0 *iam.DetachRolePolicyInput) (*request.Request, *iam.DetachRolePolicyOutput) {
+	ret := _m.ctrl.Call(_m, "DetachRolePolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DetachRolePolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DetachRolePolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachRolePolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) DetachUserPolicy(_param0 *iam.DetachUserPolicyInput) (*iam.DetachUserPolicyOutput, error) {
@@ -998,15 +1676,31 @@ func (_mr *_MockIAMAPIRecorder) DetachUserPolicy(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachUserPolicy", arg0)
 }
 
-func (_m *MockIAMAPI) EnableMFADeviceRequest(_param0 *iam.EnableMFADeviceInput) (*request.Request, *iam.EnableMFADeviceOutput) {
-	ret := _m.ctrl.Call(_m, "EnableMFADeviceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.EnableMFADeviceOutput)
+func (_m *MockIAMAPI) DetachUserPolicyWithContext(_param0 aws.Context, _param1 *iam.DetachUserPolicyInput, _param2 ...request.Option) (*iam.DetachUserPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DetachUserPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.DetachUserPolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) EnableMFADeviceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableMFADeviceRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) DetachUserPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachUserPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) DetachUserPolicyRequest(_param0 *iam.DetachUserPolicyInput) (*request.Request, *iam.DetachUserPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "DetachUserPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.DetachUserPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) DetachUserPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachUserPolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) EnableMFADevice(_param0 *iam.EnableMFADeviceInput) (*iam.EnableMFADeviceOutput, error) {
@@ -1020,15 +1714,31 @@ func (_mr *_MockIAMAPIRecorder) EnableMFADevice(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableMFADevice", arg0)
 }
 
-func (_m *MockIAMAPI) GenerateCredentialReportRequest(_param0 *iam.GenerateCredentialReportInput) (*request.Request, *iam.GenerateCredentialReportOutput) {
-	ret := _m.ctrl.Call(_m, "GenerateCredentialReportRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GenerateCredentialReportOutput)
+func (_m *MockIAMAPI) EnableMFADeviceWithContext(_param0 aws.Context, _param1 *iam.EnableMFADeviceInput, _param2 ...request.Option) (*iam.EnableMFADeviceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "EnableMFADeviceWithContext", _s...)
+	ret0, _ := ret[0].(*iam.EnableMFADeviceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GenerateCredentialReportRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GenerateCredentialReportRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) EnableMFADeviceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableMFADeviceWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) EnableMFADeviceRequest(_param0 *iam.EnableMFADeviceInput) (*request.Request, *iam.EnableMFADeviceOutput) {
+	ret := _m.ctrl.Call(_m, "EnableMFADeviceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.EnableMFADeviceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) EnableMFADeviceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "EnableMFADeviceRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GenerateCredentialReport(_param0 *iam.GenerateCredentialReportInput) (*iam.GenerateCredentialReportOutput, error) {
@@ -1042,15 +1752,31 @@ func (_mr *_MockIAMAPIRecorder) GenerateCredentialReport(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GenerateCredentialReport", arg0)
 }
 
-func (_m *MockIAMAPI) GetAccessKeyLastUsedRequest(_param0 *iam.GetAccessKeyLastUsedInput) (*request.Request, *iam.GetAccessKeyLastUsedOutput) {
-	ret := _m.ctrl.Call(_m, "GetAccessKeyLastUsedRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetAccessKeyLastUsedOutput)
+func (_m *MockIAMAPI) GenerateCredentialReportWithContext(_param0 aws.Context, _param1 *iam.GenerateCredentialReportInput, _param2 ...request.Option) (*iam.GenerateCredentialReportOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GenerateCredentialReportWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GenerateCredentialReportOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetAccessKeyLastUsedRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccessKeyLastUsedRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GenerateCredentialReportWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GenerateCredentialReportWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GenerateCredentialReportRequest(_param0 *iam.GenerateCredentialReportInput) (*request.Request, *iam.GenerateCredentialReportOutput) {
+	ret := _m.ctrl.Call(_m, "GenerateCredentialReportRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GenerateCredentialReportOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GenerateCredentialReportRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GenerateCredentialReportRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetAccessKeyLastUsed(_param0 *iam.GetAccessKeyLastUsedInput) (*iam.GetAccessKeyLastUsedOutput, error) {
@@ -1064,15 +1790,31 @@ func (_mr *_MockIAMAPIRecorder) GetAccessKeyLastUsed(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccessKeyLastUsed", arg0)
 }
 
-func (_m *MockIAMAPI) GetAccountAuthorizationDetailsRequest(_param0 *iam.GetAccountAuthorizationDetailsInput) (*request.Request, *iam.GetAccountAuthorizationDetailsOutput) {
-	ret := _m.ctrl.Call(_m, "GetAccountAuthorizationDetailsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetAccountAuthorizationDetailsOutput)
+func (_m *MockIAMAPI) GetAccessKeyLastUsedWithContext(_param0 aws.Context, _param1 *iam.GetAccessKeyLastUsedInput, _param2 ...request.Option) (*iam.GetAccessKeyLastUsedOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetAccessKeyLastUsedWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetAccessKeyLastUsedOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetAccountAuthorizationDetailsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccountAuthorizationDetailsRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetAccessKeyLastUsedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccessKeyLastUsedWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetAccessKeyLastUsedRequest(_param0 *iam.GetAccessKeyLastUsedInput) (*request.Request, *iam.GetAccessKeyLastUsedOutput) {
+	ret := _m.ctrl.Call(_m, "GetAccessKeyLastUsedRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetAccessKeyLastUsedOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetAccessKeyLastUsedRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccessKeyLastUsedRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetAccountAuthorizationDetails(_param0 *iam.GetAccountAuthorizationDetailsInput) (*iam.GetAccountAuthorizationDetailsOutput, error) {
@@ -1086,6 +1828,33 @@ func (_mr *_MockIAMAPIRecorder) GetAccountAuthorizationDetails(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccountAuthorizationDetails", arg0)
 }
 
+func (_m *MockIAMAPI) GetAccountAuthorizationDetailsWithContext(_param0 aws.Context, _param1 *iam.GetAccountAuthorizationDetailsInput, _param2 ...request.Option) (*iam.GetAccountAuthorizationDetailsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetAccountAuthorizationDetailsWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetAccountAuthorizationDetailsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetAccountAuthorizationDetailsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccountAuthorizationDetailsWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetAccountAuthorizationDetailsRequest(_param0 *iam.GetAccountAuthorizationDetailsInput) (*request.Request, *iam.GetAccountAuthorizationDetailsOutput) {
+	ret := _m.ctrl.Call(_m, "GetAccountAuthorizationDetailsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetAccountAuthorizationDetailsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetAccountAuthorizationDetailsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccountAuthorizationDetailsRequest", arg0)
+}
+
 func (_m *MockIAMAPI) GetAccountAuthorizationDetailsPages(_param0 *iam.GetAccountAuthorizationDetailsInput, _param1 func(*iam.GetAccountAuthorizationDetailsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "GetAccountAuthorizationDetailsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1096,15 +1865,19 @@ func (_mr *_MockIAMAPIRecorder) GetAccountAuthorizationDetailsPages(arg0, arg1 i
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccountAuthorizationDetailsPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) GetAccountPasswordPolicyRequest(_param0 *iam.GetAccountPasswordPolicyInput) (*request.Request, *iam.GetAccountPasswordPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "GetAccountPasswordPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetAccountPasswordPolicyOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) GetAccountAuthorizationDetailsPagesWithContext(_param0 aws.Context, _param1 *iam.GetAccountAuthorizationDetailsInput, _param2 func(*iam.GetAccountAuthorizationDetailsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetAccountAuthorizationDetailsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) GetAccountPasswordPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccountPasswordPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetAccountAuthorizationDetailsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccountAuthorizationDetailsPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) GetAccountPasswordPolicy(_param0 *iam.GetAccountPasswordPolicyInput) (*iam.GetAccountPasswordPolicyOutput, error) {
@@ -1118,15 +1891,31 @@ func (_mr *_MockIAMAPIRecorder) GetAccountPasswordPolicy(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccountPasswordPolicy", arg0)
 }
 
-func (_m *MockIAMAPI) GetAccountSummaryRequest(_param0 *iam.GetAccountSummaryInput) (*request.Request, *iam.GetAccountSummaryOutput) {
-	ret := _m.ctrl.Call(_m, "GetAccountSummaryRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetAccountSummaryOutput)
+func (_m *MockIAMAPI) GetAccountPasswordPolicyWithContext(_param0 aws.Context, _param1 *iam.GetAccountPasswordPolicyInput, _param2 ...request.Option) (*iam.GetAccountPasswordPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetAccountPasswordPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetAccountPasswordPolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetAccountSummaryRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccountSummaryRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetAccountPasswordPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccountPasswordPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetAccountPasswordPolicyRequest(_param0 *iam.GetAccountPasswordPolicyInput) (*request.Request, *iam.GetAccountPasswordPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "GetAccountPasswordPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetAccountPasswordPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetAccountPasswordPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccountPasswordPolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetAccountSummary(_param0 *iam.GetAccountSummaryInput) (*iam.GetAccountSummaryOutput, error) {
@@ -1140,15 +1929,31 @@ func (_mr *_MockIAMAPIRecorder) GetAccountSummary(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccountSummary", arg0)
 }
 
-func (_m *MockIAMAPI) GetContextKeysForCustomPolicyRequest(_param0 *iam.GetContextKeysForCustomPolicyInput) (*request.Request, *iam.GetContextKeysForPolicyResponse) {
-	ret := _m.ctrl.Call(_m, "GetContextKeysForCustomPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetContextKeysForPolicyResponse)
+func (_m *MockIAMAPI) GetAccountSummaryWithContext(_param0 aws.Context, _param1 *iam.GetAccountSummaryInput, _param2 ...request.Option) (*iam.GetAccountSummaryOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetAccountSummaryWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetAccountSummaryOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetContextKeysForCustomPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetContextKeysForCustomPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetAccountSummaryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccountSummaryWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetAccountSummaryRequest(_param0 *iam.GetAccountSummaryInput) (*request.Request, *iam.GetAccountSummaryOutput) {
+	ret := _m.ctrl.Call(_m, "GetAccountSummaryRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetAccountSummaryOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetAccountSummaryRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccountSummaryRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetContextKeysForCustomPolicy(_param0 *iam.GetContextKeysForCustomPolicyInput) (*iam.GetContextKeysForPolicyResponse, error) {
@@ -1162,15 +1967,31 @@ func (_mr *_MockIAMAPIRecorder) GetContextKeysForCustomPolicy(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetContextKeysForCustomPolicy", arg0)
 }
 
-func (_m *MockIAMAPI) GetContextKeysForPrincipalPolicyRequest(_param0 *iam.GetContextKeysForPrincipalPolicyInput) (*request.Request, *iam.GetContextKeysForPolicyResponse) {
-	ret := _m.ctrl.Call(_m, "GetContextKeysForPrincipalPolicyRequest", _param0)
+func (_m *MockIAMAPI) GetContextKeysForCustomPolicyWithContext(_param0 aws.Context, _param1 *iam.GetContextKeysForCustomPolicyInput, _param2 ...request.Option) (*iam.GetContextKeysForPolicyResponse, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetContextKeysForCustomPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetContextKeysForPolicyResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetContextKeysForCustomPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetContextKeysForCustomPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetContextKeysForCustomPolicyRequest(_param0 *iam.GetContextKeysForCustomPolicyInput) (*request.Request, *iam.GetContextKeysForPolicyResponse) {
+	ret := _m.ctrl.Call(_m, "GetContextKeysForCustomPolicyRequest", _param0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetContextKeysForPolicyResponse)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetContextKeysForPrincipalPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetContextKeysForPrincipalPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetContextKeysForCustomPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetContextKeysForCustomPolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetContextKeysForPrincipalPolicy(_param0 *iam.GetContextKeysForPrincipalPolicyInput) (*iam.GetContextKeysForPolicyResponse, error) {
@@ -1184,15 +2005,31 @@ func (_mr *_MockIAMAPIRecorder) GetContextKeysForPrincipalPolicy(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetContextKeysForPrincipalPolicy", arg0)
 }
 
-func (_m *MockIAMAPI) GetCredentialReportRequest(_param0 *iam.GetCredentialReportInput) (*request.Request, *iam.GetCredentialReportOutput) {
-	ret := _m.ctrl.Call(_m, "GetCredentialReportRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetCredentialReportOutput)
+func (_m *MockIAMAPI) GetContextKeysForPrincipalPolicyWithContext(_param0 aws.Context, _param1 *iam.GetContextKeysForPrincipalPolicyInput, _param2 ...request.Option) (*iam.GetContextKeysForPolicyResponse, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetContextKeysForPrincipalPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetContextKeysForPolicyResponse)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetCredentialReportRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCredentialReportRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetContextKeysForPrincipalPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetContextKeysForPrincipalPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetContextKeysForPrincipalPolicyRequest(_param0 *iam.GetContextKeysForPrincipalPolicyInput) (*request.Request, *iam.GetContextKeysForPolicyResponse) {
+	ret := _m.ctrl.Call(_m, "GetContextKeysForPrincipalPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetContextKeysForPolicyResponse)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetContextKeysForPrincipalPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetContextKeysForPrincipalPolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetCredentialReport(_param0 *iam.GetCredentialReportInput) (*iam.GetCredentialReportOutput, error) {
@@ -1206,15 +2043,31 @@ func (_mr *_MockIAMAPIRecorder) GetCredentialReport(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCredentialReport", arg0)
 }
 
-func (_m *MockIAMAPI) GetGroupRequest(_param0 *iam.GetGroupInput) (*request.Request, *iam.GetGroupOutput) {
-	ret := _m.ctrl.Call(_m, "GetGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetGroupOutput)
+func (_m *MockIAMAPI) GetCredentialReportWithContext(_param0 aws.Context, _param1 *iam.GetCredentialReportInput, _param2 ...request.Option) (*iam.GetCredentialReportOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetCredentialReportWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetCredentialReportOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetGroupRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetCredentialReportWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCredentialReportWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetCredentialReportRequest(_param0 *iam.GetCredentialReportInput) (*request.Request, *iam.GetCredentialReportOutput) {
+	ret := _m.ctrl.Call(_m, "GetCredentialReportRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetCredentialReportOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetCredentialReportRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCredentialReportRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetGroup(_param0 *iam.GetGroupInput) (*iam.GetGroupOutput, error) {
@@ -1228,6 +2081,33 @@ func (_mr *_MockIAMAPIRecorder) GetGroup(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetGroup", arg0)
 }
 
+func (_m *MockIAMAPI) GetGroupWithContext(_param0 aws.Context, _param1 *iam.GetGroupInput, _param2 ...request.Option) (*iam.GetGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetGroupWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetGroupOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetGroupWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetGroupRequest(_param0 *iam.GetGroupInput) (*request.Request, *iam.GetGroupOutput) {
+	ret := _m.ctrl.Call(_m, "GetGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetGroupRequest", arg0)
+}
+
 func (_m *MockIAMAPI) GetGroupPages(_param0 *iam.GetGroupInput, _param1 func(*iam.GetGroupOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "GetGroupPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1238,15 +2118,19 @@ func (_mr *_MockIAMAPIRecorder) GetGroupPages(arg0, arg1 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetGroupPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) GetGroupPolicyRequest(_param0 *iam.GetGroupPolicyInput) (*request.Request, *iam.GetGroupPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "GetGroupPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetGroupPolicyOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) GetGroupPagesWithContext(_param0 aws.Context, _param1 *iam.GetGroupInput, _param2 func(*iam.GetGroupOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetGroupPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) GetGroupPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetGroupPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetGroupPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetGroupPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) GetGroupPolicy(_param0 *iam.GetGroupPolicyInput) (*iam.GetGroupPolicyOutput, error) {
@@ -1260,15 +2144,31 @@ func (_mr *_MockIAMAPIRecorder) GetGroupPolicy(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetGroupPolicy", arg0)
 }
 
-func (_m *MockIAMAPI) GetInstanceProfileRequest(_param0 *iam.GetInstanceProfileInput) (*request.Request, *iam.GetInstanceProfileOutput) {
-	ret := _m.ctrl.Call(_m, "GetInstanceProfileRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetInstanceProfileOutput)
+func (_m *MockIAMAPI) GetGroupPolicyWithContext(_param0 aws.Context, _param1 *iam.GetGroupPolicyInput, _param2 ...request.Option) (*iam.GetGroupPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetGroupPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetGroupPolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetInstanceProfileRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetInstanceProfileRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetGroupPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetGroupPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetGroupPolicyRequest(_param0 *iam.GetGroupPolicyInput) (*request.Request, *iam.GetGroupPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "GetGroupPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetGroupPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetGroupPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetGroupPolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetInstanceProfile(_param0 *iam.GetInstanceProfileInput) (*iam.GetInstanceProfileOutput, error) {
@@ -1282,15 +2182,31 @@ func (_mr *_MockIAMAPIRecorder) GetInstanceProfile(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetInstanceProfile", arg0)
 }
 
-func (_m *MockIAMAPI) GetLoginProfileRequest(_param0 *iam.GetLoginProfileInput) (*request.Request, *iam.GetLoginProfileOutput) {
-	ret := _m.ctrl.Call(_m, "GetLoginProfileRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetLoginProfileOutput)
+func (_m *MockIAMAPI) GetInstanceProfileWithContext(_param0 aws.Context, _param1 *iam.GetInstanceProfileInput, _param2 ...request.Option) (*iam.GetInstanceProfileOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetInstanceProfileWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetInstanceProfileOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetLoginProfileRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLoginProfileRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetInstanceProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetInstanceProfileWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetInstanceProfileRequest(_param0 *iam.GetInstanceProfileInput) (*request.Request, *iam.GetInstanceProfileOutput) {
+	ret := _m.ctrl.Call(_m, "GetInstanceProfileRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetInstanceProfileOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetInstanceProfileRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetInstanceProfileRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetLoginProfile(_param0 *iam.GetLoginProfileInput) (*iam.GetLoginProfileOutput, error) {
@@ -1304,15 +2220,31 @@ func (_mr *_MockIAMAPIRecorder) GetLoginProfile(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLoginProfile", arg0)
 }
 
-func (_m *MockIAMAPI) GetOpenIDConnectProviderRequest(_param0 *iam.GetOpenIDConnectProviderInput) (*request.Request, *iam.GetOpenIDConnectProviderOutput) {
-	ret := _m.ctrl.Call(_m, "GetOpenIDConnectProviderRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetOpenIDConnectProviderOutput)
+func (_m *MockIAMAPI) GetLoginProfileWithContext(_param0 aws.Context, _param1 *iam.GetLoginProfileInput, _param2 ...request.Option) (*iam.GetLoginProfileOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetLoginProfileWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetLoginProfileOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetOpenIDConnectProviderRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetOpenIDConnectProviderRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetLoginProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLoginProfileWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetLoginProfileRequest(_param0 *iam.GetLoginProfileInput) (*request.Request, *iam.GetLoginProfileOutput) {
+	ret := _m.ctrl.Call(_m, "GetLoginProfileRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetLoginProfileOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetLoginProfileRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLoginProfileRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetOpenIDConnectProvider(_param0 *iam.GetOpenIDConnectProviderInput) (*iam.GetOpenIDConnectProviderOutput, error) {
@@ -1326,15 +2258,31 @@ func (_mr *_MockIAMAPIRecorder) GetOpenIDConnectProvider(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetOpenIDConnectProvider", arg0)
 }
 
-func (_m *MockIAMAPI) GetPolicyRequest(_param0 *iam.GetPolicyInput) (*request.Request, *iam.GetPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "GetPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetPolicyOutput)
+func (_m *MockIAMAPI) GetOpenIDConnectProviderWithContext(_param0 aws.Context, _param1 *iam.GetOpenIDConnectProviderInput, _param2 ...request.Option) (*iam.GetOpenIDConnectProviderOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetOpenIDConnectProviderWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetOpenIDConnectProviderOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetOpenIDConnectProviderWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetOpenIDConnectProviderWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetOpenIDConnectProviderRequest(_param0 *iam.GetOpenIDConnectProviderInput) (*request.Request, *iam.GetOpenIDConnectProviderOutput) {
+	ret := _m.ctrl.Call(_m, "GetOpenIDConnectProviderRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetOpenIDConnectProviderOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetOpenIDConnectProviderRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetOpenIDConnectProviderRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetPolicy(_param0 *iam.GetPolicyInput) (*iam.GetPolicyOutput, error) {
@@ -1348,15 +2296,31 @@ func (_mr *_MockIAMAPIRecorder) GetPolicy(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPolicy", arg0)
 }
 
-func (_m *MockIAMAPI) GetPolicyVersionRequest(_param0 *iam.GetPolicyVersionInput) (*request.Request, *iam.GetPolicyVersionOutput) {
-	ret := _m.ctrl.Call(_m, "GetPolicyVersionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetPolicyVersionOutput)
+func (_m *MockIAMAPI) GetPolicyWithContext(_param0 aws.Context, _param1 *iam.GetPolicyInput, _param2 ...request.Option) (*iam.GetPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetPolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetPolicyVersionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPolicyVersionRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetPolicyRequest(_param0 *iam.GetPolicyInput) (*request.Request, *iam.GetPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "GetPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetPolicyVersion(_param0 *iam.GetPolicyVersionInput) (*iam.GetPolicyVersionOutput, error) {
@@ -1370,15 +2334,31 @@ func (_mr *_MockIAMAPIRecorder) GetPolicyVersion(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPolicyVersion", arg0)
 }
 
-func (_m *MockIAMAPI) GetRoleRequest(_param0 *iam.GetRoleInput) (*request.Request, *iam.GetRoleOutput) {
-	ret := _m.ctrl.Call(_m, "GetRoleRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetRoleOutput)
+func (_m *MockIAMAPI) GetPolicyVersionWithContext(_param0 aws.Context, _param1 *iam.GetPolicyVersionInput, _param2 ...request.Option) (*iam.GetPolicyVersionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetPolicyVersionWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetPolicyVersionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetRoleRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetRoleRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetPolicyVersionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPolicyVersionWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetPolicyVersionRequest(_param0 *iam.GetPolicyVersionInput) (*request.Request, *iam.GetPolicyVersionOutput) {
+	ret := _m.ctrl.Call(_m, "GetPolicyVersionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetPolicyVersionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetPolicyVersionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPolicyVersionRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetRole(_param0 *iam.GetRoleInput) (*iam.GetRoleOutput, error) {
@@ -1392,15 +2372,31 @@ func (_mr *_MockIAMAPIRecorder) GetRole(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetRole", arg0)
 }
 
-func (_m *MockIAMAPI) GetRolePolicyRequest(_param0 *iam.GetRolePolicyInput) (*request.Request, *iam.GetRolePolicyOutput) {
-	ret := _m.ctrl.Call(_m, "GetRolePolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetRolePolicyOutput)
+func (_m *MockIAMAPI) GetRoleWithContext(_param0 aws.Context, _param1 *iam.GetRoleInput, _param2 ...request.Option) (*iam.GetRoleOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetRoleWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetRoleOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetRolePolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetRolePolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetRoleWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetRoleRequest(_param0 *iam.GetRoleInput) (*request.Request, *iam.GetRoleOutput) {
+	ret := _m.ctrl.Call(_m, "GetRoleRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetRoleOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetRoleRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetRoleRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetRolePolicy(_param0 *iam.GetRolePolicyInput) (*iam.GetRolePolicyOutput, error) {
@@ -1414,15 +2410,31 @@ func (_mr *_MockIAMAPIRecorder) GetRolePolicy(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetRolePolicy", arg0)
 }
 
-func (_m *MockIAMAPI) GetSAMLProviderRequest(_param0 *iam.GetSAMLProviderInput) (*request.Request, *iam.GetSAMLProviderOutput) {
-	ret := _m.ctrl.Call(_m, "GetSAMLProviderRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetSAMLProviderOutput)
+func (_m *MockIAMAPI) GetRolePolicyWithContext(_param0 aws.Context, _param1 *iam.GetRolePolicyInput, _param2 ...request.Option) (*iam.GetRolePolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetRolePolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetRolePolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetSAMLProviderRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSAMLProviderRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetRolePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetRolePolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetRolePolicyRequest(_param0 *iam.GetRolePolicyInput) (*request.Request, *iam.GetRolePolicyOutput) {
+	ret := _m.ctrl.Call(_m, "GetRolePolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetRolePolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetRolePolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetRolePolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetSAMLProvider(_param0 *iam.GetSAMLProviderInput) (*iam.GetSAMLProviderOutput, error) {
@@ -1436,15 +2448,31 @@ func (_mr *_MockIAMAPIRecorder) GetSAMLProvider(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSAMLProvider", arg0)
 }
 
-func (_m *MockIAMAPI) GetSSHPublicKeyRequest(_param0 *iam.GetSSHPublicKeyInput) (*request.Request, *iam.GetSSHPublicKeyOutput) {
-	ret := _m.ctrl.Call(_m, "GetSSHPublicKeyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetSSHPublicKeyOutput)
+func (_m *MockIAMAPI) GetSAMLProviderWithContext(_param0 aws.Context, _param1 *iam.GetSAMLProviderInput, _param2 ...request.Option) (*iam.GetSAMLProviderOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetSAMLProviderWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetSAMLProviderOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetSSHPublicKeyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSSHPublicKeyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetSAMLProviderWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSAMLProviderWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetSAMLProviderRequest(_param0 *iam.GetSAMLProviderInput) (*request.Request, *iam.GetSAMLProviderOutput) {
+	ret := _m.ctrl.Call(_m, "GetSAMLProviderRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetSAMLProviderOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetSAMLProviderRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSAMLProviderRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetSSHPublicKey(_param0 *iam.GetSSHPublicKeyInput) (*iam.GetSSHPublicKeyOutput, error) {
@@ -1458,15 +2486,31 @@ func (_mr *_MockIAMAPIRecorder) GetSSHPublicKey(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSSHPublicKey", arg0)
 }
 
-func (_m *MockIAMAPI) GetServerCertificateRequest(_param0 *iam.GetServerCertificateInput) (*request.Request, *iam.GetServerCertificateOutput) {
-	ret := _m.ctrl.Call(_m, "GetServerCertificateRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetServerCertificateOutput)
+func (_m *MockIAMAPI) GetSSHPublicKeyWithContext(_param0 aws.Context, _param1 *iam.GetSSHPublicKeyInput, _param2 ...request.Option) (*iam.GetSSHPublicKeyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetSSHPublicKeyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetSSHPublicKeyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetServerCertificateRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetServerCertificateRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetSSHPublicKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSSHPublicKeyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetSSHPublicKeyRequest(_param0 *iam.GetSSHPublicKeyInput) (*request.Request, *iam.GetSSHPublicKeyOutput) {
+	ret := _m.ctrl.Call(_m, "GetSSHPublicKeyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetSSHPublicKeyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetSSHPublicKeyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSSHPublicKeyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetServerCertificate(_param0 *iam.GetServerCertificateInput) (*iam.GetServerCertificateOutput, error) {
@@ -1480,15 +2524,31 @@ func (_mr *_MockIAMAPIRecorder) GetServerCertificate(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetServerCertificate", arg0)
 }
 
-func (_m *MockIAMAPI) GetUserRequest(_param0 *iam.GetUserInput) (*request.Request, *iam.GetUserOutput) {
-	ret := _m.ctrl.Call(_m, "GetUserRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetUserOutput)
+func (_m *MockIAMAPI) GetServerCertificateWithContext(_param0 aws.Context, _param1 *iam.GetServerCertificateInput, _param2 ...request.Option) (*iam.GetServerCertificateOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetServerCertificateWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetServerCertificateOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetUserRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetServerCertificateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetServerCertificateWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetServerCertificateRequest(_param0 *iam.GetServerCertificateInput) (*request.Request, *iam.GetServerCertificateOutput) {
+	ret := _m.ctrl.Call(_m, "GetServerCertificateRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetServerCertificateOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetServerCertificateRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetServerCertificateRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetUser(_param0 *iam.GetUserInput) (*iam.GetUserOutput, error) {
@@ -1502,15 +2562,31 @@ func (_mr *_MockIAMAPIRecorder) GetUser(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUser", arg0)
 }
 
-func (_m *MockIAMAPI) GetUserPolicyRequest(_param0 *iam.GetUserPolicyInput) (*request.Request, *iam.GetUserPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "GetUserPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.GetUserPolicyOutput)
+func (_m *MockIAMAPI) GetUserWithContext(_param0 aws.Context, _param1 *iam.GetUserInput, _param2 ...request.Option) (*iam.GetUserOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetUserWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetUserOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) GetUserPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetUserWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetUserRequest(_param0 *iam.GetUserInput) (*request.Request, *iam.GetUserOutput) {
+	ret := _m.ctrl.Call(_m, "GetUserRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetUserOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetUserRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserRequest", arg0)
 }
 
 func (_m *MockIAMAPI) GetUserPolicy(_param0 *iam.GetUserPolicyInput) (*iam.GetUserPolicyOutput, error) {
@@ -1524,15 +2600,31 @@ func (_mr *_MockIAMAPIRecorder) GetUserPolicy(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserPolicy", arg0)
 }
 
-func (_m *MockIAMAPI) ListAccessKeysRequest(_param0 *iam.ListAccessKeysInput) (*request.Request, *iam.ListAccessKeysOutput) {
-	ret := _m.ctrl.Call(_m, "ListAccessKeysRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListAccessKeysOutput)
+func (_m *MockIAMAPI) GetUserPolicyWithContext(_param0 aws.Context, _param1 *iam.GetUserPolicyInput, _param2 ...request.Option) (*iam.GetUserPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "GetUserPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.GetUserPolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) ListAccessKeysRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAccessKeysRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) GetUserPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) GetUserPolicyRequest(_param0 *iam.GetUserPolicyInput) (*request.Request, *iam.GetUserPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "GetUserPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.GetUserPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) GetUserPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserPolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) ListAccessKeys(_param0 *iam.ListAccessKeysInput) (*iam.ListAccessKeysOutput, error) {
@@ -1546,6 +2638,33 @@ func (_mr *_MockIAMAPIRecorder) ListAccessKeys(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAccessKeys", arg0)
 }
 
+func (_m *MockIAMAPI) ListAccessKeysWithContext(_param0 aws.Context, _param1 *iam.ListAccessKeysInput, _param2 ...request.Option) (*iam.ListAccessKeysOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListAccessKeysWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListAccessKeysOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListAccessKeysWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAccessKeysWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListAccessKeysRequest(_param0 *iam.ListAccessKeysInput) (*request.Request, *iam.ListAccessKeysOutput) {
+	ret := _m.ctrl.Call(_m, "ListAccessKeysRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListAccessKeysOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListAccessKeysRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAccessKeysRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListAccessKeysPages(_param0 *iam.ListAccessKeysInput, _param1 func(*iam.ListAccessKeysOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListAccessKeysPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1556,15 +2675,19 @@ func (_mr *_MockIAMAPIRecorder) ListAccessKeysPages(arg0, arg1 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAccessKeysPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListAccountAliasesRequest(_param0 *iam.ListAccountAliasesInput) (*request.Request, *iam.ListAccountAliasesOutput) {
-	ret := _m.ctrl.Call(_m, "ListAccountAliasesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListAccountAliasesOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListAccessKeysPagesWithContext(_param0 aws.Context, _param1 *iam.ListAccessKeysInput, _param2 func(*iam.ListAccessKeysOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListAccessKeysPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListAccountAliasesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAccountAliasesRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListAccessKeysPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAccessKeysPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListAccountAliases(_param0 *iam.ListAccountAliasesInput) (*iam.ListAccountAliasesOutput, error) {
@@ -1578,6 +2701,33 @@ func (_mr *_MockIAMAPIRecorder) ListAccountAliases(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAccountAliases", arg0)
 }
 
+func (_m *MockIAMAPI) ListAccountAliasesWithContext(_param0 aws.Context, _param1 *iam.ListAccountAliasesInput, _param2 ...request.Option) (*iam.ListAccountAliasesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListAccountAliasesWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListAccountAliasesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListAccountAliasesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAccountAliasesWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListAccountAliasesRequest(_param0 *iam.ListAccountAliasesInput) (*request.Request, *iam.ListAccountAliasesOutput) {
+	ret := _m.ctrl.Call(_m, "ListAccountAliasesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListAccountAliasesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListAccountAliasesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAccountAliasesRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListAccountAliasesPages(_param0 *iam.ListAccountAliasesInput, _param1 func(*iam.ListAccountAliasesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListAccountAliasesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1588,15 +2738,19 @@ func (_mr *_MockIAMAPIRecorder) ListAccountAliasesPages(arg0, arg1 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAccountAliasesPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListAttachedGroupPoliciesRequest(_param0 *iam.ListAttachedGroupPoliciesInput) (*request.Request, *iam.ListAttachedGroupPoliciesOutput) {
-	ret := _m.ctrl.Call(_m, "ListAttachedGroupPoliciesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListAttachedGroupPoliciesOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListAccountAliasesPagesWithContext(_param0 aws.Context, _param1 *iam.ListAccountAliasesInput, _param2 func(*iam.ListAccountAliasesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListAccountAliasesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListAttachedGroupPoliciesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAttachedGroupPoliciesRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListAccountAliasesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAccountAliasesPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListAttachedGroupPolicies(_param0 *iam.ListAttachedGroupPoliciesInput) (*iam.ListAttachedGroupPoliciesOutput, error) {
@@ -1610,6 +2764,33 @@ func (_mr *_MockIAMAPIRecorder) ListAttachedGroupPolicies(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAttachedGroupPolicies", arg0)
 }
 
+func (_m *MockIAMAPI) ListAttachedGroupPoliciesWithContext(_param0 aws.Context, _param1 *iam.ListAttachedGroupPoliciesInput, _param2 ...request.Option) (*iam.ListAttachedGroupPoliciesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListAttachedGroupPoliciesWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListAttachedGroupPoliciesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListAttachedGroupPoliciesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAttachedGroupPoliciesWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListAttachedGroupPoliciesRequest(_param0 *iam.ListAttachedGroupPoliciesInput) (*request.Request, *iam.ListAttachedGroupPoliciesOutput) {
+	ret := _m.ctrl.Call(_m, "ListAttachedGroupPoliciesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListAttachedGroupPoliciesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListAttachedGroupPoliciesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAttachedGroupPoliciesRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListAttachedGroupPoliciesPages(_param0 *iam.ListAttachedGroupPoliciesInput, _param1 func(*iam.ListAttachedGroupPoliciesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListAttachedGroupPoliciesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1620,15 +2801,19 @@ func (_mr *_MockIAMAPIRecorder) ListAttachedGroupPoliciesPages(arg0, arg1 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAttachedGroupPoliciesPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListAttachedRolePoliciesRequest(_param0 *iam.ListAttachedRolePoliciesInput) (*request.Request, *iam.ListAttachedRolePoliciesOutput) {
-	ret := _m.ctrl.Call(_m, "ListAttachedRolePoliciesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListAttachedRolePoliciesOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListAttachedGroupPoliciesPagesWithContext(_param0 aws.Context, _param1 *iam.ListAttachedGroupPoliciesInput, _param2 func(*iam.ListAttachedGroupPoliciesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListAttachedGroupPoliciesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListAttachedRolePoliciesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAttachedRolePoliciesRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListAttachedGroupPoliciesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAttachedGroupPoliciesPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListAttachedRolePolicies(_param0 *iam.ListAttachedRolePoliciesInput) (*iam.ListAttachedRolePoliciesOutput, error) {
@@ -1642,6 +2827,33 @@ func (_mr *_MockIAMAPIRecorder) ListAttachedRolePolicies(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAttachedRolePolicies", arg0)
 }
 
+func (_m *MockIAMAPI) ListAttachedRolePoliciesWithContext(_param0 aws.Context, _param1 *iam.ListAttachedRolePoliciesInput, _param2 ...request.Option) (*iam.ListAttachedRolePoliciesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListAttachedRolePoliciesWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListAttachedRolePoliciesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListAttachedRolePoliciesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAttachedRolePoliciesWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListAttachedRolePoliciesRequest(_param0 *iam.ListAttachedRolePoliciesInput) (*request.Request, *iam.ListAttachedRolePoliciesOutput) {
+	ret := _m.ctrl.Call(_m, "ListAttachedRolePoliciesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListAttachedRolePoliciesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListAttachedRolePoliciesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAttachedRolePoliciesRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListAttachedRolePoliciesPages(_param0 *iam.ListAttachedRolePoliciesInput, _param1 func(*iam.ListAttachedRolePoliciesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListAttachedRolePoliciesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1652,15 +2864,19 @@ func (_mr *_MockIAMAPIRecorder) ListAttachedRolePoliciesPages(arg0, arg1 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAttachedRolePoliciesPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListAttachedUserPoliciesRequest(_param0 *iam.ListAttachedUserPoliciesInput) (*request.Request, *iam.ListAttachedUserPoliciesOutput) {
-	ret := _m.ctrl.Call(_m, "ListAttachedUserPoliciesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListAttachedUserPoliciesOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListAttachedRolePoliciesPagesWithContext(_param0 aws.Context, _param1 *iam.ListAttachedRolePoliciesInput, _param2 func(*iam.ListAttachedRolePoliciesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListAttachedRolePoliciesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListAttachedUserPoliciesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAttachedUserPoliciesRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListAttachedRolePoliciesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAttachedRolePoliciesPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListAttachedUserPolicies(_param0 *iam.ListAttachedUserPoliciesInput) (*iam.ListAttachedUserPoliciesOutput, error) {
@@ -1674,6 +2890,33 @@ func (_mr *_MockIAMAPIRecorder) ListAttachedUserPolicies(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAttachedUserPolicies", arg0)
 }
 
+func (_m *MockIAMAPI) ListAttachedUserPoliciesWithContext(_param0 aws.Context, _param1 *iam.ListAttachedUserPoliciesInput, _param2 ...request.Option) (*iam.ListAttachedUserPoliciesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListAttachedUserPoliciesWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListAttachedUserPoliciesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListAttachedUserPoliciesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAttachedUserPoliciesWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListAttachedUserPoliciesRequest(_param0 *iam.ListAttachedUserPoliciesInput) (*request.Request, *iam.ListAttachedUserPoliciesOutput) {
+	ret := _m.ctrl.Call(_m, "ListAttachedUserPoliciesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListAttachedUserPoliciesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListAttachedUserPoliciesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAttachedUserPoliciesRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListAttachedUserPoliciesPages(_param0 *iam.ListAttachedUserPoliciesInput, _param1 func(*iam.ListAttachedUserPoliciesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListAttachedUserPoliciesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1684,15 +2927,19 @@ func (_mr *_MockIAMAPIRecorder) ListAttachedUserPoliciesPages(arg0, arg1 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAttachedUserPoliciesPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListEntitiesForPolicyRequest(_param0 *iam.ListEntitiesForPolicyInput) (*request.Request, *iam.ListEntitiesForPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "ListEntitiesForPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListEntitiesForPolicyOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListAttachedUserPoliciesPagesWithContext(_param0 aws.Context, _param1 *iam.ListAttachedUserPoliciesInput, _param2 func(*iam.ListAttachedUserPoliciesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListAttachedUserPoliciesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListEntitiesForPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListEntitiesForPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListAttachedUserPoliciesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAttachedUserPoliciesPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListEntitiesForPolicy(_param0 *iam.ListEntitiesForPolicyInput) (*iam.ListEntitiesForPolicyOutput, error) {
@@ -1706,6 +2953,33 @@ func (_mr *_MockIAMAPIRecorder) ListEntitiesForPolicy(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListEntitiesForPolicy", arg0)
 }
 
+func (_m *MockIAMAPI) ListEntitiesForPolicyWithContext(_param0 aws.Context, _param1 *iam.ListEntitiesForPolicyInput, _param2 ...request.Option) (*iam.ListEntitiesForPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListEntitiesForPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListEntitiesForPolicyOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListEntitiesForPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListEntitiesForPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListEntitiesForPolicyRequest(_param0 *iam.ListEntitiesForPolicyInput) (*request.Request, *iam.ListEntitiesForPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "ListEntitiesForPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListEntitiesForPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListEntitiesForPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListEntitiesForPolicyRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListEntitiesForPolicyPages(_param0 *iam.ListEntitiesForPolicyInput, _param1 func(*iam.ListEntitiesForPolicyOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListEntitiesForPolicyPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1716,15 +2990,19 @@ func (_mr *_MockIAMAPIRecorder) ListEntitiesForPolicyPages(arg0, arg1 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListEntitiesForPolicyPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListGroupPoliciesRequest(_param0 *iam.ListGroupPoliciesInput) (*request.Request, *iam.ListGroupPoliciesOutput) {
-	ret := _m.ctrl.Call(_m, "ListGroupPoliciesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListGroupPoliciesOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListEntitiesForPolicyPagesWithContext(_param0 aws.Context, _param1 *iam.ListEntitiesForPolicyInput, _param2 func(*iam.ListEntitiesForPolicyOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListEntitiesForPolicyPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListGroupPoliciesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListGroupPoliciesRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListEntitiesForPolicyPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListEntitiesForPolicyPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListGroupPolicies(_param0 *iam.ListGroupPoliciesInput) (*iam.ListGroupPoliciesOutput, error) {
@@ -1738,6 +3016,33 @@ func (_mr *_MockIAMAPIRecorder) ListGroupPolicies(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListGroupPolicies", arg0)
 }
 
+func (_m *MockIAMAPI) ListGroupPoliciesWithContext(_param0 aws.Context, _param1 *iam.ListGroupPoliciesInput, _param2 ...request.Option) (*iam.ListGroupPoliciesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListGroupPoliciesWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListGroupPoliciesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListGroupPoliciesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListGroupPoliciesWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListGroupPoliciesRequest(_param0 *iam.ListGroupPoliciesInput) (*request.Request, *iam.ListGroupPoliciesOutput) {
+	ret := _m.ctrl.Call(_m, "ListGroupPoliciesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListGroupPoliciesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListGroupPoliciesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListGroupPoliciesRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListGroupPoliciesPages(_param0 *iam.ListGroupPoliciesInput, _param1 func(*iam.ListGroupPoliciesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListGroupPoliciesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1748,15 +3053,19 @@ func (_mr *_MockIAMAPIRecorder) ListGroupPoliciesPages(arg0, arg1 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListGroupPoliciesPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListGroupsRequest(_param0 *iam.ListGroupsInput) (*request.Request, *iam.ListGroupsOutput) {
-	ret := _m.ctrl.Call(_m, "ListGroupsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListGroupsOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListGroupPoliciesPagesWithContext(_param0 aws.Context, _param1 *iam.ListGroupPoliciesInput, _param2 func(*iam.ListGroupPoliciesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListGroupPoliciesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListGroupsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListGroupsRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListGroupPoliciesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListGroupPoliciesPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListGroups(_param0 *iam.ListGroupsInput) (*iam.ListGroupsOutput, error) {
@@ -1770,6 +3079,33 @@ func (_mr *_MockIAMAPIRecorder) ListGroups(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListGroups", arg0)
 }
 
+func (_m *MockIAMAPI) ListGroupsWithContext(_param0 aws.Context, _param1 *iam.ListGroupsInput, _param2 ...request.Option) (*iam.ListGroupsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListGroupsWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListGroupsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListGroupsWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListGroupsRequest(_param0 *iam.ListGroupsInput) (*request.Request, *iam.ListGroupsOutput) {
+	ret := _m.ctrl.Call(_m, "ListGroupsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListGroupsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListGroupsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListGroupsRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListGroupsPages(_param0 *iam.ListGroupsInput, _param1 func(*iam.ListGroupsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListGroupsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1780,15 +3116,19 @@ func (_mr *_MockIAMAPIRecorder) ListGroupsPages(arg0, arg1 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListGroupsPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListGroupsForUserRequest(_param0 *iam.ListGroupsForUserInput) (*request.Request, *iam.ListGroupsForUserOutput) {
-	ret := _m.ctrl.Call(_m, "ListGroupsForUserRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListGroupsForUserOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListGroupsPagesWithContext(_param0 aws.Context, _param1 *iam.ListGroupsInput, _param2 func(*iam.ListGroupsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListGroupsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListGroupsForUserRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListGroupsForUserRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListGroupsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListGroupsPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListGroupsForUser(_param0 *iam.ListGroupsForUserInput) (*iam.ListGroupsForUserOutput, error) {
@@ -1802,6 +3142,33 @@ func (_mr *_MockIAMAPIRecorder) ListGroupsForUser(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListGroupsForUser", arg0)
 }
 
+func (_m *MockIAMAPI) ListGroupsForUserWithContext(_param0 aws.Context, _param1 *iam.ListGroupsForUserInput, _param2 ...request.Option) (*iam.ListGroupsForUserOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListGroupsForUserWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListGroupsForUserOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListGroupsForUserWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListGroupsForUserWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListGroupsForUserRequest(_param0 *iam.ListGroupsForUserInput) (*request.Request, *iam.ListGroupsForUserOutput) {
+	ret := _m.ctrl.Call(_m, "ListGroupsForUserRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListGroupsForUserOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListGroupsForUserRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListGroupsForUserRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListGroupsForUserPages(_param0 *iam.ListGroupsForUserInput, _param1 func(*iam.ListGroupsForUserOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListGroupsForUserPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1812,15 +3179,19 @@ func (_mr *_MockIAMAPIRecorder) ListGroupsForUserPages(arg0, arg1 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListGroupsForUserPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListInstanceProfilesRequest(_param0 *iam.ListInstanceProfilesInput) (*request.Request, *iam.ListInstanceProfilesOutput) {
-	ret := _m.ctrl.Call(_m, "ListInstanceProfilesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListInstanceProfilesOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListGroupsForUserPagesWithContext(_param0 aws.Context, _param1 *iam.ListGroupsForUserInput, _param2 func(*iam.ListGroupsForUserOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListGroupsForUserPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListInstanceProfilesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListInstanceProfilesRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListGroupsForUserPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListGroupsForUserPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListInstanceProfiles(_param0 *iam.ListInstanceProfilesInput) (*iam.ListInstanceProfilesOutput, error) {
@@ -1834,6 +3205,33 @@ func (_mr *_MockIAMAPIRecorder) ListInstanceProfiles(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListInstanceProfiles", arg0)
 }
 
+func (_m *MockIAMAPI) ListInstanceProfilesWithContext(_param0 aws.Context, _param1 *iam.ListInstanceProfilesInput, _param2 ...request.Option) (*iam.ListInstanceProfilesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListInstanceProfilesWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListInstanceProfilesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListInstanceProfilesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListInstanceProfilesWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListInstanceProfilesRequest(_param0 *iam.ListInstanceProfilesInput) (*request.Request, *iam.ListInstanceProfilesOutput) {
+	ret := _m.ctrl.Call(_m, "ListInstanceProfilesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListInstanceProfilesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListInstanceProfilesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListInstanceProfilesRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListInstanceProfilesPages(_param0 *iam.ListInstanceProfilesInput, _param1 func(*iam.ListInstanceProfilesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListInstanceProfilesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1844,15 +3242,19 @@ func (_mr *_MockIAMAPIRecorder) ListInstanceProfilesPages(arg0, arg1 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListInstanceProfilesPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListInstanceProfilesForRoleRequest(_param0 *iam.ListInstanceProfilesForRoleInput) (*request.Request, *iam.ListInstanceProfilesForRoleOutput) {
-	ret := _m.ctrl.Call(_m, "ListInstanceProfilesForRoleRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListInstanceProfilesForRoleOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListInstanceProfilesPagesWithContext(_param0 aws.Context, _param1 *iam.ListInstanceProfilesInput, _param2 func(*iam.ListInstanceProfilesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListInstanceProfilesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListInstanceProfilesForRoleRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListInstanceProfilesForRoleRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListInstanceProfilesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListInstanceProfilesPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListInstanceProfilesForRole(_param0 *iam.ListInstanceProfilesForRoleInput) (*iam.ListInstanceProfilesForRoleOutput, error) {
@@ -1866,6 +3268,33 @@ func (_mr *_MockIAMAPIRecorder) ListInstanceProfilesForRole(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListInstanceProfilesForRole", arg0)
 }
 
+func (_m *MockIAMAPI) ListInstanceProfilesForRoleWithContext(_param0 aws.Context, _param1 *iam.ListInstanceProfilesForRoleInput, _param2 ...request.Option) (*iam.ListInstanceProfilesForRoleOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListInstanceProfilesForRoleWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListInstanceProfilesForRoleOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListInstanceProfilesForRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListInstanceProfilesForRoleWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListInstanceProfilesForRoleRequest(_param0 *iam.ListInstanceProfilesForRoleInput) (*request.Request, *iam.ListInstanceProfilesForRoleOutput) {
+	ret := _m.ctrl.Call(_m, "ListInstanceProfilesForRoleRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListInstanceProfilesForRoleOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListInstanceProfilesForRoleRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListInstanceProfilesForRoleRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListInstanceProfilesForRolePages(_param0 *iam.ListInstanceProfilesForRoleInput, _param1 func(*iam.ListInstanceProfilesForRoleOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListInstanceProfilesForRolePages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1876,15 +3305,19 @@ func (_mr *_MockIAMAPIRecorder) ListInstanceProfilesForRolePages(arg0, arg1 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListInstanceProfilesForRolePages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListMFADevicesRequest(_param0 *iam.ListMFADevicesInput) (*request.Request, *iam.ListMFADevicesOutput) {
-	ret := _m.ctrl.Call(_m, "ListMFADevicesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListMFADevicesOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListInstanceProfilesForRolePagesWithContext(_param0 aws.Context, _param1 *iam.ListInstanceProfilesForRoleInput, _param2 func(*iam.ListInstanceProfilesForRoleOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListInstanceProfilesForRolePagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListMFADevicesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListMFADevicesRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListInstanceProfilesForRolePagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListInstanceProfilesForRolePagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListMFADevices(_param0 *iam.ListMFADevicesInput) (*iam.ListMFADevicesOutput, error) {
@@ -1898,6 +3331,33 @@ func (_mr *_MockIAMAPIRecorder) ListMFADevices(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListMFADevices", arg0)
 }
 
+func (_m *MockIAMAPI) ListMFADevicesWithContext(_param0 aws.Context, _param1 *iam.ListMFADevicesInput, _param2 ...request.Option) (*iam.ListMFADevicesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListMFADevicesWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListMFADevicesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListMFADevicesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListMFADevicesWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListMFADevicesRequest(_param0 *iam.ListMFADevicesInput) (*request.Request, *iam.ListMFADevicesOutput) {
+	ret := _m.ctrl.Call(_m, "ListMFADevicesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListMFADevicesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListMFADevicesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListMFADevicesRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListMFADevicesPages(_param0 *iam.ListMFADevicesInput, _param1 func(*iam.ListMFADevicesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListMFADevicesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1908,15 +3368,19 @@ func (_mr *_MockIAMAPIRecorder) ListMFADevicesPages(arg0, arg1 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListMFADevicesPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListOpenIDConnectProvidersRequest(_param0 *iam.ListOpenIDConnectProvidersInput) (*request.Request, *iam.ListOpenIDConnectProvidersOutput) {
-	ret := _m.ctrl.Call(_m, "ListOpenIDConnectProvidersRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListOpenIDConnectProvidersOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListMFADevicesPagesWithContext(_param0 aws.Context, _param1 *iam.ListMFADevicesInput, _param2 func(*iam.ListMFADevicesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListMFADevicesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListOpenIDConnectProvidersRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListOpenIDConnectProvidersRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListMFADevicesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListMFADevicesPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListOpenIDConnectProviders(_param0 *iam.ListOpenIDConnectProvidersInput) (*iam.ListOpenIDConnectProvidersOutput, error) {
@@ -1930,15 +3394,31 @@ func (_mr *_MockIAMAPIRecorder) ListOpenIDConnectProviders(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListOpenIDConnectProviders", arg0)
 }
 
-func (_m *MockIAMAPI) ListPoliciesRequest(_param0 *iam.ListPoliciesInput) (*request.Request, *iam.ListPoliciesOutput) {
-	ret := _m.ctrl.Call(_m, "ListPoliciesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListPoliciesOutput)
+func (_m *MockIAMAPI) ListOpenIDConnectProvidersWithContext(_param0 aws.Context, _param1 *iam.ListOpenIDConnectProvidersInput, _param2 ...request.Option) (*iam.ListOpenIDConnectProvidersOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListOpenIDConnectProvidersWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListOpenIDConnectProvidersOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) ListPoliciesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListPoliciesRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListOpenIDConnectProvidersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListOpenIDConnectProvidersWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListOpenIDConnectProvidersRequest(_param0 *iam.ListOpenIDConnectProvidersInput) (*request.Request, *iam.ListOpenIDConnectProvidersOutput) {
+	ret := _m.ctrl.Call(_m, "ListOpenIDConnectProvidersRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListOpenIDConnectProvidersOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListOpenIDConnectProvidersRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListOpenIDConnectProvidersRequest", arg0)
 }
 
 func (_m *MockIAMAPI) ListPolicies(_param0 *iam.ListPoliciesInput) (*iam.ListPoliciesOutput, error) {
@@ -1952,6 +3432,33 @@ func (_mr *_MockIAMAPIRecorder) ListPolicies(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListPolicies", arg0)
 }
 
+func (_m *MockIAMAPI) ListPoliciesWithContext(_param0 aws.Context, _param1 *iam.ListPoliciesInput, _param2 ...request.Option) (*iam.ListPoliciesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListPoliciesWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListPoliciesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListPoliciesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListPoliciesWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListPoliciesRequest(_param0 *iam.ListPoliciesInput) (*request.Request, *iam.ListPoliciesOutput) {
+	ret := _m.ctrl.Call(_m, "ListPoliciesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListPoliciesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListPoliciesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListPoliciesRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListPoliciesPages(_param0 *iam.ListPoliciesInput, _param1 func(*iam.ListPoliciesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListPoliciesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1962,15 +3469,19 @@ func (_mr *_MockIAMAPIRecorder) ListPoliciesPages(arg0, arg1 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListPoliciesPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListPolicyVersionsRequest(_param0 *iam.ListPolicyVersionsInput) (*request.Request, *iam.ListPolicyVersionsOutput) {
-	ret := _m.ctrl.Call(_m, "ListPolicyVersionsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListPolicyVersionsOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListPoliciesPagesWithContext(_param0 aws.Context, _param1 *iam.ListPoliciesInput, _param2 func(*iam.ListPoliciesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListPoliciesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListPolicyVersionsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListPolicyVersionsRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListPoliciesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListPoliciesPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListPolicyVersions(_param0 *iam.ListPolicyVersionsInput) (*iam.ListPolicyVersionsOutput, error) {
@@ -1984,6 +3495,33 @@ func (_mr *_MockIAMAPIRecorder) ListPolicyVersions(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListPolicyVersions", arg0)
 }
 
+func (_m *MockIAMAPI) ListPolicyVersionsWithContext(_param0 aws.Context, _param1 *iam.ListPolicyVersionsInput, _param2 ...request.Option) (*iam.ListPolicyVersionsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListPolicyVersionsWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListPolicyVersionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListPolicyVersionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListPolicyVersionsWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListPolicyVersionsRequest(_param0 *iam.ListPolicyVersionsInput) (*request.Request, *iam.ListPolicyVersionsOutput) {
+	ret := _m.ctrl.Call(_m, "ListPolicyVersionsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListPolicyVersionsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListPolicyVersionsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListPolicyVersionsRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListPolicyVersionsPages(_param0 *iam.ListPolicyVersionsInput, _param1 func(*iam.ListPolicyVersionsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListPolicyVersionsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1994,15 +3532,19 @@ func (_mr *_MockIAMAPIRecorder) ListPolicyVersionsPages(arg0, arg1 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListPolicyVersionsPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListRolePoliciesRequest(_param0 *iam.ListRolePoliciesInput) (*request.Request, *iam.ListRolePoliciesOutput) {
-	ret := _m.ctrl.Call(_m, "ListRolePoliciesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListRolePoliciesOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListPolicyVersionsPagesWithContext(_param0 aws.Context, _param1 *iam.ListPolicyVersionsInput, _param2 func(*iam.ListPolicyVersionsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListPolicyVersionsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListRolePoliciesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListRolePoliciesRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListPolicyVersionsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListPolicyVersionsPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListRolePolicies(_param0 *iam.ListRolePoliciesInput) (*iam.ListRolePoliciesOutput, error) {
@@ -2016,6 +3558,33 @@ func (_mr *_MockIAMAPIRecorder) ListRolePolicies(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListRolePolicies", arg0)
 }
 
+func (_m *MockIAMAPI) ListRolePoliciesWithContext(_param0 aws.Context, _param1 *iam.ListRolePoliciesInput, _param2 ...request.Option) (*iam.ListRolePoliciesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListRolePoliciesWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListRolePoliciesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListRolePoliciesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListRolePoliciesWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListRolePoliciesRequest(_param0 *iam.ListRolePoliciesInput) (*request.Request, *iam.ListRolePoliciesOutput) {
+	ret := _m.ctrl.Call(_m, "ListRolePoliciesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListRolePoliciesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListRolePoliciesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListRolePoliciesRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListRolePoliciesPages(_param0 *iam.ListRolePoliciesInput, _param1 func(*iam.ListRolePoliciesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListRolePoliciesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -2026,15 +3595,19 @@ func (_mr *_MockIAMAPIRecorder) ListRolePoliciesPages(arg0, arg1 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListRolePoliciesPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListRolesRequest(_param0 *iam.ListRolesInput) (*request.Request, *iam.ListRolesOutput) {
-	ret := _m.ctrl.Call(_m, "ListRolesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListRolesOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListRolePoliciesPagesWithContext(_param0 aws.Context, _param1 *iam.ListRolePoliciesInput, _param2 func(*iam.ListRolePoliciesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListRolePoliciesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListRolesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListRolesRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListRolePoliciesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListRolePoliciesPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListRoles(_param0 *iam.ListRolesInput) (*iam.ListRolesOutput, error) {
@@ -2048,6 +3621,33 @@ func (_mr *_MockIAMAPIRecorder) ListRoles(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListRoles", arg0)
 }
 
+func (_m *MockIAMAPI) ListRolesWithContext(_param0 aws.Context, _param1 *iam.ListRolesInput, _param2 ...request.Option) (*iam.ListRolesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListRolesWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListRolesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListRolesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListRolesWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListRolesRequest(_param0 *iam.ListRolesInput) (*request.Request, *iam.ListRolesOutput) {
+	ret := _m.ctrl.Call(_m, "ListRolesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListRolesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListRolesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListRolesRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListRolesPages(_param0 *iam.ListRolesInput, _param1 func(*iam.ListRolesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListRolesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -2058,15 +3658,19 @@ func (_mr *_MockIAMAPIRecorder) ListRolesPages(arg0, arg1 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListRolesPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListSAMLProvidersRequest(_param0 *iam.ListSAMLProvidersInput) (*request.Request, *iam.ListSAMLProvidersOutput) {
-	ret := _m.ctrl.Call(_m, "ListSAMLProvidersRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListSAMLProvidersOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListRolesPagesWithContext(_param0 aws.Context, _param1 *iam.ListRolesInput, _param2 func(*iam.ListRolesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListRolesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListSAMLProvidersRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListSAMLProvidersRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListRolesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListRolesPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListSAMLProviders(_param0 *iam.ListSAMLProvidersInput) (*iam.ListSAMLProvidersOutput, error) {
@@ -2080,15 +3684,31 @@ func (_mr *_MockIAMAPIRecorder) ListSAMLProviders(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListSAMLProviders", arg0)
 }
 
-func (_m *MockIAMAPI) ListSSHPublicKeysRequest(_param0 *iam.ListSSHPublicKeysInput) (*request.Request, *iam.ListSSHPublicKeysOutput) {
-	ret := _m.ctrl.Call(_m, "ListSSHPublicKeysRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListSSHPublicKeysOutput)
+func (_m *MockIAMAPI) ListSAMLProvidersWithContext(_param0 aws.Context, _param1 *iam.ListSAMLProvidersInput, _param2 ...request.Option) (*iam.ListSAMLProvidersOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListSAMLProvidersWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListSAMLProvidersOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) ListSSHPublicKeysRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListSSHPublicKeysRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListSAMLProvidersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListSAMLProvidersWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListSAMLProvidersRequest(_param0 *iam.ListSAMLProvidersInput) (*request.Request, *iam.ListSAMLProvidersOutput) {
+	ret := _m.ctrl.Call(_m, "ListSAMLProvidersRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListSAMLProvidersOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListSAMLProvidersRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListSAMLProvidersRequest", arg0)
 }
 
 func (_m *MockIAMAPI) ListSSHPublicKeys(_param0 *iam.ListSSHPublicKeysInput) (*iam.ListSSHPublicKeysOutput, error) {
@@ -2102,6 +3722,33 @@ func (_mr *_MockIAMAPIRecorder) ListSSHPublicKeys(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListSSHPublicKeys", arg0)
 }
 
+func (_m *MockIAMAPI) ListSSHPublicKeysWithContext(_param0 aws.Context, _param1 *iam.ListSSHPublicKeysInput, _param2 ...request.Option) (*iam.ListSSHPublicKeysOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListSSHPublicKeysWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListSSHPublicKeysOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListSSHPublicKeysWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListSSHPublicKeysWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListSSHPublicKeysRequest(_param0 *iam.ListSSHPublicKeysInput) (*request.Request, *iam.ListSSHPublicKeysOutput) {
+	ret := _m.ctrl.Call(_m, "ListSSHPublicKeysRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListSSHPublicKeysOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListSSHPublicKeysRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListSSHPublicKeysRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListSSHPublicKeysPages(_param0 *iam.ListSSHPublicKeysInput, _param1 func(*iam.ListSSHPublicKeysOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListSSHPublicKeysPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -2112,15 +3759,19 @@ func (_mr *_MockIAMAPIRecorder) ListSSHPublicKeysPages(arg0, arg1 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListSSHPublicKeysPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListServerCertificatesRequest(_param0 *iam.ListServerCertificatesInput) (*request.Request, *iam.ListServerCertificatesOutput) {
-	ret := _m.ctrl.Call(_m, "ListServerCertificatesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListServerCertificatesOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListSSHPublicKeysPagesWithContext(_param0 aws.Context, _param1 *iam.ListSSHPublicKeysInput, _param2 func(*iam.ListSSHPublicKeysOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListSSHPublicKeysPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListServerCertificatesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListServerCertificatesRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListSSHPublicKeysPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListSSHPublicKeysPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListServerCertificates(_param0 *iam.ListServerCertificatesInput) (*iam.ListServerCertificatesOutput, error) {
@@ -2134,6 +3785,33 @@ func (_mr *_MockIAMAPIRecorder) ListServerCertificates(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListServerCertificates", arg0)
 }
 
+func (_m *MockIAMAPI) ListServerCertificatesWithContext(_param0 aws.Context, _param1 *iam.ListServerCertificatesInput, _param2 ...request.Option) (*iam.ListServerCertificatesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListServerCertificatesWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListServerCertificatesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListServerCertificatesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListServerCertificatesWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListServerCertificatesRequest(_param0 *iam.ListServerCertificatesInput) (*request.Request, *iam.ListServerCertificatesOutput) {
+	ret := _m.ctrl.Call(_m, "ListServerCertificatesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListServerCertificatesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListServerCertificatesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListServerCertificatesRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListServerCertificatesPages(_param0 *iam.ListServerCertificatesInput, _param1 func(*iam.ListServerCertificatesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListServerCertificatesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -2144,15 +3822,19 @@ func (_mr *_MockIAMAPIRecorder) ListServerCertificatesPages(arg0, arg1 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListServerCertificatesPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListServiceSpecificCredentialsRequest(_param0 *iam.ListServiceSpecificCredentialsInput) (*request.Request, *iam.ListServiceSpecificCredentialsOutput) {
-	ret := _m.ctrl.Call(_m, "ListServiceSpecificCredentialsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListServiceSpecificCredentialsOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListServerCertificatesPagesWithContext(_param0 aws.Context, _param1 *iam.ListServerCertificatesInput, _param2 func(*iam.ListServerCertificatesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListServerCertificatesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListServiceSpecificCredentialsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListServiceSpecificCredentialsRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListServerCertificatesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListServerCertificatesPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListServiceSpecificCredentials(_param0 *iam.ListServiceSpecificCredentialsInput) (*iam.ListServiceSpecificCredentialsOutput, error) {
@@ -2166,15 +3848,31 @@ func (_mr *_MockIAMAPIRecorder) ListServiceSpecificCredentials(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListServiceSpecificCredentials", arg0)
 }
 
-func (_m *MockIAMAPI) ListSigningCertificatesRequest(_param0 *iam.ListSigningCertificatesInput) (*request.Request, *iam.ListSigningCertificatesOutput) {
-	ret := _m.ctrl.Call(_m, "ListSigningCertificatesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListSigningCertificatesOutput)
+func (_m *MockIAMAPI) ListServiceSpecificCredentialsWithContext(_param0 aws.Context, _param1 *iam.ListServiceSpecificCredentialsInput, _param2 ...request.Option) (*iam.ListServiceSpecificCredentialsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListServiceSpecificCredentialsWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListServiceSpecificCredentialsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) ListSigningCertificatesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListSigningCertificatesRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListServiceSpecificCredentialsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListServiceSpecificCredentialsWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListServiceSpecificCredentialsRequest(_param0 *iam.ListServiceSpecificCredentialsInput) (*request.Request, *iam.ListServiceSpecificCredentialsOutput) {
+	ret := _m.ctrl.Call(_m, "ListServiceSpecificCredentialsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListServiceSpecificCredentialsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListServiceSpecificCredentialsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListServiceSpecificCredentialsRequest", arg0)
 }
 
 func (_m *MockIAMAPI) ListSigningCertificates(_param0 *iam.ListSigningCertificatesInput) (*iam.ListSigningCertificatesOutput, error) {
@@ -2188,6 +3886,33 @@ func (_mr *_MockIAMAPIRecorder) ListSigningCertificates(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListSigningCertificates", arg0)
 }
 
+func (_m *MockIAMAPI) ListSigningCertificatesWithContext(_param0 aws.Context, _param1 *iam.ListSigningCertificatesInput, _param2 ...request.Option) (*iam.ListSigningCertificatesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListSigningCertificatesWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListSigningCertificatesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListSigningCertificatesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListSigningCertificatesWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListSigningCertificatesRequest(_param0 *iam.ListSigningCertificatesInput) (*request.Request, *iam.ListSigningCertificatesOutput) {
+	ret := _m.ctrl.Call(_m, "ListSigningCertificatesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListSigningCertificatesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListSigningCertificatesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListSigningCertificatesRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListSigningCertificatesPages(_param0 *iam.ListSigningCertificatesInput, _param1 func(*iam.ListSigningCertificatesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListSigningCertificatesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -2198,15 +3923,19 @@ func (_mr *_MockIAMAPIRecorder) ListSigningCertificatesPages(arg0, arg1 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListSigningCertificatesPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListUserPoliciesRequest(_param0 *iam.ListUserPoliciesInput) (*request.Request, *iam.ListUserPoliciesOutput) {
-	ret := _m.ctrl.Call(_m, "ListUserPoliciesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListUserPoliciesOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListSigningCertificatesPagesWithContext(_param0 aws.Context, _param1 *iam.ListSigningCertificatesInput, _param2 func(*iam.ListSigningCertificatesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListSigningCertificatesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListUserPoliciesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListUserPoliciesRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListSigningCertificatesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListSigningCertificatesPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListUserPolicies(_param0 *iam.ListUserPoliciesInput) (*iam.ListUserPoliciesOutput, error) {
@@ -2220,6 +3949,33 @@ func (_mr *_MockIAMAPIRecorder) ListUserPolicies(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListUserPolicies", arg0)
 }
 
+func (_m *MockIAMAPI) ListUserPoliciesWithContext(_param0 aws.Context, _param1 *iam.ListUserPoliciesInput, _param2 ...request.Option) (*iam.ListUserPoliciesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListUserPoliciesWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListUserPoliciesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListUserPoliciesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListUserPoliciesWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListUserPoliciesRequest(_param0 *iam.ListUserPoliciesInput) (*request.Request, *iam.ListUserPoliciesOutput) {
+	ret := _m.ctrl.Call(_m, "ListUserPoliciesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListUserPoliciesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListUserPoliciesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListUserPoliciesRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListUserPoliciesPages(_param0 *iam.ListUserPoliciesInput, _param1 func(*iam.ListUserPoliciesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListUserPoliciesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -2230,15 +3986,19 @@ func (_mr *_MockIAMAPIRecorder) ListUserPoliciesPages(arg0, arg1 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListUserPoliciesPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListUsersRequest(_param0 *iam.ListUsersInput) (*request.Request, *iam.ListUsersOutput) {
-	ret := _m.ctrl.Call(_m, "ListUsersRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListUsersOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListUserPoliciesPagesWithContext(_param0 aws.Context, _param1 *iam.ListUserPoliciesInput, _param2 func(*iam.ListUserPoliciesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListUserPoliciesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListUsersRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListUsersRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListUserPoliciesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListUserPoliciesPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListUsers(_param0 *iam.ListUsersInput) (*iam.ListUsersOutput, error) {
@@ -2252,6 +4012,33 @@ func (_mr *_MockIAMAPIRecorder) ListUsers(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListUsers", arg0)
 }
 
+func (_m *MockIAMAPI) ListUsersWithContext(_param0 aws.Context, _param1 *iam.ListUsersInput, _param2 ...request.Option) (*iam.ListUsersOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListUsersWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListUsersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListUsersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListUsersWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListUsersRequest(_param0 *iam.ListUsersInput) (*request.Request, *iam.ListUsersOutput) {
+	ret := _m.ctrl.Call(_m, "ListUsersRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListUsersOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListUsersRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListUsersRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListUsersPages(_param0 *iam.ListUsersInput, _param1 func(*iam.ListUsersOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListUsersPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -2262,15 +4049,19 @@ func (_mr *_MockIAMAPIRecorder) ListUsersPages(arg0, arg1 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListUsersPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) ListVirtualMFADevicesRequest(_param0 *iam.ListVirtualMFADevicesInput) (*request.Request, *iam.ListVirtualMFADevicesOutput) {
-	ret := _m.ctrl.Call(_m, "ListVirtualMFADevicesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ListVirtualMFADevicesOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListUsersPagesWithContext(_param0 aws.Context, _param1 *iam.ListUsersInput, _param2 func(*iam.ListUsersOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListUsersPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) ListVirtualMFADevicesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListVirtualMFADevicesRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListUsersPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListUsersPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) ListVirtualMFADevices(_param0 *iam.ListVirtualMFADevicesInput) (*iam.ListVirtualMFADevicesOutput, error) {
@@ -2284,6 +4075,33 @@ func (_mr *_MockIAMAPIRecorder) ListVirtualMFADevices(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListVirtualMFADevices", arg0)
 }
 
+func (_m *MockIAMAPI) ListVirtualMFADevicesWithContext(_param0 aws.Context, _param1 *iam.ListVirtualMFADevicesInput, _param2 ...request.Option) (*iam.ListVirtualMFADevicesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListVirtualMFADevicesWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ListVirtualMFADevicesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListVirtualMFADevicesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListVirtualMFADevicesWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ListVirtualMFADevicesRequest(_param0 *iam.ListVirtualMFADevicesInput) (*request.Request, *iam.ListVirtualMFADevicesOutput) {
+	ret := _m.ctrl.Call(_m, "ListVirtualMFADevicesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ListVirtualMFADevicesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ListVirtualMFADevicesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListVirtualMFADevicesRequest", arg0)
+}
+
 func (_m *MockIAMAPI) ListVirtualMFADevicesPages(_param0 *iam.ListVirtualMFADevicesInput, _param1 func(*iam.ListVirtualMFADevicesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "ListVirtualMFADevicesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -2294,15 +4112,19 @@ func (_mr *_MockIAMAPIRecorder) ListVirtualMFADevicesPages(arg0, arg1 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListVirtualMFADevicesPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) PutGroupPolicyRequest(_param0 *iam.PutGroupPolicyInput) (*request.Request, *iam.PutGroupPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "PutGroupPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.PutGroupPolicyOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) ListVirtualMFADevicesPagesWithContext(_param0 aws.Context, _param1 *iam.ListVirtualMFADevicesInput, _param2 func(*iam.ListVirtualMFADevicesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListVirtualMFADevicesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) PutGroupPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutGroupPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ListVirtualMFADevicesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListVirtualMFADevicesPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) PutGroupPolicy(_param0 *iam.PutGroupPolicyInput) (*iam.PutGroupPolicyOutput, error) {
@@ -2316,15 +4138,31 @@ func (_mr *_MockIAMAPIRecorder) PutGroupPolicy(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutGroupPolicy", arg0)
 }
 
-func (_m *MockIAMAPI) PutRolePolicyRequest(_param0 *iam.PutRolePolicyInput) (*request.Request, *iam.PutRolePolicyOutput) {
-	ret := _m.ctrl.Call(_m, "PutRolePolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.PutRolePolicyOutput)
+func (_m *MockIAMAPI) PutGroupPolicyWithContext(_param0 aws.Context, _param1 *iam.PutGroupPolicyInput, _param2 ...request.Option) (*iam.PutGroupPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "PutGroupPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.PutGroupPolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) PutRolePolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutRolePolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) PutGroupPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutGroupPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) PutGroupPolicyRequest(_param0 *iam.PutGroupPolicyInput) (*request.Request, *iam.PutGroupPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "PutGroupPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.PutGroupPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) PutGroupPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutGroupPolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) PutRolePolicy(_param0 *iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error) {
@@ -2338,15 +4176,31 @@ func (_mr *_MockIAMAPIRecorder) PutRolePolicy(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutRolePolicy", arg0)
 }
 
-func (_m *MockIAMAPI) PutUserPolicyRequest(_param0 *iam.PutUserPolicyInput) (*request.Request, *iam.PutUserPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "PutUserPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.PutUserPolicyOutput)
+func (_m *MockIAMAPI) PutRolePolicyWithContext(_param0 aws.Context, _param1 *iam.PutRolePolicyInput, _param2 ...request.Option) (*iam.PutRolePolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "PutRolePolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.PutRolePolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) PutUserPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutUserPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) PutRolePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutRolePolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) PutRolePolicyRequest(_param0 *iam.PutRolePolicyInput) (*request.Request, *iam.PutRolePolicyOutput) {
+	ret := _m.ctrl.Call(_m, "PutRolePolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.PutRolePolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) PutRolePolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutRolePolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) PutUserPolicy(_param0 *iam.PutUserPolicyInput) (*iam.PutUserPolicyOutput, error) {
@@ -2360,15 +4214,31 @@ func (_mr *_MockIAMAPIRecorder) PutUserPolicy(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutUserPolicy", arg0)
 }
 
-func (_m *MockIAMAPI) RemoveClientIDFromOpenIDConnectProviderRequest(_param0 *iam.RemoveClientIDFromOpenIDConnectProviderInput) (*request.Request, *iam.RemoveClientIDFromOpenIDConnectProviderOutput) {
-	ret := _m.ctrl.Call(_m, "RemoveClientIDFromOpenIDConnectProviderRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.RemoveClientIDFromOpenIDConnectProviderOutput)
+func (_m *MockIAMAPI) PutUserPolicyWithContext(_param0 aws.Context, _param1 *iam.PutUserPolicyInput, _param2 ...request.Option) (*iam.PutUserPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "PutUserPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.PutUserPolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) RemoveClientIDFromOpenIDConnectProviderRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveClientIDFromOpenIDConnectProviderRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) PutUserPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutUserPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) PutUserPolicyRequest(_param0 *iam.PutUserPolicyInput) (*request.Request, *iam.PutUserPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "PutUserPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.PutUserPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) PutUserPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutUserPolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) RemoveClientIDFromOpenIDConnectProvider(_param0 *iam.RemoveClientIDFromOpenIDConnectProviderInput) (*iam.RemoveClientIDFromOpenIDConnectProviderOutput, error) {
@@ -2382,15 +4252,31 @@ func (_mr *_MockIAMAPIRecorder) RemoveClientIDFromOpenIDConnectProvider(arg0 int
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveClientIDFromOpenIDConnectProvider", arg0)
 }
 
-func (_m *MockIAMAPI) RemoveRoleFromInstanceProfileRequest(_param0 *iam.RemoveRoleFromInstanceProfileInput) (*request.Request, *iam.RemoveRoleFromInstanceProfileOutput) {
-	ret := _m.ctrl.Call(_m, "RemoveRoleFromInstanceProfileRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.RemoveRoleFromInstanceProfileOutput)
+func (_m *MockIAMAPI) RemoveClientIDFromOpenIDConnectProviderWithContext(_param0 aws.Context, _param1 *iam.RemoveClientIDFromOpenIDConnectProviderInput, _param2 ...request.Option) (*iam.RemoveClientIDFromOpenIDConnectProviderOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RemoveClientIDFromOpenIDConnectProviderWithContext", _s...)
+	ret0, _ := ret[0].(*iam.RemoveClientIDFromOpenIDConnectProviderOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) RemoveRoleFromInstanceProfileRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveRoleFromInstanceProfileRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) RemoveClientIDFromOpenIDConnectProviderWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveClientIDFromOpenIDConnectProviderWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) RemoveClientIDFromOpenIDConnectProviderRequest(_param0 *iam.RemoveClientIDFromOpenIDConnectProviderInput) (*request.Request, *iam.RemoveClientIDFromOpenIDConnectProviderOutput) {
+	ret := _m.ctrl.Call(_m, "RemoveClientIDFromOpenIDConnectProviderRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.RemoveClientIDFromOpenIDConnectProviderOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) RemoveClientIDFromOpenIDConnectProviderRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveClientIDFromOpenIDConnectProviderRequest", arg0)
 }
 
 func (_m *MockIAMAPI) RemoveRoleFromInstanceProfile(_param0 *iam.RemoveRoleFromInstanceProfileInput) (*iam.RemoveRoleFromInstanceProfileOutput, error) {
@@ -2404,15 +4290,31 @@ func (_mr *_MockIAMAPIRecorder) RemoveRoleFromInstanceProfile(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveRoleFromInstanceProfile", arg0)
 }
 
-func (_m *MockIAMAPI) RemoveUserFromGroupRequest(_param0 *iam.RemoveUserFromGroupInput) (*request.Request, *iam.RemoveUserFromGroupOutput) {
-	ret := _m.ctrl.Call(_m, "RemoveUserFromGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.RemoveUserFromGroupOutput)
+func (_m *MockIAMAPI) RemoveRoleFromInstanceProfileWithContext(_param0 aws.Context, _param1 *iam.RemoveRoleFromInstanceProfileInput, _param2 ...request.Option) (*iam.RemoveRoleFromInstanceProfileOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RemoveRoleFromInstanceProfileWithContext", _s...)
+	ret0, _ := ret[0].(*iam.RemoveRoleFromInstanceProfileOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) RemoveUserFromGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveUserFromGroupRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) RemoveRoleFromInstanceProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveRoleFromInstanceProfileWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) RemoveRoleFromInstanceProfileRequest(_param0 *iam.RemoveRoleFromInstanceProfileInput) (*request.Request, *iam.RemoveRoleFromInstanceProfileOutput) {
+	ret := _m.ctrl.Call(_m, "RemoveRoleFromInstanceProfileRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.RemoveRoleFromInstanceProfileOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) RemoveRoleFromInstanceProfileRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveRoleFromInstanceProfileRequest", arg0)
 }
 
 func (_m *MockIAMAPI) RemoveUserFromGroup(_param0 *iam.RemoveUserFromGroupInput) (*iam.RemoveUserFromGroupOutput, error) {
@@ -2426,15 +4328,31 @@ func (_mr *_MockIAMAPIRecorder) RemoveUserFromGroup(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveUserFromGroup", arg0)
 }
 
-func (_m *MockIAMAPI) ResetServiceSpecificCredentialRequest(_param0 *iam.ResetServiceSpecificCredentialInput) (*request.Request, *iam.ResetServiceSpecificCredentialOutput) {
-	ret := _m.ctrl.Call(_m, "ResetServiceSpecificCredentialRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ResetServiceSpecificCredentialOutput)
+func (_m *MockIAMAPI) RemoveUserFromGroupWithContext(_param0 aws.Context, _param1 *iam.RemoveUserFromGroupInput, _param2 ...request.Option) (*iam.RemoveUserFromGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RemoveUserFromGroupWithContext", _s...)
+	ret0, _ := ret[0].(*iam.RemoveUserFromGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) ResetServiceSpecificCredentialRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetServiceSpecificCredentialRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) RemoveUserFromGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveUserFromGroupWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) RemoveUserFromGroupRequest(_param0 *iam.RemoveUserFromGroupInput) (*request.Request, *iam.RemoveUserFromGroupOutput) {
+	ret := _m.ctrl.Call(_m, "RemoveUserFromGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.RemoveUserFromGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) RemoveUserFromGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveUserFromGroupRequest", arg0)
 }
 
 func (_m *MockIAMAPI) ResetServiceSpecificCredential(_param0 *iam.ResetServiceSpecificCredentialInput) (*iam.ResetServiceSpecificCredentialOutput, error) {
@@ -2448,15 +4366,31 @@ func (_mr *_MockIAMAPIRecorder) ResetServiceSpecificCredential(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetServiceSpecificCredential", arg0)
 }
 
-func (_m *MockIAMAPI) ResyncMFADeviceRequest(_param0 *iam.ResyncMFADeviceInput) (*request.Request, *iam.ResyncMFADeviceOutput) {
-	ret := _m.ctrl.Call(_m, "ResyncMFADeviceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.ResyncMFADeviceOutput)
+func (_m *MockIAMAPI) ResetServiceSpecificCredentialWithContext(_param0 aws.Context, _param1 *iam.ResetServiceSpecificCredentialInput, _param2 ...request.Option) (*iam.ResetServiceSpecificCredentialOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ResetServiceSpecificCredentialWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ResetServiceSpecificCredentialOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) ResyncMFADeviceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResyncMFADeviceRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ResetServiceSpecificCredentialWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetServiceSpecificCredentialWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ResetServiceSpecificCredentialRequest(_param0 *iam.ResetServiceSpecificCredentialInput) (*request.Request, *iam.ResetServiceSpecificCredentialOutput) {
+	ret := _m.ctrl.Call(_m, "ResetServiceSpecificCredentialRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ResetServiceSpecificCredentialOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ResetServiceSpecificCredentialRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetServiceSpecificCredentialRequest", arg0)
 }
 
 func (_m *MockIAMAPI) ResyncMFADevice(_param0 *iam.ResyncMFADeviceInput) (*iam.ResyncMFADeviceOutput, error) {
@@ -2470,15 +4404,31 @@ func (_mr *_MockIAMAPIRecorder) ResyncMFADevice(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResyncMFADevice", arg0)
 }
 
-func (_m *MockIAMAPI) SetDefaultPolicyVersionRequest(_param0 *iam.SetDefaultPolicyVersionInput) (*request.Request, *iam.SetDefaultPolicyVersionOutput) {
-	ret := _m.ctrl.Call(_m, "SetDefaultPolicyVersionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.SetDefaultPolicyVersionOutput)
+func (_m *MockIAMAPI) ResyncMFADeviceWithContext(_param0 aws.Context, _param1 *iam.ResyncMFADeviceInput, _param2 ...request.Option) (*iam.ResyncMFADeviceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ResyncMFADeviceWithContext", _s...)
+	ret0, _ := ret[0].(*iam.ResyncMFADeviceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) SetDefaultPolicyVersionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetDefaultPolicyVersionRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) ResyncMFADeviceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResyncMFADeviceWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) ResyncMFADeviceRequest(_param0 *iam.ResyncMFADeviceInput) (*request.Request, *iam.ResyncMFADeviceOutput) {
+	ret := _m.ctrl.Call(_m, "ResyncMFADeviceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.ResyncMFADeviceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) ResyncMFADeviceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResyncMFADeviceRequest", arg0)
 }
 
 func (_m *MockIAMAPI) SetDefaultPolicyVersion(_param0 *iam.SetDefaultPolicyVersionInput) (*iam.SetDefaultPolicyVersionOutput, error) {
@@ -2492,15 +4442,31 @@ func (_mr *_MockIAMAPIRecorder) SetDefaultPolicyVersion(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetDefaultPolicyVersion", arg0)
 }
 
-func (_m *MockIAMAPI) SimulateCustomPolicyRequest(_param0 *iam.SimulateCustomPolicyInput) (*request.Request, *iam.SimulatePolicyResponse) {
-	ret := _m.ctrl.Call(_m, "SimulateCustomPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.SimulatePolicyResponse)
+func (_m *MockIAMAPI) SetDefaultPolicyVersionWithContext(_param0 aws.Context, _param1 *iam.SetDefaultPolicyVersionInput, _param2 ...request.Option) (*iam.SetDefaultPolicyVersionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "SetDefaultPolicyVersionWithContext", _s...)
+	ret0, _ := ret[0].(*iam.SetDefaultPolicyVersionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) SimulateCustomPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SimulateCustomPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) SetDefaultPolicyVersionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetDefaultPolicyVersionWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) SetDefaultPolicyVersionRequest(_param0 *iam.SetDefaultPolicyVersionInput) (*request.Request, *iam.SetDefaultPolicyVersionOutput) {
+	ret := _m.ctrl.Call(_m, "SetDefaultPolicyVersionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.SetDefaultPolicyVersionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) SetDefaultPolicyVersionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetDefaultPolicyVersionRequest", arg0)
 }
 
 func (_m *MockIAMAPI) SimulateCustomPolicy(_param0 *iam.SimulateCustomPolicyInput) (*iam.SimulatePolicyResponse, error) {
@@ -2514,6 +4480,33 @@ func (_mr *_MockIAMAPIRecorder) SimulateCustomPolicy(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SimulateCustomPolicy", arg0)
 }
 
+func (_m *MockIAMAPI) SimulateCustomPolicyWithContext(_param0 aws.Context, _param1 *iam.SimulateCustomPolicyInput, _param2 ...request.Option) (*iam.SimulatePolicyResponse, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "SimulateCustomPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.SimulatePolicyResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) SimulateCustomPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SimulateCustomPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) SimulateCustomPolicyRequest(_param0 *iam.SimulateCustomPolicyInput) (*request.Request, *iam.SimulatePolicyResponse) {
+	ret := _m.ctrl.Call(_m, "SimulateCustomPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.SimulatePolicyResponse)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) SimulateCustomPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SimulateCustomPolicyRequest", arg0)
+}
+
 func (_m *MockIAMAPI) SimulateCustomPolicyPages(_param0 *iam.SimulateCustomPolicyInput, _param1 func(*iam.SimulatePolicyResponse, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "SimulateCustomPolicyPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -2524,15 +4517,19 @@ func (_mr *_MockIAMAPIRecorder) SimulateCustomPolicyPages(arg0, arg1 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SimulateCustomPolicyPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) SimulatePrincipalPolicyRequest(_param0 *iam.SimulatePrincipalPolicyInput) (*request.Request, *iam.SimulatePolicyResponse) {
-	ret := _m.ctrl.Call(_m, "SimulatePrincipalPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.SimulatePolicyResponse)
-	return ret0, ret1
+func (_m *MockIAMAPI) SimulateCustomPolicyPagesWithContext(_param0 aws.Context, _param1 *iam.SimulateCustomPolicyInput, _param2 func(*iam.SimulatePolicyResponse, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "SimulateCustomPolicyPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) SimulatePrincipalPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SimulatePrincipalPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) SimulateCustomPolicyPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SimulateCustomPolicyPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) SimulatePrincipalPolicy(_param0 *iam.SimulatePrincipalPolicyInput) (*iam.SimulatePolicyResponse, error) {
@@ -2546,6 +4543,33 @@ func (_mr *_MockIAMAPIRecorder) SimulatePrincipalPolicy(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SimulatePrincipalPolicy", arg0)
 }
 
+func (_m *MockIAMAPI) SimulatePrincipalPolicyWithContext(_param0 aws.Context, _param1 *iam.SimulatePrincipalPolicyInput, _param2 ...request.Option) (*iam.SimulatePolicyResponse, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "SimulatePrincipalPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.SimulatePolicyResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) SimulatePrincipalPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SimulatePrincipalPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) SimulatePrincipalPolicyRequest(_param0 *iam.SimulatePrincipalPolicyInput) (*request.Request, *iam.SimulatePolicyResponse) {
+	ret := _m.ctrl.Call(_m, "SimulatePrincipalPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.SimulatePolicyResponse)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) SimulatePrincipalPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SimulatePrincipalPolicyRequest", arg0)
+}
+
 func (_m *MockIAMAPI) SimulatePrincipalPolicyPages(_param0 *iam.SimulatePrincipalPolicyInput, _param1 func(*iam.SimulatePolicyResponse, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "SimulatePrincipalPolicyPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -2556,15 +4580,19 @@ func (_mr *_MockIAMAPIRecorder) SimulatePrincipalPolicyPages(arg0, arg1 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SimulatePrincipalPolicyPages", arg0, arg1)
 }
 
-func (_m *MockIAMAPI) UpdateAccessKeyRequest(_param0 *iam.UpdateAccessKeyInput) (*request.Request, *iam.UpdateAccessKeyOutput) {
-	ret := _m.ctrl.Call(_m, "UpdateAccessKeyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.UpdateAccessKeyOutput)
-	return ret0, ret1
+func (_m *MockIAMAPI) SimulatePrincipalPolicyPagesWithContext(_param0 aws.Context, _param1 *iam.SimulatePrincipalPolicyInput, _param2 func(*iam.SimulatePolicyResponse, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "SimulatePrincipalPolicyPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockIAMAPIRecorder) UpdateAccessKeyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateAccessKeyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) SimulatePrincipalPolicyPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SimulatePrincipalPolicyPagesWithContext", _s...)
 }
 
 func (_m *MockIAMAPI) UpdateAccessKey(_param0 *iam.UpdateAccessKeyInput) (*iam.UpdateAccessKeyOutput, error) {
@@ -2578,15 +4606,31 @@ func (_mr *_MockIAMAPIRecorder) UpdateAccessKey(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateAccessKey", arg0)
 }
 
-func (_m *MockIAMAPI) UpdateAccountPasswordPolicyRequest(_param0 *iam.UpdateAccountPasswordPolicyInput) (*request.Request, *iam.UpdateAccountPasswordPolicyOutput) {
-	ret := _m.ctrl.Call(_m, "UpdateAccountPasswordPolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.UpdateAccountPasswordPolicyOutput)
+func (_m *MockIAMAPI) UpdateAccessKeyWithContext(_param0 aws.Context, _param1 *iam.UpdateAccessKeyInput, _param2 ...request.Option) (*iam.UpdateAccessKeyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "UpdateAccessKeyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.UpdateAccessKeyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) UpdateAccountPasswordPolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateAccountPasswordPolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) UpdateAccessKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateAccessKeyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) UpdateAccessKeyRequest(_param0 *iam.UpdateAccessKeyInput) (*request.Request, *iam.UpdateAccessKeyOutput) {
+	ret := _m.ctrl.Call(_m, "UpdateAccessKeyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.UpdateAccessKeyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) UpdateAccessKeyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateAccessKeyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) UpdateAccountPasswordPolicy(_param0 *iam.UpdateAccountPasswordPolicyInput) (*iam.UpdateAccountPasswordPolicyOutput, error) {
@@ -2600,15 +4644,31 @@ func (_mr *_MockIAMAPIRecorder) UpdateAccountPasswordPolicy(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateAccountPasswordPolicy", arg0)
 }
 
-func (_m *MockIAMAPI) UpdateAssumeRolePolicyRequest(_param0 *iam.UpdateAssumeRolePolicyInput) (*request.Request, *iam.UpdateAssumeRolePolicyOutput) {
-	ret := _m.ctrl.Call(_m, "UpdateAssumeRolePolicyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.UpdateAssumeRolePolicyOutput)
+func (_m *MockIAMAPI) UpdateAccountPasswordPolicyWithContext(_param0 aws.Context, _param1 *iam.UpdateAccountPasswordPolicyInput, _param2 ...request.Option) (*iam.UpdateAccountPasswordPolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "UpdateAccountPasswordPolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.UpdateAccountPasswordPolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) UpdateAssumeRolePolicyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateAssumeRolePolicyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) UpdateAccountPasswordPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateAccountPasswordPolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) UpdateAccountPasswordPolicyRequest(_param0 *iam.UpdateAccountPasswordPolicyInput) (*request.Request, *iam.UpdateAccountPasswordPolicyOutput) {
+	ret := _m.ctrl.Call(_m, "UpdateAccountPasswordPolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.UpdateAccountPasswordPolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) UpdateAccountPasswordPolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateAccountPasswordPolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) UpdateAssumeRolePolicy(_param0 *iam.UpdateAssumeRolePolicyInput) (*iam.UpdateAssumeRolePolicyOutput, error) {
@@ -2622,15 +4682,31 @@ func (_mr *_MockIAMAPIRecorder) UpdateAssumeRolePolicy(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateAssumeRolePolicy", arg0)
 }
 
-func (_m *MockIAMAPI) UpdateGroupRequest(_param0 *iam.UpdateGroupInput) (*request.Request, *iam.UpdateGroupOutput) {
-	ret := _m.ctrl.Call(_m, "UpdateGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.UpdateGroupOutput)
+func (_m *MockIAMAPI) UpdateAssumeRolePolicyWithContext(_param0 aws.Context, _param1 *iam.UpdateAssumeRolePolicyInput, _param2 ...request.Option) (*iam.UpdateAssumeRolePolicyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "UpdateAssumeRolePolicyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.UpdateAssumeRolePolicyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) UpdateGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateGroupRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) UpdateAssumeRolePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateAssumeRolePolicyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) UpdateAssumeRolePolicyRequest(_param0 *iam.UpdateAssumeRolePolicyInput) (*request.Request, *iam.UpdateAssumeRolePolicyOutput) {
+	ret := _m.ctrl.Call(_m, "UpdateAssumeRolePolicyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.UpdateAssumeRolePolicyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) UpdateAssumeRolePolicyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateAssumeRolePolicyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) UpdateGroup(_param0 *iam.UpdateGroupInput) (*iam.UpdateGroupOutput, error) {
@@ -2644,15 +4720,31 @@ func (_mr *_MockIAMAPIRecorder) UpdateGroup(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateGroup", arg0)
 }
 
-func (_m *MockIAMAPI) UpdateLoginProfileRequest(_param0 *iam.UpdateLoginProfileInput) (*request.Request, *iam.UpdateLoginProfileOutput) {
-	ret := _m.ctrl.Call(_m, "UpdateLoginProfileRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.UpdateLoginProfileOutput)
+func (_m *MockIAMAPI) UpdateGroupWithContext(_param0 aws.Context, _param1 *iam.UpdateGroupInput, _param2 ...request.Option) (*iam.UpdateGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "UpdateGroupWithContext", _s...)
+	ret0, _ := ret[0].(*iam.UpdateGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) UpdateLoginProfileRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateLoginProfileRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) UpdateGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateGroupWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) UpdateGroupRequest(_param0 *iam.UpdateGroupInput) (*request.Request, *iam.UpdateGroupOutput) {
+	ret := _m.ctrl.Call(_m, "UpdateGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.UpdateGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) UpdateGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateGroupRequest", arg0)
 }
 
 func (_m *MockIAMAPI) UpdateLoginProfile(_param0 *iam.UpdateLoginProfileInput) (*iam.UpdateLoginProfileOutput, error) {
@@ -2666,15 +4758,31 @@ func (_mr *_MockIAMAPIRecorder) UpdateLoginProfile(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateLoginProfile", arg0)
 }
 
-func (_m *MockIAMAPI) UpdateOpenIDConnectProviderThumbprintRequest(_param0 *iam.UpdateOpenIDConnectProviderThumbprintInput) (*request.Request, *iam.UpdateOpenIDConnectProviderThumbprintOutput) {
-	ret := _m.ctrl.Call(_m, "UpdateOpenIDConnectProviderThumbprintRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.UpdateOpenIDConnectProviderThumbprintOutput)
+func (_m *MockIAMAPI) UpdateLoginProfileWithContext(_param0 aws.Context, _param1 *iam.UpdateLoginProfileInput, _param2 ...request.Option) (*iam.UpdateLoginProfileOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "UpdateLoginProfileWithContext", _s...)
+	ret0, _ := ret[0].(*iam.UpdateLoginProfileOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) UpdateOpenIDConnectProviderThumbprintRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateOpenIDConnectProviderThumbprintRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) UpdateLoginProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateLoginProfileWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) UpdateLoginProfileRequest(_param0 *iam.UpdateLoginProfileInput) (*request.Request, *iam.UpdateLoginProfileOutput) {
+	ret := _m.ctrl.Call(_m, "UpdateLoginProfileRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.UpdateLoginProfileOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) UpdateLoginProfileRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateLoginProfileRequest", arg0)
 }
 
 func (_m *MockIAMAPI) UpdateOpenIDConnectProviderThumbprint(_param0 *iam.UpdateOpenIDConnectProviderThumbprintInput) (*iam.UpdateOpenIDConnectProviderThumbprintOutput, error) {
@@ -2688,15 +4796,31 @@ func (_mr *_MockIAMAPIRecorder) UpdateOpenIDConnectProviderThumbprint(arg0 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateOpenIDConnectProviderThumbprint", arg0)
 }
 
-func (_m *MockIAMAPI) UpdateSAMLProviderRequest(_param0 *iam.UpdateSAMLProviderInput) (*request.Request, *iam.UpdateSAMLProviderOutput) {
-	ret := _m.ctrl.Call(_m, "UpdateSAMLProviderRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.UpdateSAMLProviderOutput)
+func (_m *MockIAMAPI) UpdateOpenIDConnectProviderThumbprintWithContext(_param0 aws.Context, _param1 *iam.UpdateOpenIDConnectProviderThumbprintInput, _param2 ...request.Option) (*iam.UpdateOpenIDConnectProviderThumbprintOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "UpdateOpenIDConnectProviderThumbprintWithContext", _s...)
+	ret0, _ := ret[0].(*iam.UpdateOpenIDConnectProviderThumbprintOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) UpdateSAMLProviderRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateSAMLProviderRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) UpdateOpenIDConnectProviderThumbprintWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateOpenIDConnectProviderThumbprintWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) UpdateOpenIDConnectProviderThumbprintRequest(_param0 *iam.UpdateOpenIDConnectProviderThumbprintInput) (*request.Request, *iam.UpdateOpenIDConnectProviderThumbprintOutput) {
+	ret := _m.ctrl.Call(_m, "UpdateOpenIDConnectProviderThumbprintRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.UpdateOpenIDConnectProviderThumbprintOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) UpdateOpenIDConnectProviderThumbprintRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateOpenIDConnectProviderThumbprintRequest", arg0)
 }
 
 func (_m *MockIAMAPI) UpdateSAMLProvider(_param0 *iam.UpdateSAMLProviderInput) (*iam.UpdateSAMLProviderOutput, error) {
@@ -2710,15 +4834,31 @@ func (_mr *_MockIAMAPIRecorder) UpdateSAMLProvider(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateSAMLProvider", arg0)
 }
 
-func (_m *MockIAMAPI) UpdateSSHPublicKeyRequest(_param0 *iam.UpdateSSHPublicKeyInput) (*request.Request, *iam.UpdateSSHPublicKeyOutput) {
-	ret := _m.ctrl.Call(_m, "UpdateSSHPublicKeyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.UpdateSSHPublicKeyOutput)
+func (_m *MockIAMAPI) UpdateSAMLProviderWithContext(_param0 aws.Context, _param1 *iam.UpdateSAMLProviderInput, _param2 ...request.Option) (*iam.UpdateSAMLProviderOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "UpdateSAMLProviderWithContext", _s...)
+	ret0, _ := ret[0].(*iam.UpdateSAMLProviderOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) UpdateSSHPublicKeyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateSSHPublicKeyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) UpdateSAMLProviderWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateSAMLProviderWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) UpdateSAMLProviderRequest(_param0 *iam.UpdateSAMLProviderInput) (*request.Request, *iam.UpdateSAMLProviderOutput) {
+	ret := _m.ctrl.Call(_m, "UpdateSAMLProviderRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.UpdateSAMLProviderOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) UpdateSAMLProviderRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateSAMLProviderRequest", arg0)
 }
 
 func (_m *MockIAMAPI) UpdateSSHPublicKey(_param0 *iam.UpdateSSHPublicKeyInput) (*iam.UpdateSSHPublicKeyOutput, error) {
@@ -2732,15 +4872,31 @@ func (_mr *_MockIAMAPIRecorder) UpdateSSHPublicKey(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateSSHPublicKey", arg0)
 }
 
-func (_m *MockIAMAPI) UpdateServerCertificateRequest(_param0 *iam.UpdateServerCertificateInput) (*request.Request, *iam.UpdateServerCertificateOutput) {
-	ret := _m.ctrl.Call(_m, "UpdateServerCertificateRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.UpdateServerCertificateOutput)
+func (_m *MockIAMAPI) UpdateSSHPublicKeyWithContext(_param0 aws.Context, _param1 *iam.UpdateSSHPublicKeyInput, _param2 ...request.Option) (*iam.UpdateSSHPublicKeyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "UpdateSSHPublicKeyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.UpdateSSHPublicKeyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) UpdateServerCertificateRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateServerCertificateRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) UpdateSSHPublicKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateSSHPublicKeyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) UpdateSSHPublicKeyRequest(_param0 *iam.UpdateSSHPublicKeyInput) (*request.Request, *iam.UpdateSSHPublicKeyOutput) {
+	ret := _m.ctrl.Call(_m, "UpdateSSHPublicKeyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.UpdateSSHPublicKeyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) UpdateSSHPublicKeyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateSSHPublicKeyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) UpdateServerCertificate(_param0 *iam.UpdateServerCertificateInput) (*iam.UpdateServerCertificateOutput, error) {
@@ -2754,15 +4910,31 @@ func (_mr *_MockIAMAPIRecorder) UpdateServerCertificate(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateServerCertificate", arg0)
 }
 
-func (_m *MockIAMAPI) UpdateServiceSpecificCredentialRequest(_param0 *iam.UpdateServiceSpecificCredentialInput) (*request.Request, *iam.UpdateServiceSpecificCredentialOutput) {
-	ret := _m.ctrl.Call(_m, "UpdateServiceSpecificCredentialRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.UpdateServiceSpecificCredentialOutput)
+func (_m *MockIAMAPI) UpdateServerCertificateWithContext(_param0 aws.Context, _param1 *iam.UpdateServerCertificateInput, _param2 ...request.Option) (*iam.UpdateServerCertificateOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "UpdateServerCertificateWithContext", _s...)
+	ret0, _ := ret[0].(*iam.UpdateServerCertificateOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) UpdateServiceSpecificCredentialRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateServiceSpecificCredentialRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) UpdateServerCertificateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateServerCertificateWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) UpdateServerCertificateRequest(_param0 *iam.UpdateServerCertificateInput) (*request.Request, *iam.UpdateServerCertificateOutput) {
+	ret := _m.ctrl.Call(_m, "UpdateServerCertificateRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.UpdateServerCertificateOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) UpdateServerCertificateRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateServerCertificateRequest", arg0)
 }
 
 func (_m *MockIAMAPI) UpdateServiceSpecificCredential(_param0 *iam.UpdateServiceSpecificCredentialInput) (*iam.UpdateServiceSpecificCredentialOutput, error) {
@@ -2776,15 +4948,31 @@ func (_mr *_MockIAMAPIRecorder) UpdateServiceSpecificCredential(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateServiceSpecificCredential", arg0)
 }
 
-func (_m *MockIAMAPI) UpdateSigningCertificateRequest(_param0 *iam.UpdateSigningCertificateInput) (*request.Request, *iam.UpdateSigningCertificateOutput) {
-	ret := _m.ctrl.Call(_m, "UpdateSigningCertificateRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.UpdateSigningCertificateOutput)
+func (_m *MockIAMAPI) UpdateServiceSpecificCredentialWithContext(_param0 aws.Context, _param1 *iam.UpdateServiceSpecificCredentialInput, _param2 ...request.Option) (*iam.UpdateServiceSpecificCredentialOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "UpdateServiceSpecificCredentialWithContext", _s...)
+	ret0, _ := ret[0].(*iam.UpdateServiceSpecificCredentialOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) UpdateSigningCertificateRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateSigningCertificateRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) UpdateServiceSpecificCredentialWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateServiceSpecificCredentialWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) UpdateServiceSpecificCredentialRequest(_param0 *iam.UpdateServiceSpecificCredentialInput) (*request.Request, *iam.UpdateServiceSpecificCredentialOutput) {
+	ret := _m.ctrl.Call(_m, "UpdateServiceSpecificCredentialRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.UpdateServiceSpecificCredentialOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) UpdateServiceSpecificCredentialRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateServiceSpecificCredentialRequest", arg0)
 }
 
 func (_m *MockIAMAPI) UpdateSigningCertificate(_param0 *iam.UpdateSigningCertificateInput) (*iam.UpdateSigningCertificateOutput, error) {
@@ -2798,15 +4986,31 @@ func (_mr *_MockIAMAPIRecorder) UpdateSigningCertificate(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateSigningCertificate", arg0)
 }
 
-func (_m *MockIAMAPI) UpdateUserRequest(_param0 *iam.UpdateUserInput) (*request.Request, *iam.UpdateUserOutput) {
-	ret := _m.ctrl.Call(_m, "UpdateUserRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.UpdateUserOutput)
+func (_m *MockIAMAPI) UpdateSigningCertificateWithContext(_param0 aws.Context, _param1 *iam.UpdateSigningCertificateInput, _param2 ...request.Option) (*iam.UpdateSigningCertificateOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "UpdateSigningCertificateWithContext", _s...)
+	ret0, _ := ret[0].(*iam.UpdateSigningCertificateOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) UpdateUserRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateUserRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) UpdateSigningCertificateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateSigningCertificateWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) UpdateSigningCertificateRequest(_param0 *iam.UpdateSigningCertificateInput) (*request.Request, *iam.UpdateSigningCertificateOutput) {
+	ret := _m.ctrl.Call(_m, "UpdateSigningCertificateRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.UpdateSigningCertificateOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) UpdateSigningCertificateRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateSigningCertificateRequest", arg0)
 }
 
 func (_m *MockIAMAPI) UpdateUser(_param0 *iam.UpdateUserInput) (*iam.UpdateUserOutput, error) {
@@ -2820,15 +5024,31 @@ func (_mr *_MockIAMAPIRecorder) UpdateUser(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateUser", arg0)
 }
 
-func (_m *MockIAMAPI) UploadSSHPublicKeyRequest(_param0 *iam.UploadSSHPublicKeyInput) (*request.Request, *iam.UploadSSHPublicKeyOutput) {
-	ret := _m.ctrl.Call(_m, "UploadSSHPublicKeyRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.UploadSSHPublicKeyOutput)
+func (_m *MockIAMAPI) UpdateUserWithContext(_param0 aws.Context, _param1 *iam.UpdateUserInput, _param2 ...request.Option) (*iam.UpdateUserOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "UpdateUserWithContext", _s...)
+	ret0, _ := ret[0].(*iam.UpdateUserOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) UploadSSHPublicKeyRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UploadSSHPublicKeyRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) UpdateUserWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateUserWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) UpdateUserRequest(_param0 *iam.UpdateUserInput) (*request.Request, *iam.UpdateUserOutput) {
+	ret := _m.ctrl.Call(_m, "UpdateUserRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.UpdateUserOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) UpdateUserRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateUserRequest", arg0)
 }
 
 func (_m *MockIAMAPI) UploadSSHPublicKey(_param0 *iam.UploadSSHPublicKeyInput) (*iam.UploadSSHPublicKeyOutput, error) {
@@ -2842,15 +5062,31 @@ func (_mr *_MockIAMAPIRecorder) UploadSSHPublicKey(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UploadSSHPublicKey", arg0)
 }
 
-func (_m *MockIAMAPI) UploadServerCertificateRequest(_param0 *iam.UploadServerCertificateInput) (*request.Request, *iam.UploadServerCertificateOutput) {
-	ret := _m.ctrl.Call(_m, "UploadServerCertificateRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.UploadServerCertificateOutput)
+func (_m *MockIAMAPI) UploadSSHPublicKeyWithContext(_param0 aws.Context, _param1 *iam.UploadSSHPublicKeyInput, _param2 ...request.Option) (*iam.UploadSSHPublicKeyOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "UploadSSHPublicKeyWithContext", _s...)
+	ret0, _ := ret[0].(*iam.UploadSSHPublicKeyOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) UploadServerCertificateRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UploadServerCertificateRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) UploadSSHPublicKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UploadSSHPublicKeyWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) UploadSSHPublicKeyRequest(_param0 *iam.UploadSSHPublicKeyInput) (*request.Request, *iam.UploadSSHPublicKeyOutput) {
+	ret := _m.ctrl.Call(_m, "UploadSSHPublicKeyRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.UploadSSHPublicKeyOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) UploadSSHPublicKeyRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UploadSSHPublicKeyRequest", arg0)
 }
 
 func (_m *MockIAMAPI) UploadServerCertificate(_param0 *iam.UploadServerCertificateInput) (*iam.UploadServerCertificateOutput, error) {
@@ -2864,15 +5100,31 @@ func (_mr *_MockIAMAPIRecorder) UploadServerCertificate(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UploadServerCertificate", arg0)
 }
 
-func (_m *MockIAMAPI) UploadSigningCertificateRequest(_param0 *iam.UploadSigningCertificateInput) (*request.Request, *iam.UploadSigningCertificateOutput) {
-	ret := _m.ctrl.Call(_m, "UploadSigningCertificateRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*iam.UploadSigningCertificateOutput)
+func (_m *MockIAMAPI) UploadServerCertificateWithContext(_param0 aws.Context, _param1 *iam.UploadServerCertificateInput, _param2 ...request.Option) (*iam.UploadServerCertificateOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "UploadServerCertificateWithContext", _s...)
+	ret0, _ := ret[0].(*iam.UploadServerCertificateOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockIAMAPIRecorder) UploadSigningCertificateRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UploadSigningCertificateRequest", arg0)
+func (_mr *_MockIAMAPIRecorder) UploadServerCertificateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UploadServerCertificateWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) UploadServerCertificateRequest(_param0 *iam.UploadServerCertificateInput) (*request.Request, *iam.UploadServerCertificateOutput) {
+	ret := _m.ctrl.Call(_m, "UploadServerCertificateRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.UploadServerCertificateOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) UploadServerCertificateRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UploadServerCertificateRequest", arg0)
 }
 
 func (_m *MockIAMAPI) UploadSigningCertificate(_param0 *iam.UploadSigningCertificateInput) (*iam.UploadSigningCertificateOutput, error) {
@@ -2886,6 +5138,33 @@ func (_mr *_MockIAMAPIRecorder) UploadSigningCertificate(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UploadSigningCertificate", arg0)
 }
 
+func (_m *MockIAMAPI) UploadSigningCertificateWithContext(_param0 aws.Context, _param1 *iam.UploadSigningCertificateInput, _param2 ...request.Option) (*iam.UploadSigningCertificateOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "UploadSigningCertificateWithContext", _s...)
+	ret0, _ := ret[0].(*iam.UploadSigningCertificateOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) UploadSigningCertificateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UploadSigningCertificateWithContext", _s...)
+}
+
+func (_m *MockIAMAPI) UploadSigningCertificateRequest(_param0 *iam.UploadSigningCertificateInput) (*request.Request, *iam.UploadSigningCertificateOutput) {
+	ret := _m.ctrl.Call(_m, "UploadSigningCertificateRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*iam.UploadSigningCertificateOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockIAMAPIRecorder) UploadSigningCertificateRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UploadSigningCertificateRequest", arg0)
+}
+
 func (_m *MockIAMAPI) WaitUntilInstanceProfileExists(_param0 *iam.GetInstanceProfileInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilInstanceProfileExists", _param0)
 	ret0, _ := ret[0].(error)
@@ -2896,6 +5175,21 @@ func (_mr *_MockIAMAPIRecorder) WaitUntilInstanceProfileExists(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceProfileExists", arg0)
 }
 
+func (_m *MockIAMAPI) WaitUntilInstanceProfileExistsWithContext(_param0 aws.Context, _param1 *iam.GetInstanceProfileInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilInstanceProfileExistsWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockIAMAPIRecorder) WaitUntilInstanceProfileExistsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilInstanceProfileExistsWithContext", _s...)
+}
+
 func (_m *MockIAMAPI) WaitUntilUserExists(_param0 *iam.GetUserInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilUserExists", _param0)
 	ret0, _ := ret[0].(error)
@@ -2904,4 +5198,19 @@ func (_m *MockIAMAPI) WaitUntilUserExists(_param0 *iam.GetUserInput) error {
 
 func (_mr *_MockIAMAPIRecorder) WaitUntilUserExists(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilUserExists", arg0)
+}
+
+func (_m *MockIAMAPI) WaitUntilUserExistsWithContext(_param0 aws.Context, _param1 *iam.GetUserInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilUserExistsWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockIAMAPIRecorder) WaitUntilUserExistsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilUserExistsWithContext", _s...)
 }

--- a/mock/rdsmock.go
+++ b/mock/rdsmock.go
@@ -4,6 +4,7 @@
 package mock
 
 import (
+	aws "github.com/aws/aws-sdk-go/aws"
 	request "github.com/aws/aws-sdk-go/aws/request"
 	rds "github.com/aws/aws-sdk-go/service/rds"
 	gomock "github.com/golang/mock/gomock"
@@ -30,17 +31,6 @@ func (_m *MockRDSAPI) EXPECT() *_MockRDSAPIRecorder {
 	return _m.recorder
 }
 
-func (_m *MockRDSAPI) AddRoleToDBClusterRequest(_param0 *rds.AddRoleToDBClusterInput) (*request.Request, *rds.AddRoleToDBClusterOutput) {
-	ret := _m.ctrl.Call(_m, "AddRoleToDBClusterRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.AddRoleToDBClusterOutput)
-	return ret0, ret1
-}
-
-func (_mr *_MockRDSAPIRecorder) AddRoleToDBClusterRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddRoleToDBClusterRequest", arg0)
-}
-
 func (_m *MockRDSAPI) AddRoleToDBCluster(_param0 *rds.AddRoleToDBClusterInput) (*rds.AddRoleToDBClusterOutput, error) {
 	ret := _m.ctrl.Call(_m, "AddRoleToDBCluster", _param0)
 	ret0, _ := ret[0].(*rds.AddRoleToDBClusterOutput)
@@ -52,15 +42,31 @@ func (_mr *_MockRDSAPIRecorder) AddRoleToDBCluster(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddRoleToDBCluster", arg0)
 }
 
-func (_m *MockRDSAPI) AddSourceIdentifierToSubscriptionRequest(_param0 *rds.AddSourceIdentifierToSubscriptionInput) (*request.Request, *rds.AddSourceIdentifierToSubscriptionOutput) {
-	ret := _m.ctrl.Call(_m, "AddSourceIdentifierToSubscriptionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.AddSourceIdentifierToSubscriptionOutput)
+func (_m *MockRDSAPI) AddRoleToDBClusterWithContext(_param0 aws.Context, _param1 *rds.AddRoleToDBClusterInput, _param2 ...request.Option) (*rds.AddRoleToDBClusterOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AddRoleToDBClusterWithContext", _s...)
+	ret0, _ := ret[0].(*rds.AddRoleToDBClusterOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) AddSourceIdentifierToSubscriptionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddSourceIdentifierToSubscriptionRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) AddRoleToDBClusterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddRoleToDBClusterWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) AddRoleToDBClusterRequest(_param0 *rds.AddRoleToDBClusterInput) (*request.Request, *rds.AddRoleToDBClusterOutput) {
+	ret := _m.ctrl.Call(_m, "AddRoleToDBClusterRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.AddRoleToDBClusterOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) AddRoleToDBClusterRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddRoleToDBClusterRequest", arg0)
 }
 
 func (_m *MockRDSAPI) AddSourceIdentifierToSubscription(_param0 *rds.AddSourceIdentifierToSubscriptionInput) (*rds.AddSourceIdentifierToSubscriptionOutput, error) {
@@ -74,15 +80,31 @@ func (_mr *_MockRDSAPIRecorder) AddSourceIdentifierToSubscription(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddSourceIdentifierToSubscription", arg0)
 }
 
-func (_m *MockRDSAPI) AddTagsToResourceRequest(_param0 *rds.AddTagsToResourceInput) (*request.Request, *rds.AddTagsToResourceOutput) {
-	ret := _m.ctrl.Call(_m, "AddTagsToResourceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.AddTagsToResourceOutput)
+func (_m *MockRDSAPI) AddSourceIdentifierToSubscriptionWithContext(_param0 aws.Context, _param1 *rds.AddSourceIdentifierToSubscriptionInput, _param2 ...request.Option) (*rds.AddSourceIdentifierToSubscriptionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AddSourceIdentifierToSubscriptionWithContext", _s...)
+	ret0, _ := ret[0].(*rds.AddSourceIdentifierToSubscriptionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) AddTagsToResourceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddTagsToResourceRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) AddSourceIdentifierToSubscriptionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddSourceIdentifierToSubscriptionWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) AddSourceIdentifierToSubscriptionRequest(_param0 *rds.AddSourceIdentifierToSubscriptionInput) (*request.Request, *rds.AddSourceIdentifierToSubscriptionOutput) {
+	ret := _m.ctrl.Call(_m, "AddSourceIdentifierToSubscriptionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.AddSourceIdentifierToSubscriptionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) AddSourceIdentifierToSubscriptionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddSourceIdentifierToSubscriptionRequest", arg0)
 }
 
 func (_m *MockRDSAPI) AddTagsToResource(_param0 *rds.AddTagsToResourceInput) (*rds.AddTagsToResourceOutput, error) {
@@ -96,15 +118,31 @@ func (_mr *_MockRDSAPIRecorder) AddTagsToResource(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddTagsToResource", arg0)
 }
 
-func (_m *MockRDSAPI) ApplyPendingMaintenanceActionRequest(_param0 *rds.ApplyPendingMaintenanceActionInput) (*request.Request, *rds.ApplyPendingMaintenanceActionOutput) {
-	ret := _m.ctrl.Call(_m, "ApplyPendingMaintenanceActionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.ApplyPendingMaintenanceActionOutput)
+func (_m *MockRDSAPI) AddTagsToResourceWithContext(_param0 aws.Context, _param1 *rds.AddTagsToResourceInput, _param2 ...request.Option) (*rds.AddTagsToResourceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AddTagsToResourceWithContext", _s...)
+	ret0, _ := ret[0].(*rds.AddTagsToResourceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) ApplyPendingMaintenanceActionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ApplyPendingMaintenanceActionRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) AddTagsToResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddTagsToResourceWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) AddTagsToResourceRequest(_param0 *rds.AddTagsToResourceInput) (*request.Request, *rds.AddTagsToResourceOutput) {
+	ret := _m.ctrl.Call(_m, "AddTagsToResourceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.AddTagsToResourceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) AddTagsToResourceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddTagsToResourceRequest", arg0)
 }
 
 func (_m *MockRDSAPI) ApplyPendingMaintenanceAction(_param0 *rds.ApplyPendingMaintenanceActionInput) (*rds.ApplyPendingMaintenanceActionOutput, error) {
@@ -118,15 +156,31 @@ func (_mr *_MockRDSAPIRecorder) ApplyPendingMaintenanceAction(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ApplyPendingMaintenanceAction", arg0)
 }
 
-func (_m *MockRDSAPI) AuthorizeDBSecurityGroupIngressRequest(_param0 *rds.AuthorizeDBSecurityGroupIngressInput) (*request.Request, *rds.AuthorizeDBSecurityGroupIngressOutput) {
-	ret := _m.ctrl.Call(_m, "AuthorizeDBSecurityGroupIngressRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.AuthorizeDBSecurityGroupIngressOutput)
+func (_m *MockRDSAPI) ApplyPendingMaintenanceActionWithContext(_param0 aws.Context, _param1 *rds.ApplyPendingMaintenanceActionInput, _param2 ...request.Option) (*rds.ApplyPendingMaintenanceActionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ApplyPendingMaintenanceActionWithContext", _s...)
+	ret0, _ := ret[0].(*rds.ApplyPendingMaintenanceActionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) AuthorizeDBSecurityGroupIngressRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AuthorizeDBSecurityGroupIngressRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) ApplyPendingMaintenanceActionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ApplyPendingMaintenanceActionWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) ApplyPendingMaintenanceActionRequest(_param0 *rds.ApplyPendingMaintenanceActionInput) (*request.Request, *rds.ApplyPendingMaintenanceActionOutput) {
+	ret := _m.ctrl.Call(_m, "ApplyPendingMaintenanceActionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.ApplyPendingMaintenanceActionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) ApplyPendingMaintenanceActionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ApplyPendingMaintenanceActionRequest", arg0)
 }
 
 func (_m *MockRDSAPI) AuthorizeDBSecurityGroupIngress(_param0 *rds.AuthorizeDBSecurityGroupIngressInput) (*rds.AuthorizeDBSecurityGroupIngressOutput, error) {
@@ -140,15 +194,31 @@ func (_mr *_MockRDSAPIRecorder) AuthorizeDBSecurityGroupIngress(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AuthorizeDBSecurityGroupIngress", arg0)
 }
 
-func (_m *MockRDSAPI) CopyDBClusterParameterGroupRequest(_param0 *rds.CopyDBClusterParameterGroupInput) (*request.Request, *rds.CopyDBClusterParameterGroupOutput) {
-	ret := _m.ctrl.Call(_m, "CopyDBClusterParameterGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.CopyDBClusterParameterGroupOutput)
+func (_m *MockRDSAPI) AuthorizeDBSecurityGroupIngressWithContext(_param0 aws.Context, _param1 *rds.AuthorizeDBSecurityGroupIngressInput, _param2 ...request.Option) (*rds.AuthorizeDBSecurityGroupIngressOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "AuthorizeDBSecurityGroupIngressWithContext", _s...)
+	ret0, _ := ret[0].(*rds.AuthorizeDBSecurityGroupIngressOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) CopyDBClusterParameterGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyDBClusterParameterGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) AuthorizeDBSecurityGroupIngressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AuthorizeDBSecurityGroupIngressWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) AuthorizeDBSecurityGroupIngressRequest(_param0 *rds.AuthorizeDBSecurityGroupIngressInput) (*request.Request, *rds.AuthorizeDBSecurityGroupIngressOutput) {
+	ret := _m.ctrl.Call(_m, "AuthorizeDBSecurityGroupIngressRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.AuthorizeDBSecurityGroupIngressOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) AuthorizeDBSecurityGroupIngressRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AuthorizeDBSecurityGroupIngressRequest", arg0)
 }
 
 func (_m *MockRDSAPI) CopyDBClusterParameterGroup(_param0 *rds.CopyDBClusterParameterGroupInput) (*rds.CopyDBClusterParameterGroupOutput, error) {
@@ -162,15 +232,31 @@ func (_mr *_MockRDSAPIRecorder) CopyDBClusterParameterGroup(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyDBClusterParameterGroup", arg0)
 }
 
-func (_m *MockRDSAPI) CopyDBClusterSnapshotRequest(_param0 *rds.CopyDBClusterSnapshotInput) (*request.Request, *rds.CopyDBClusterSnapshotOutput) {
-	ret := _m.ctrl.Call(_m, "CopyDBClusterSnapshotRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.CopyDBClusterSnapshotOutput)
+func (_m *MockRDSAPI) CopyDBClusterParameterGroupWithContext(_param0 aws.Context, _param1 *rds.CopyDBClusterParameterGroupInput, _param2 ...request.Option) (*rds.CopyDBClusterParameterGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CopyDBClusterParameterGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.CopyDBClusterParameterGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) CopyDBClusterSnapshotRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyDBClusterSnapshotRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) CopyDBClusterParameterGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyDBClusterParameterGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) CopyDBClusterParameterGroupRequest(_param0 *rds.CopyDBClusterParameterGroupInput) (*request.Request, *rds.CopyDBClusterParameterGroupOutput) {
+	ret := _m.ctrl.Call(_m, "CopyDBClusterParameterGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.CopyDBClusterParameterGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) CopyDBClusterParameterGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyDBClusterParameterGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) CopyDBClusterSnapshot(_param0 *rds.CopyDBClusterSnapshotInput) (*rds.CopyDBClusterSnapshotOutput, error) {
@@ -184,15 +270,31 @@ func (_mr *_MockRDSAPIRecorder) CopyDBClusterSnapshot(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyDBClusterSnapshot", arg0)
 }
 
-func (_m *MockRDSAPI) CopyDBParameterGroupRequest(_param0 *rds.CopyDBParameterGroupInput) (*request.Request, *rds.CopyDBParameterGroupOutput) {
-	ret := _m.ctrl.Call(_m, "CopyDBParameterGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.CopyDBParameterGroupOutput)
+func (_m *MockRDSAPI) CopyDBClusterSnapshotWithContext(_param0 aws.Context, _param1 *rds.CopyDBClusterSnapshotInput, _param2 ...request.Option) (*rds.CopyDBClusterSnapshotOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CopyDBClusterSnapshotWithContext", _s...)
+	ret0, _ := ret[0].(*rds.CopyDBClusterSnapshotOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) CopyDBParameterGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyDBParameterGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) CopyDBClusterSnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyDBClusterSnapshotWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) CopyDBClusterSnapshotRequest(_param0 *rds.CopyDBClusterSnapshotInput) (*request.Request, *rds.CopyDBClusterSnapshotOutput) {
+	ret := _m.ctrl.Call(_m, "CopyDBClusterSnapshotRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.CopyDBClusterSnapshotOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) CopyDBClusterSnapshotRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyDBClusterSnapshotRequest", arg0)
 }
 
 func (_m *MockRDSAPI) CopyDBParameterGroup(_param0 *rds.CopyDBParameterGroupInput) (*rds.CopyDBParameterGroupOutput, error) {
@@ -206,15 +308,31 @@ func (_mr *_MockRDSAPIRecorder) CopyDBParameterGroup(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyDBParameterGroup", arg0)
 }
 
-func (_m *MockRDSAPI) CopyDBSnapshotRequest(_param0 *rds.CopyDBSnapshotInput) (*request.Request, *rds.CopyDBSnapshotOutput) {
-	ret := _m.ctrl.Call(_m, "CopyDBSnapshotRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.CopyDBSnapshotOutput)
+func (_m *MockRDSAPI) CopyDBParameterGroupWithContext(_param0 aws.Context, _param1 *rds.CopyDBParameterGroupInput, _param2 ...request.Option) (*rds.CopyDBParameterGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CopyDBParameterGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.CopyDBParameterGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) CopyDBSnapshotRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyDBSnapshotRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) CopyDBParameterGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyDBParameterGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) CopyDBParameterGroupRequest(_param0 *rds.CopyDBParameterGroupInput) (*request.Request, *rds.CopyDBParameterGroupOutput) {
+	ret := _m.ctrl.Call(_m, "CopyDBParameterGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.CopyDBParameterGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) CopyDBParameterGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyDBParameterGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) CopyDBSnapshot(_param0 *rds.CopyDBSnapshotInput) (*rds.CopyDBSnapshotOutput, error) {
@@ -228,15 +346,31 @@ func (_mr *_MockRDSAPIRecorder) CopyDBSnapshot(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyDBSnapshot", arg0)
 }
 
-func (_m *MockRDSAPI) CopyOptionGroupRequest(_param0 *rds.CopyOptionGroupInput) (*request.Request, *rds.CopyOptionGroupOutput) {
-	ret := _m.ctrl.Call(_m, "CopyOptionGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.CopyOptionGroupOutput)
+func (_m *MockRDSAPI) CopyDBSnapshotWithContext(_param0 aws.Context, _param1 *rds.CopyDBSnapshotInput, _param2 ...request.Option) (*rds.CopyDBSnapshotOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CopyDBSnapshotWithContext", _s...)
+	ret0, _ := ret[0].(*rds.CopyDBSnapshotOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) CopyOptionGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyOptionGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) CopyDBSnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyDBSnapshotWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) CopyDBSnapshotRequest(_param0 *rds.CopyDBSnapshotInput) (*request.Request, *rds.CopyDBSnapshotOutput) {
+	ret := _m.ctrl.Call(_m, "CopyDBSnapshotRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.CopyDBSnapshotOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) CopyDBSnapshotRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyDBSnapshotRequest", arg0)
 }
 
 func (_m *MockRDSAPI) CopyOptionGroup(_param0 *rds.CopyOptionGroupInput) (*rds.CopyOptionGroupOutput, error) {
@@ -250,15 +384,31 @@ func (_mr *_MockRDSAPIRecorder) CopyOptionGroup(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyOptionGroup", arg0)
 }
 
-func (_m *MockRDSAPI) CreateDBClusterRequest(_param0 *rds.CreateDBClusterInput) (*request.Request, *rds.CreateDBClusterOutput) {
-	ret := _m.ctrl.Call(_m, "CreateDBClusterRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.CreateDBClusterOutput)
+func (_m *MockRDSAPI) CopyOptionGroupWithContext(_param0 aws.Context, _param1 *rds.CopyOptionGroupInput, _param2 ...request.Option) (*rds.CopyOptionGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CopyOptionGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.CopyOptionGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) CreateDBClusterRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBClusterRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) CopyOptionGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyOptionGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) CopyOptionGroupRequest(_param0 *rds.CopyOptionGroupInput) (*request.Request, *rds.CopyOptionGroupOutput) {
+	ret := _m.ctrl.Call(_m, "CopyOptionGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.CopyOptionGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) CopyOptionGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CopyOptionGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) CreateDBCluster(_param0 *rds.CreateDBClusterInput) (*rds.CreateDBClusterOutput, error) {
@@ -272,15 +422,31 @@ func (_mr *_MockRDSAPIRecorder) CreateDBCluster(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBCluster", arg0)
 }
 
-func (_m *MockRDSAPI) CreateDBClusterParameterGroupRequest(_param0 *rds.CreateDBClusterParameterGroupInput) (*request.Request, *rds.CreateDBClusterParameterGroupOutput) {
-	ret := _m.ctrl.Call(_m, "CreateDBClusterParameterGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.CreateDBClusterParameterGroupOutput)
+func (_m *MockRDSAPI) CreateDBClusterWithContext(_param0 aws.Context, _param1 *rds.CreateDBClusterInput, _param2 ...request.Option) (*rds.CreateDBClusterOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateDBClusterWithContext", _s...)
+	ret0, _ := ret[0].(*rds.CreateDBClusterOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) CreateDBClusterParameterGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBClusterParameterGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) CreateDBClusterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBClusterWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) CreateDBClusterRequest(_param0 *rds.CreateDBClusterInput) (*request.Request, *rds.CreateDBClusterOutput) {
+	ret := _m.ctrl.Call(_m, "CreateDBClusterRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.CreateDBClusterOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) CreateDBClusterRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBClusterRequest", arg0)
 }
 
 func (_m *MockRDSAPI) CreateDBClusterParameterGroup(_param0 *rds.CreateDBClusterParameterGroupInput) (*rds.CreateDBClusterParameterGroupOutput, error) {
@@ -294,15 +460,31 @@ func (_mr *_MockRDSAPIRecorder) CreateDBClusterParameterGroup(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBClusterParameterGroup", arg0)
 }
 
-func (_m *MockRDSAPI) CreateDBClusterSnapshotRequest(_param0 *rds.CreateDBClusterSnapshotInput) (*request.Request, *rds.CreateDBClusterSnapshotOutput) {
-	ret := _m.ctrl.Call(_m, "CreateDBClusterSnapshotRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.CreateDBClusterSnapshotOutput)
+func (_m *MockRDSAPI) CreateDBClusterParameterGroupWithContext(_param0 aws.Context, _param1 *rds.CreateDBClusterParameterGroupInput, _param2 ...request.Option) (*rds.CreateDBClusterParameterGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateDBClusterParameterGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.CreateDBClusterParameterGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) CreateDBClusterSnapshotRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBClusterSnapshotRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) CreateDBClusterParameterGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBClusterParameterGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) CreateDBClusterParameterGroupRequest(_param0 *rds.CreateDBClusterParameterGroupInput) (*request.Request, *rds.CreateDBClusterParameterGroupOutput) {
+	ret := _m.ctrl.Call(_m, "CreateDBClusterParameterGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.CreateDBClusterParameterGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) CreateDBClusterParameterGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBClusterParameterGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) CreateDBClusterSnapshot(_param0 *rds.CreateDBClusterSnapshotInput) (*rds.CreateDBClusterSnapshotOutput, error) {
@@ -316,15 +498,31 @@ func (_mr *_MockRDSAPIRecorder) CreateDBClusterSnapshot(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBClusterSnapshot", arg0)
 }
 
-func (_m *MockRDSAPI) CreateDBInstanceRequest(_param0 *rds.CreateDBInstanceInput) (*request.Request, *rds.CreateDBInstanceOutput) {
-	ret := _m.ctrl.Call(_m, "CreateDBInstanceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.CreateDBInstanceOutput)
+func (_m *MockRDSAPI) CreateDBClusterSnapshotWithContext(_param0 aws.Context, _param1 *rds.CreateDBClusterSnapshotInput, _param2 ...request.Option) (*rds.CreateDBClusterSnapshotOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateDBClusterSnapshotWithContext", _s...)
+	ret0, _ := ret[0].(*rds.CreateDBClusterSnapshotOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) CreateDBInstanceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBInstanceRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) CreateDBClusterSnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBClusterSnapshotWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) CreateDBClusterSnapshotRequest(_param0 *rds.CreateDBClusterSnapshotInput) (*request.Request, *rds.CreateDBClusterSnapshotOutput) {
+	ret := _m.ctrl.Call(_m, "CreateDBClusterSnapshotRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.CreateDBClusterSnapshotOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) CreateDBClusterSnapshotRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBClusterSnapshotRequest", arg0)
 }
 
 func (_m *MockRDSAPI) CreateDBInstance(_param0 *rds.CreateDBInstanceInput) (*rds.CreateDBInstanceOutput, error) {
@@ -338,15 +536,31 @@ func (_mr *_MockRDSAPIRecorder) CreateDBInstance(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBInstance", arg0)
 }
 
-func (_m *MockRDSAPI) CreateDBInstanceReadReplicaRequest(_param0 *rds.CreateDBInstanceReadReplicaInput) (*request.Request, *rds.CreateDBInstanceReadReplicaOutput) {
-	ret := _m.ctrl.Call(_m, "CreateDBInstanceReadReplicaRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.CreateDBInstanceReadReplicaOutput)
+func (_m *MockRDSAPI) CreateDBInstanceWithContext(_param0 aws.Context, _param1 *rds.CreateDBInstanceInput, _param2 ...request.Option) (*rds.CreateDBInstanceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateDBInstanceWithContext", _s...)
+	ret0, _ := ret[0].(*rds.CreateDBInstanceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) CreateDBInstanceReadReplicaRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBInstanceReadReplicaRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) CreateDBInstanceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBInstanceWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) CreateDBInstanceRequest(_param0 *rds.CreateDBInstanceInput) (*request.Request, *rds.CreateDBInstanceOutput) {
+	ret := _m.ctrl.Call(_m, "CreateDBInstanceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.CreateDBInstanceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) CreateDBInstanceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBInstanceRequest", arg0)
 }
 
 func (_m *MockRDSAPI) CreateDBInstanceReadReplica(_param0 *rds.CreateDBInstanceReadReplicaInput) (*rds.CreateDBInstanceReadReplicaOutput, error) {
@@ -360,15 +574,31 @@ func (_mr *_MockRDSAPIRecorder) CreateDBInstanceReadReplica(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBInstanceReadReplica", arg0)
 }
 
-func (_m *MockRDSAPI) CreateDBParameterGroupRequest(_param0 *rds.CreateDBParameterGroupInput) (*request.Request, *rds.CreateDBParameterGroupOutput) {
-	ret := _m.ctrl.Call(_m, "CreateDBParameterGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.CreateDBParameterGroupOutput)
+func (_m *MockRDSAPI) CreateDBInstanceReadReplicaWithContext(_param0 aws.Context, _param1 *rds.CreateDBInstanceReadReplicaInput, _param2 ...request.Option) (*rds.CreateDBInstanceReadReplicaOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateDBInstanceReadReplicaWithContext", _s...)
+	ret0, _ := ret[0].(*rds.CreateDBInstanceReadReplicaOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) CreateDBParameterGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBParameterGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) CreateDBInstanceReadReplicaWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBInstanceReadReplicaWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) CreateDBInstanceReadReplicaRequest(_param0 *rds.CreateDBInstanceReadReplicaInput) (*request.Request, *rds.CreateDBInstanceReadReplicaOutput) {
+	ret := _m.ctrl.Call(_m, "CreateDBInstanceReadReplicaRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.CreateDBInstanceReadReplicaOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) CreateDBInstanceReadReplicaRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBInstanceReadReplicaRequest", arg0)
 }
 
 func (_m *MockRDSAPI) CreateDBParameterGroup(_param0 *rds.CreateDBParameterGroupInput) (*rds.CreateDBParameterGroupOutput, error) {
@@ -382,15 +612,31 @@ func (_mr *_MockRDSAPIRecorder) CreateDBParameterGroup(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBParameterGroup", arg0)
 }
 
-func (_m *MockRDSAPI) CreateDBSecurityGroupRequest(_param0 *rds.CreateDBSecurityGroupInput) (*request.Request, *rds.CreateDBSecurityGroupOutput) {
-	ret := _m.ctrl.Call(_m, "CreateDBSecurityGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.CreateDBSecurityGroupOutput)
+func (_m *MockRDSAPI) CreateDBParameterGroupWithContext(_param0 aws.Context, _param1 *rds.CreateDBParameterGroupInput, _param2 ...request.Option) (*rds.CreateDBParameterGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateDBParameterGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.CreateDBParameterGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) CreateDBSecurityGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBSecurityGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) CreateDBParameterGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBParameterGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) CreateDBParameterGroupRequest(_param0 *rds.CreateDBParameterGroupInput) (*request.Request, *rds.CreateDBParameterGroupOutput) {
+	ret := _m.ctrl.Call(_m, "CreateDBParameterGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.CreateDBParameterGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) CreateDBParameterGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBParameterGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) CreateDBSecurityGroup(_param0 *rds.CreateDBSecurityGroupInput) (*rds.CreateDBSecurityGroupOutput, error) {
@@ -404,15 +650,31 @@ func (_mr *_MockRDSAPIRecorder) CreateDBSecurityGroup(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBSecurityGroup", arg0)
 }
 
-func (_m *MockRDSAPI) CreateDBSnapshotRequest(_param0 *rds.CreateDBSnapshotInput) (*request.Request, *rds.CreateDBSnapshotOutput) {
-	ret := _m.ctrl.Call(_m, "CreateDBSnapshotRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.CreateDBSnapshotOutput)
+func (_m *MockRDSAPI) CreateDBSecurityGroupWithContext(_param0 aws.Context, _param1 *rds.CreateDBSecurityGroupInput, _param2 ...request.Option) (*rds.CreateDBSecurityGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateDBSecurityGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.CreateDBSecurityGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) CreateDBSnapshotRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBSnapshotRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) CreateDBSecurityGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBSecurityGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) CreateDBSecurityGroupRequest(_param0 *rds.CreateDBSecurityGroupInput) (*request.Request, *rds.CreateDBSecurityGroupOutput) {
+	ret := _m.ctrl.Call(_m, "CreateDBSecurityGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.CreateDBSecurityGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) CreateDBSecurityGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBSecurityGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) CreateDBSnapshot(_param0 *rds.CreateDBSnapshotInput) (*rds.CreateDBSnapshotOutput, error) {
@@ -426,15 +688,31 @@ func (_mr *_MockRDSAPIRecorder) CreateDBSnapshot(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBSnapshot", arg0)
 }
 
-func (_m *MockRDSAPI) CreateDBSubnetGroupRequest(_param0 *rds.CreateDBSubnetGroupInput) (*request.Request, *rds.CreateDBSubnetGroupOutput) {
-	ret := _m.ctrl.Call(_m, "CreateDBSubnetGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.CreateDBSubnetGroupOutput)
+func (_m *MockRDSAPI) CreateDBSnapshotWithContext(_param0 aws.Context, _param1 *rds.CreateDBSnapshotInput, _param2 ...request.Option) (*rds.CreateDBSnapshotOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateDBSnapshotWithContext", _s...)
+	ret0, _ := ret[0].(*rds.CreateDBSnapshotOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) CreateDBSubnetGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBSubnetGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) CreateDBSnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBSnapshotWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) CreateDBSnapshotRequest(_param0 *rds.CreateDBSnapshotInput) (*request.Request, *rds.CreateDBSnapshotOutput) {
+	ret := _m.ctrl.Call(_m, "CreateDBSnapshotRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.CreateDBSnapshotOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) CreateDBSnapshotRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBSnapshotRequest", arg0)
 }
 
 func (_m *MockRDSAPI) CreateDBSubnetGroup(_param0 *rds.CreateDBSubnetGroupInput) (*rds.CreateDBSubnetGroupOutput, error) {
@@ -448,15 +726,31 @@ func (_mr *_MockRDSAPIRecorder) CreateDBSubnetGroup(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBSubnetGroup", arg0)
 }
 
-func (_m *MockRDSAPI) CreateEventSubscriptionRequest(_param0 *rds.CreateEventSubscriptionInput) (*request.Request, *rds.CreateEventSubscriptionOutput) {
-	ret := _m.ctrl.Call(_m, "CreateEventSubscriptionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.CreateEventSubscriptionOutput)
+func (_m *MockRDSAPI) CreateDBSubnetGroupWithContext(_param0 aws.Context, _param1 *rds.CreateDBSubnetGroupInput, _param2 ...request.Option) (*rds.CreateDBSubnetGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateDBSubnetGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.CreateDBSubnetGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) CreateEventSubscriptionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateEventSubscriptionRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) CreateDBSubnetGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBSubnetGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) CreateDBSubnetGroupRequest(_param0 *rds.CreateDBSubnetGroupInput) (*request.Request, *rds.CreateDBSubnetGroupOutput) {
+	ret := _m.ctrl.Call(_m, "CreateDBSubnetGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.CreateDBSubnetGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) CreateDBSubnetGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateDBSubnetGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) CreateEventSubscription(_param0 *rds.CreateEventSubscriptionInput) (*rds.CreateEventSubscriptionOutput, error) {
@@ -470,15 +764,31 @@ func (_mr *_MockRDSAPIRecorder) CreateEventSubscription(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateEventSubscription", arg0)
 }
 
-func (_m *MockRDSAPI) CreateOptionGroupRequest(_param0 *rds.CreateOptionGroupInput) (*request.Request, *rds.CreateOptionGroupOutput) {
-	ret := _m.ctrl.Call(_m, "CreateOptionGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.CreateOptionGroupOutput)
+func (_m *MockRDSAPI) CreateEventSubscriptionWithContext(_param0 aws.Context, _param1 *rds.CreateEventSubscriptionInput, _param2 ...request.Option) (*rds.CreateEventSubscriptionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateEventSubscriptionWithContext", _s...)
+	ret0, _ := ret[0].(*rds.CreateEventSubscriptionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) CreateOptionGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateOptionGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) CreateEventSubscriptionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateEventSubscriptionWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) CreateEventSubscriptionRequest(_param0 *rds.CreateEventSubscriptionInput) (*request.Request, *rds.CreateEventSubscriptionOutput) {
+	ret := _m.ctrl.Call(_m, "CreateEventSubscriptionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.CreateEventSubscriptionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) CreateEventSubscriptionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateEventSubscriptionRequest", arg0)
 }
 
 func (_m *MockRDSAPI) CreateOptionGroup(_param0 *rds.CreateOptionGroupInput) (*rds.CreateOptionGroupOutput, error) {
@@ -492,15 +802,31 @@ func (_mr *_MockRDSAPIRecorder) CreateOptionGroup(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateOptionGroup", arg0)
 }
 
-func (_m *MockRDSAPI) DeleteDBClusterRequest(_param0 *rds.DeleteDBClusterInput) (*request.Request, *rds.DeleteDBClusterOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteDBClusterRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DeleteDBClusterOutput)
+func (_m *MockRDSAPI) CreateOptionGroupWithContext(_param0 aws.Context, _param1 *rds.CreateOptionGroupInput, _param2 ...request.Option) (*rds.CreateOptionGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "CreateOptionGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.CreateOptionGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DeleteDBClusterRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBClusterRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) CreateOptionGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateOptionGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) CreateOptionGroupRequest(_param0 *rds.CreateOptionGroupInput) (*request.Request, *rds.CreateOptionGroupOutput) {
+	ret := _m.ctrl.Call(_m, "CreateOptionGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.CreateOptionGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) CreateOptionGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateOptionGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DeleteDBCluster(_param0 *rds.DeleteDBClusterInput) (*rds.DeleteDBClusterOutput, error) {
@@ -514,15 +840,31 @@ func (_mr *_MockRDSAPIRecorder) DeleteDBCluster(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBCluster", arg0)
 }
 
-func (_m *MockRDSAPI) DeleteDBClusterParameterGroupRequest(_param0 *rds.DeleteDBClusterParameterGroupInput) (*request.Request, *rds.DeleteDBClusterParameterGroupOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteDBClusterParameterGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DeleteDBClusterParameterGroupOutput)
+func (_m *MockRDSAPI) DeleteDBClusterWithContext(_param0 aws.Context, _param1 *rds.DeleteDBClusterInput, _param2 ...request.Option) (*rds.DeleteDBClusterOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteDBClusterWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DeleteDBClusterOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DeleteDBClusterParameterGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBClusterParameterGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DeleteDBClusterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBClusterWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DeleteDBClusterRequest(_param0 *rds.DeleteDBClusterInput) (*request.Request, *rds.DeleteDBClusterOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteDBClusterRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DeleteDBClusterOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DeleteDBClusterRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBClusterRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DeleteDBClusterParameterGroup(_param0 *rds.DeleteDBClusterParameterGroupInput) (*rds.DeleteDBClusterParameterGroupOutput, error) {
@@ -536,15 +878,31 @@ func (_mr *_MockRDSAPIRecorder) DeleteDBClusterParameterGroup(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBClusterParameterGroup", arg0)
 }
 
-func (_m *MockRDSAPI) DeleteDBClusterSnapshotRequest(_param0 *rds.DeleteDBClusterSnapshotInput) (*request.Request, *rds.DeleteDBClusterSnapshotOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteDBClusterSnapshotRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DeleteDBClusterSnapshotOutput)
+func (_m *MockRDSAPI) DeleteDBClusterParameterGroupWithContext(_param0 aws.Context, _param1 *rds.DeleteDBClusterParameterGroupInput, _param2 ...request.Option) (*rds.DeleteDBClusterParameterGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteDBClusterParameterGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DeleteDBClusterParameterGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DeleteDBClusterSnapshotRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBClusterSnapshotRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DeleteDBClusterParameterGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBClusterParameterGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DeleteDBClusterParameterGroupRequest(_param0 *rds.DeleteDBClusterParameterGroupInput) (*request.Request, *rds.DeleteDBClusterParameterGroupOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteDBClusterParameterGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DeleteDBClusterParameterGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DeleteDBClusterParameterGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBClusterParameterGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DeleteDBClusterSnapshot(_param0 *rds.DeleteDBClusterSnapshotInput) (*rds.DeleteDBClusterSnapshotOutput, error) {
@@ -558,15 +916,31 @@ func (_mr *_MockRDSAPIRecorder) DeleteDBClusterSnapshot(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBClusterSnapshot", arg0)
 }
 
-func (_m *MockRDSAPI) DeleteDBInstanceRequest(_param0 *rds.DeleteDBInstanceInput) (*request.Request, *rds.DeleteDBInstanceOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteDBInstanceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DeleteDBInstanceOutput)
+func (_m *MockRDSAPI) DeleteDBClusterSnapshotWithContext(_param0 aws.Context, _param1 *rds.DeleteDBClusterSnapshotInput, _param2 ...request.Option) (*rds.DeleteDBClusterSnapshotOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteDBClusterSnapshotWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DeleteDBClusterSnapshotOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DeleteDBInstanceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBInstanceRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DeleteDBClusterSnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBClusterSnapshotWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DeleteDBClusterSnapshotRequest(_param0 *rds.DeleteDBClusterSnapshotInput) (*request.Request, *rds.DeleteDBClusterSnapshotOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteDBClusterSnapshotRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DeleteDBClusterSnapshotOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DeleteDBClusterSnapshotRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBClusterSnapshotRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DeleteDBInstance(_param0 *rds.DeleteDBInstanceInput) (*rds.DeleteDBInstanceOutput, error) {
@@ -580,15 +954,31 @@ func (_mr *_MockRDSAPIRecorder) DeleteDBInstance(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBInstance", arg0)
 }
 
-func (_m *MockRDSAPI) DeleteDBParameterGroupRequest(_param0 *rds.DeleteDBParameterGroupInput) (*request.Request, *rds.DeleteDBParameterGroupOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteDBParameterGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DeleteDBParameterGroupOutput)
+func (_m *MockRDSAPI) DeleteDBInstanceWithContext(_param0 aws.Context, _param1 *rds.DeleteDBInstanceInput, _param2 ...request.Option) (*rds.DeleteDBInstanceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteDBInstanceWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DeleteDBInstanceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DeleteDBParameterGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBParameterGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DeleteDBInstanceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBInstanceWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DeleteDBInstanceRequest(_param0 *rds.DeleteDBInstanceInput) (*request.Request, *rds.DeleteDBInstanceOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteDBInstanceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DeleteDBInstanceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DeleteDBInstanceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBInstanceRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DeleteDBParameterGroup(_param0 *rds.DeleteDBParameterGroupInput) (*rds.DeleteDBParameterGroupOutput, error) {
@@ -602,15 +992,31 @@ func (_mr *_MockRDSAPIRecorder) DeleteDBParameterGroup(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBParameterGroup", arg0)
 }
 
-func (_m *MockRDSAPI) DeleteDBSecurityGroupRequest(_param0 *rds.DeleteDBSecurityGroupInput) (*request.Request, *rds.DeleteDBSecurityGroupOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteDBSecurityGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DeleteDBSecurityGroupOutput)
+func (_m *MockRDSAPI) DeleteDBParameterGroupWithContext(_param0 aws.Context, _param1 *rds.DeleteDBParameterGroupInput, _param2 ...request.Option) (*rds.DeleteDBParameterGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteDBParameterGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DeleteDBParameterGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DeleteDBSecurityGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBSecurityGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DeleteDBParameterGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBParameterGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DeleteDBParameterGroupRequest(_param0 *rds.DeleteDBParameterGroupInput) (*request.Request, *rds.DeleteDBParameterGroupOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteDBParameterGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DeleteDBParameterGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DeleteDBParameterGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBParameterGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DeleteDBSecurityGroup(_param0 *rds.DeleteDBSecurityGroupInput) (*rds.DeleteDBSecurityGroupOutput, error) {
@@ -624,15 +1030,31 @@ func (_mr *_MockRDSAPIRecorder) DeleteDBSecurityGroup(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBSecurityGroup", arg0)
 }
 
-func (_m *MockRDSAPI) DeleteDBSnapshotRequest(_param0 *rds.DeleteDBSnapshotInput) (*request.Request, *rds.DeleteDBSnapshotOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteDBSnapshotRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DeleteDBSnapshotOutput)
+func (_m *MockRDSAPI) DeleteDBSecurityGroupWithContext(_param0 aws.Context, _param1 *rds.DeleteDBSecurityGroupInput, _param2 ...request.Option) (*rds.DeleteDBSecurityGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteDBSecurityGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DeleteDBSecurityGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DeleteDBSnapshotRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBSnapshotRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DeleteDBSecurityGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBSecurityGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DeleteDBSecurityGroupRequest(_param0 *rds.DeleteDBSecurityGroupInput) (*request.Request, *rds.DeleteDBSecurityGroupOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteDBSecurityGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DeleteDBSecurityGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DeleteDBSecurityGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBSecurityGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DeleteDBSnapshot(_param0 *rds.DeleteDBSnapshotInput) (*rds.DeleteDBSnapshotOutput, error) {
@@ -646,15 +1068,31 @@ func (_mr *_MockRDSAPIRecorder) DeleteDBSnapshot(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBSnapshot", arg0)
 }
 
-func (_m *MockRDSAPI) DeleteDBSubnetGroupRequest(_param0 *rds.DeleteDBSubnetGroupInput) (*request.Request, *rds.DeleteDBSubnetGroupOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteDBSubnetGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DeleteDBSubnetGroupOutput)
+func (_m *MockRDSAPI) DeleteDBSnapshotWithContext(_param0 aws.Context, _param1 *rds.DeleteDBSnapshotInput, _param2 ...request.Option) (*rds.DeleteDBSnapshotOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteDBSnapshotWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DeleteDBSnapshotOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DeleteDBSubnetGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBSubnetGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DeleteDBSnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBSnapshotWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DeleteDBSnapshotRequest(_param0 *rds.DeleteDBSnapshotInput) (*request.Request, *rds.DeleteDBSnapshotOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteDBSnapshotRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DeleteDBSnapshotOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DeleteDBSnapshotRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBSnapshotRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DeleteDBSubnetGroup(_param0 *rds.DeleteDBSubnetGroupInput) (*rds.DeleteDBSubnetGroupOutput, error) {
@@ -668,15 +1106,31 @@ func (_mr *_MockRDSAPIRecorder) DeleteDBSubnetGroup(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBSubnetGroup", arg0)
 }
 
-func (_m *MockRDSAPI) DeleteEventSubscriptionRequest(_param0 *rds.DeleteEventSubscriptionInput) (*request.Request, *rds.DeleteEventSubscriptionOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteEventSubscriptionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DeleteEventSubscriptionOutput)
+func (_m *MockRDSAPI) DeleteDBSubnetGroupWithContext(_param0 aws.Context, _param1 *rds.DeleteDBSubnetGroupInput, _param2 ...request.Option) (*rds.DeleteDBSubnetGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteDBSubnetGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DeleteDBSubnetGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DeleteEventSubscriptionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteEventSubscriptionRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DeleteDBSubnetGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBSubnetGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DeleteDBSubnetGroupRequest(_param0 *rds.DeleteDBSubnetGroupInput) (*request.Request, *rds.DeleteDBSubnetGroupOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteDBSubnetGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DeleteDBSubnetGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DeleteDBSubnetGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteDBSubnetGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DeleteEventSubscription(_param0 *rds.DeleteEventSubscriptionInput) (*rds.DeleteEventSubscriptionOutput, error) {
@@ -690,15 +1144,31 @@ func (_mr *_MockRDSAPIRecorder) DeleteEventSubscription(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteEventSubscription", arg0)
 }
 
-func (_m *MockRDSAPI) DeleteOptionGroupRequest(_param0 *rds.DeleteOptionGroupInput) (*request.Request, *rds.DeleteOptionGroupOutput) {
-	ret := _m.ctrl.Call(_m, "DeleteOptionGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DeleteOptionGroupOutput)
+func (_m *MockRDSAPI) DeleteEventSubscriptionWithContext(_param0 aws.Context, _param1 *rds.DeleteEventSubscriptionInput, _param2 ...request.Option) (*rds.DeleteEventSubscriptionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteEventSubscriptionWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DeleteEventSubscriptionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DeleteOptionGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteOptionGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DeleteEventSubscriptionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteEventSubscriptionWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DeleteEventSubscriptionRequest(_param0 *rds.DeleteEventSubscriptionInput) (*request.Request, *rds.DeleteEventSubscriptionOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteEventSubscriptionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DeleteEventSubscriptionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DeleteEventSubscriptionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteEventSubscriptionRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DeleteOptionGroup(_param0 *rds.DeleteOptionGroupInput) (*rds.DeleteOptionGroupOutput, error) {
@@ -712,15 +1182,31 @@ func (_mr *_MockRDSAPIRecorder) DeleteOptionGroup(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteOptionGroup", arg0)
 }
 
-func (_m *MockRDSAPI) DescribeAccountAttributesRequest(_param0 *rds.DescribeAccountAttributesInput) (*request.Request, *rds.DescribeAccountAttributesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeAccountAttributesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeAccountAttributesOutput)
+func (_m *MockRDSAPI) DeleteOptionGroupWithContext(_param0 aws.Context, _param1 *rds.DeleteOptionGroupInput, _param2 ...request.Option) (*rds.DeleteOptionGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DeleteOptionGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DeleteOptionGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeAccountAttributesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeAccountAttributesRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DeleteOptionGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteOptionGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DeleteOptionGroupRequest(_param0 *rds.DeleteOptionGroupInput) (*request.Request, *rds.DeleteOptionGroupOutput) {
+	ret := _m.ctrl.Call(_m, "DeleteOptionGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DeleteOptionGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DeleteOptionGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteOptionGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DescribeAccountAttributes(_param0 *rds.DescribeAccountAttributesInput) (*rds.DescribeAccountAttributesOutput, error) {
@@ -734,15 +1220,31 @@ func (_mr *_MockRDSAPIRecorder) DescribeAccountAttributes(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeAccountAttributes", arg0)
 }
 
-func (_m *MockRDSAPI) DescribeCertificatesRequest(_param0 *rds.DescribeCertificatesInput) (*request.Request, *rds.DescribeCertificatesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeCertificatesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeCertificatesOutput)
+func (_m *MockRDSAPI) DescribeAccountAttributesWithContext(_param0 aws.Context, _param1 *rds.DescribeAccountAttributesInput, _param2 ...request.Option) (*rds.DescribeAccountAttributesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeAccountAttributesWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeAccountAttributesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeCertificatesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCertificatesRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeAccountAttributesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeAccountAttributesWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeAccountAttributesRequest(_param0 *rds.DescribeAccountAttributesInput) (*request.Request, *rds.DescribeAccountAttributesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeAccountAttributesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeAccountAttributesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeAccountAttributesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeAccountAttributesRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DescribeCertificates(_param0 *rds.DescribeCertificatesInput) (*rds.DescribeCertificatesOutput, error) {
@@ -756,15 +1258,31 @@ func (_mr *_MockRDSAPIRecorder) DescribeCertificates(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCertificates", arg0)
 }
 
-func (_m *MockRDSAPI) DescribeDBClusterParameterGroupsRequest(_param0 *rds.DescribeDBClusterParameterGroupsInput) (*request.Request, *rds.DescribeDBClusterParameterGroupsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeDBClusterParameterGroupsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeDBClusterParameterGroupsOutput)
+func (_m *MockRDSAPI) DescribeCertificatesWithContext(_param0 aws.Context, _param1 *rds.DescribeCertificatesInput, _param2 ...request.Option) (*rds.DescribeCertificatesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeCertificatesWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeCertificatesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeDBClusterParameterGroupsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClusterParameterGroupsRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeCertificatesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCertificatesWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeCertificatesRequest(_param0 *rds.DescribeCertificatesInput) (*request.Request, *rds.DescribeCertificatesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeCertificatesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeCertificatesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeCertificatesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeCertificatesRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DescribeDBClusterParameterGroups(_param0 *rds.DescribeDBClusterParameterGroupsInput) (*rds.DescribeDBClusterParameterGroupsOutput, error) {
@@ -778,15 +1296,31 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBClusterParameterGroups(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClusterParameterGroups", arg0)
 }
 
-func (_m *MockRDSAPI) DescribeDBClusterParametersRequest(_param0 *rds.DescribeDBClusterParametersInput) (*request.Request, *rds.DescribeDBClusterParametersOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeDBClusterParametersRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeDBClusterParametersOutput)
+func (_m *MockRDSAPI) DescribeDBClusterParameterGroupsWithContext(_param0 aws.Context, _param1 *rds.DescribeDBClusterParameterGroupsInput, _param2 ...request.Option) (*rds.DescribeDBClusterParameterGroupsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBClusterParameterGroupsWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeDBClusterParameterGroupsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeDBClusterParametersRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClusterParametersRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeDBClusterParameterGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClusterParameterGroupsWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeDBClusterParameterGroupsRequest(_param0 *rds.DescribeDBClusterParameterGroupsInput) (*request.Request, *rds.DescribeDBClusterParameterGroupsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeDBClusterParameterGroupsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeDBClusterParameterGroupsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBClusterParameterGroupsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClusterParameterGroupsRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DescribeDBClusterParameters(_param0 *rds.DescribeDBClusterParametersInput) (*rds.DescribeDBClusterParametersOutput, error) {
@@ -800,15 +1334,31 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBClusterParameters(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClusterParameters", arg0)
 }
 
-func (_m *MockRDSAPI) DescribeDBClusterSnapshotAttributesRequest(_param0 *rds.DescribeDBClusterSnapshotAttributesInput) (*request.Request, *rds.DescribeDBClusterSnapshotAttributesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeDBClusterSnapshotAttributesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeDBClusterSnapshotAttributesOutput)
+func (_m *MockRDSAPI) DescribeDBClusterParametersWithContext(_param0 aws.Context, _param1 *rds.DescribeDBClusterParametersInput, _param2 ...request.Option) (*rds.DescribeDBClusterParametersOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBClusterParametersWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeDBClusterParametersOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeDBClusterSnapshotAttributesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClusterSnapshotAttributesRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeDBClusterParametersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClusterParametersWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeDBClusterParametersRequest(_param0 *rds.DescribeDBClusterParametersInput) (*request.Request, *rds.DescribeDBClusterParametersOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeDBClusterParametersRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeDBClusterParametersOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBClusterParametersRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClusterParametersRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DescribeDBClusterSnapshotAttributes(_param0 *rds.DescribeDBClusterSnapshotAttributesInput) (*rds.DescribeDBClusterSnapshotAttributesOutput, error) {
@@ -822,15 +1372,31 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBClusterSnapshotAttributes(arg0 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClusterSnapshotAttributes", arg0)
 }
 
-func (_m *MockRDSAPI) DescribeDBClusterSnapshotsRequest(_param0 *rds.DescribeDBClusterSnapshotsInput) (*request.Request, *rds.DescribeDBClusterSnapshotsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeDBClusterSnapshotsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeDBClusterSnapshotsOutput)
+func (_m *MockRDSAPI) DescribeDBClusterSnapshotAttributesWithContext(_param0 aws.Context, _param1 *rds.DescribeDBClusterSnapshotAttributesInput, _param2 ...request.Option) (*rds.DescribeDBClusterSnapshotAttributesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBClusterSnapshotAttributesWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeDBClusterSnapshotAttributesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeDBClusterSnapshotsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClusterSnapshotsRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeDBClusterSnapshotAttributesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClusterSnapshotAttributesWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeDBClusterSnapshotAttributesRequest(_param0 *rds.DescribeDBClusterSnapshotAttributesInput) (*request.Request, *rds.DescribeDBClusterSnapshotAttributesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeDBClusterSnapshotAttributesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeDBClusterSnapshotAttributesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBClusterSnapshotAttributesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClusterSnapshotAttributesRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DescribeDBClusterSnapshots(_param0 *rds.DescribeDBClusterSnapshotsInput) (*rds.DescribeDBClusterSnapshotsOutput, error) {
@@ -844,15 +1410,31 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBClusterSnapshots(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClusterSnapshots", arg0)
 }
 
-func (_m *MockRDSAPI) DescribeDBClustersRequest(_param0 *rds.DescribeDBClustersInput) (*request.Request, *rds.DescribeDBClustersOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeDBClustersRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeDBClustersOutput)
+func (_m *MockRDSAPI) DescribeDBClusterSnapshotsWithContext(_param0 aws.Context, _param1 *rds.DescribeDBClusterSnapshotsInput, _param2 ...request.Option) (*rds.DescribeDBClusterSnapshotsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBClusterSnapshotsWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeDBClusterSnapshotsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeDBClustersRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClustersRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeDBClusterSnapshotsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClusterSnapshotsWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeDBClusterSnapshotsRequest(_param0 *rds.DescribeDBClusterSnapshotsInput) (*request.Request, *rds.DescribeDBClusterSnapshotsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeDBClusterSnapshotsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeDBClusterSnapshotsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBClusterSnapshotsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClusterSnapshotsRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DescribeDBClusters(_param0 *rds.DescribeDBClustersInput) (*rds.DescribeDBClustersOutput, error) {
@@ -866,15 +1448,31 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBClusters(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClusters", arg0)
 }
 
-func (_m *MockRDSAPI) DescribeDBEngineVersionsRequest(_param0 *rds.DescribeDBEngineVersionsInput) (*request.Request, *rds.DescribeDBEngineVersionsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeDBEngineVersionsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeDBEngineVersionsOutput)
+func (_m *MockRDSAPI) DescribeDBClustersWithContext(_param0 aws.Context, _param1 *rds.DescribeDBClustersInput, _param2 ...request.Option) (*rds.DescribeDBClustersOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBClustersWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeDBClustersOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeDBEngineVersionsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBEngineVersionsRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeDBClustersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClustersWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeDBClustersRequest(_param0 *rds.DescribeDBClustersInput) (*request.Request, *rds.DescribeDBClustersOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeDBClustersRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeDBClustersOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBClustersRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBClustersRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DescribeDBEngineVersions(_param0 *rds.DescribeDBEngineVersionsInput) (*rds.DescribeDBEngineVersionsOutput, error) {
@@ -888,6 +1486,33 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBEngineVersions(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBEngineVersions", arg0)
 }
 
+func (_m *MockRDSAPI) DescribeDBEngineVersionsWithContext(_param0 aws.Context, _param1 *rds.DescribeDBEngineVersionsInput, _param2 ...request.Option) (*rds.DescribeDBEngineVersionsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBEngineVersionsWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeDBEngineVersionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBEngineVersionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBEngineVersionsWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeDBEngineVersionsRequest(_param0 *rds.DescribeDBEngineVersionsInput) (*request.Request, *rds.DescribeDBEngineVersionsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeDBEngineVersionsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeDBEngineVersionsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBEngineVersionsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBEngineVersionsRequest", arg0)
+}
+
 func (_m *MockRDSAPI) DescribeDBEngineVersionsPages(_param0 *rds.DescribeDBEngineVersionsInput, _param1 func(*rds.DescribeDBEngineVersionsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeDBEngineVersionsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -898,15 +1523,19 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBEngineVersionsPages(arg0, arg1 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBEngineVersionsPages", arg0, arg1)
 }
 
-func (_m *MockRDSAPI) DescribeDBInstancesRequest(_param0 *rds.DescribeDBInstancesInput) (*request.Request, *rds.DescribeDBInstancesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeDBInstancesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeDBInstancesOutput)
-	return ret0, ret1
+func (_m *MockRDSAPI) DescribeDBEngineVersionsPagesWithContext(_param0 aws.Context, _param1 *rds.DescribeDBEngineVersionsInput, _param2 func(*rds.DescribeDBEngineVersionsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBEngineVersionsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeDBInstancesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBInstancesRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeDBEngineVersionsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBEngineVersionsPagesWithContext", _s...)
 }
 
 func (_m *MockRDSAPI) DescribeDBInstances(_param0 *rds.DescribeDBInstancesInput) (*rds.DescribeDBInstancesOutput, error) {
@@ -920,6 +1549,33 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBInstances(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBInstances", arg0)
 }
 
+func (_m *MockRDSAPI) DescribeDBInstancesWithContext(_param0 aws.Context, _param1 *rds.DescribeDBInstancesInput, _param2 ...request.Option) (*rds.DescribeDBInstancesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBInstancesWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeDBInstancesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBInstancesWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeDBInstancesRequest(_param0 *rds.DescribeDBInstancesInput) (*request.Request, *rds.DescribeDBInstancesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeDBInstancesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeDBInstancesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBInstancesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBInstancesRequest", arg0)
+}
+
 func (_m *MockRDSAPI) DescribeDBInstancesPages(_param0 *rds.DescribeDBInstancesInput, _param1 func(*rds.DescribeDBInstancesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeDBInstancesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -930,15 +1586,19 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBInstancesPages(arg0, arg1 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBInstancesPages", arg0, arg1)
 }
 
-func (_m *MockRDSAPI) DescribeDBLogFilesRequest(_param0 *rds.DescribeDBLogFilesInput) (*request.Request, *rds.DescribeDBLogFilesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeDBLogFilesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeDBLogFilesOutput)
-	return ret0, ret1
+func (_m *MockRDSAPI) DescribeDBInstancesPagesWithContext(_param0 aws.Context, _param1 *rds.DescribeDBInstancesInput, _param2 func(*rds.DescribeDBInstancesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBInstancesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeDBLogFilesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBLogFilesRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeDBInstancesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBInstancesPagesWithContext", _s...)
 }
 
 func (_m *MockRDSAPI) DescribeDBLogFiles(_param0 *rds.DescribeDBLogFilesInput) (*rds.DescribeDBLogFilesOutput, error) {
@@ -952,6 +1612,33 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBLogFiles(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBLogFiles", arg0)
 }
 
+func (_m *MockRDSAPI) DescribeDBLogFilesWithContext(_param0 aws.Context, _param1 *rds.DescribeDBLogFilesInput, _param2 ...request.Option) (*rds.DescribeDBLogFilesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBLogFilesWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeDBLogFilesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBLogFilesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBLogFilesWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeDBLogFilesRequest(_param0 *rds.DescribeDBLogFilesInput) (*request.Request, *rds.DescribeDBLogFilesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeDBLogFilesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeDBLogFilesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBLogFilesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBLogFilesRequest", arg0)
+}
+
 func (_m *MockRDSAPI) DescribeDBLogFilesPages(_param0 *rds.DescribeDBLogFilesInput, _param1 func(*rds.DescribeDBLogFilesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeDBLogFilesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -962,15 +1649,19 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBLogFilesPages(arg0, arg1 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBLogFilesPages", arg0, arg1)
 }
 
-func (_m *MockRDSAPI) DescribeDBParameterGroupsRequest(_param0 *rds.DescribeDBParameterGroupsInput) (*request.Request, *rds.DescribeDBParameterGroupsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeDBParameterGroupsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeDBParameterGroupsOutput)
-	return ret0, ret1
+func (_m *MockRDSAPI) DescribeDBLogFilesPagesWithContext(_param0 aws.Context, _param1 *rds.DescribeDBLogFilesInput, _param2 func(*rds.DescribeDBLogFilesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBLogFilesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeDBParameterGroupsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBParameterGroupsRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeDBLogFilesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBLogFilesPagesWithContext", _s...)
 }
 
 func (_m *MockRDSAPI) DescribeDBParameterGroups(_param0 *rds.DescribeDBParameterGroupsInput) (*rds.DescribeDBParameterGroupsOutput, error) {
@@ -984,6 +1675,33 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBParameterGroups(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBParameterGroups", arg0)
 }
 
+func (_m *MockRDSAPI) DescribeDBParameterGroupsWithContext(_param0 aws.Context, _param1 *rds.DescribeDBParameterGroupsInput, _param2 ...request.Option) (*rds.DescribeDBParameterGroupsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBParameterGroupsWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeDBParameterGroupsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBParameterGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBParameterGroupsWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeDBParameterGroupsRequest(_param0 *rds.DescribeDBParameterGroupsInput) (*request.Request, *rds.DescribeDBParameterGroupsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeDBParameterGroupsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeDBParameterGroupsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBParameterGroupsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBParameterGroupsRequest", arg0)
+}
+
 func (_m *MockRDSAPI) DescribeDBParameterGroupsPages(_param0 *rds.DescribeDBParameterGroupsInput, _param1 func(*rds.DescribeDBParameterGroupsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeDBParameterGroupsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -994,15 +1712,19 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBParameterGroupsPages(arg0, arg1 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBParameterGroupsPages", arg0, arg1)
 }
 
-func (_m *MockRDSAPI) DescribeDBParametersRequest(_param0 *rds.DescribeDBParametersInput) (*request.Request, *rds.DescribeDBParametersOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeDBParametersRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeDBParametersOutput)
-	return ret0, ret1
+func (_m *MockRDSAPI) DescribeDBParameterGroupsPagesWithContext(_param0 aws.Context, _param1 *rds.DescribeDBParameterGroupsInput, _param2 func(*rds.DescribeDBParameterGroupsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBParameterGroupsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeDBParametersRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBParametersRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeDBParameterGroupsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBParameterGroupsPagesWithContext", _s...)
 }
 
 func (_m *MockRDSAPI) DescribeDBParameters(_param0 *rds.DescribeDBParametersInput) (*rds.DescribeDBParametersOutput, error) {
@@ -1016,6 +1738,33 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBParameters(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBParameters", arg0)
 }
 
+func (_m *MockRDSAPI) DescribeDBParametersWithContext(_param0 aws.Context, _param1 *rds.DescribeDBParametersInput, _param2 ...request.Option) (*rds.DescribeDBParametersOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBParametersWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeDBParametersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBParametersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBParametersWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeDBParametersRequest(_param0 *rds.DescribeDBParametersInput) (*request.Request, *rds.DescribeDBParametersOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeDBParametersRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeDBParametersOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBParametersRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBParametersRequest", arg0)
+}
+
 func (_m *MockRDSAPI) DescribeDBParametersPages(_param0 *rds.DescribeDBParametersInput, _param1 func(*rds.DescribeDBParametersOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeDBParametersPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1026,15 +1775,19 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBParametersPages(arg0, arg1 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBParametersPages", arg0, arg1)
 }
 
-func (_m *MockRDSAPI) DescribeDBSecurityGroupsRequest(_param0 *rds.DescribeDBSecurityGroupsInput) (*request.Request, *rds.DescribeDBSecurityGroupsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeDBSecurityGroupsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeDBSecurityGroupsOutput)
-	return ret0, ret1
+func (_m *MockRDSAPI) DescribeDBParametersPagesWithContext(_param0 aws.Context, _param1 *rds.DescribeDBParametersInput, _param2 func(*rds.DescribeDBParametersOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBParametersPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeDBSecurityGroupsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSecurityGroupsRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeDBParametersPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBParametersPagesWithContext", _s...)
 }
 
 func (_m *MockRDSAPI) DescribeDBSecurityGroups(_param0 *rds.DescribeDBSecurityGroupsInput) (*rds.DescribeDBSecurityGroupsOutput, error) {
@@ -1048,6 +1801,33 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBSecurityGroups(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSecurityGroups", arg0)
 }
 
+func (_m *MockRDSAPI) DescribeDBSecurityGroupsWithContext(_param0 aws.Context, _param1 *rds.DescribeDBSecurityGroupsInput, _param2 ...request.Option) (*rds.DescribeDBSecurityGroupsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBSecurityGroupsWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeDBSecurityGroupsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBSecurityGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSecurityGroupsWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeDBSecurityGroupsRequest(_param0 *rds.DescribeDBSecurityGroupsInput) (*request.Request, *rds.DescribeDBSecurityGroupsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeDBSecurityGroupsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeDBSecurityGroupsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBSecurityGroupsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSecurityGroupsRequest", arg0)
+}
+
 func (_m *MockRDSAPI) DescribeDBSecurityGroupsPages(_param0 *rds.DescribeDBSecurityGroupsInput, _param1 func(*rds.DescribeDBSecurityGroupsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeDBSecurityGroupsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1058,15 +1838,19 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBSecurityGroupsPages(arg0, arg1 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSecurityGroupsPages", arg0, arg1)
 }
 
-func (_m *MockRDSAPI) DescribeDBSnapshotAttributesRequest(_param0 *rds.DescribeDBSnapshotAttributesInput) (*request.Request, *rds.DescribeDBSnapshotAttributesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeDBSnapshotAttributesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeDBSnapshotAttributesOutput)
-	return ret0, ret1
+func (_m *MockRDSAPI) DescribeDBSecurityGroupsPagesWithContext(_param0 aws.Context, _param1 *rds.DescribeDBSecurityGroupsInput, _param2 func(*rds.DescribeDBSecurityGroupsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBSecurityGroupsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeDBSnapshotAttributesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSnapshotAttributesRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeDBSecurityGroupsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSecurityGroupsPagesWithContext", _s...)
 }
 
 func (_m *MockRDSAPI) DescribeDBSnapshotAttributes(_param0 *rds.DescribeDBSnapshotAttributesInput) (*rds.DescribeDBSnapshotAttributesOutput, error) {
@@ -1080,15 +1864,31 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBSnapshotAttributes(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSnapshotAttributes", arg0)
 }
 
-func (_m *MockRDSAPI) DescribeDBSnapshotsRequest(_param0 *rds.DescribeDBSnapshotsInput) (*request.Request, *rds.DescribeDBSnapshotsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeDBSnapshotsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeDBSnapshotsOutput)
+func (_m *MockRDSAPI) DescribeDBSnapshotAttributesWithContext(_param0 aws.Context, _param1 *rds.DescribeDBSnapshotAttributesInput, _param2 ...request.Option) (*rds.DescribeDBSnapshotAttributesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBSnapshotAttributesWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeDBSnapshotAttributesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeDBSnapshotsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSnapshotsRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeDBSnapshotAttributesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSnapshotAttributesWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeDBSnapshotAttributesRequest(_param0 *rds.DescribeDBSnapshotAttributesInput) (*request.Request, *rds.DescribeDBSnapshotAttributesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeDBSnapshotAttributesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeDBSnapshotAttributesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBSnapshotAttributesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSnapshotAttributesRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DescribeDBSnapshots(_param0 *rds.DescribeDBSnapshotsInput) (*rds.DescribeDBSnapshotsOutput, error) {
@@ -1102,6 +1902,33 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBSnapshots(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSnapshots", arg0)
 }
 
+func (_m *MockRDSAPI) DescribeDBSnapshotsWithContext(_param0 aws.Context, _param1 *rds.DescribeDBSnapshotsInput, _param2 ...request.Option) (*rds.DescribeDBSnapshotsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBSnapshotsWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeDBSnapshotsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBSnapshotsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSnapshotsWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeDBSnapshotsRequest(_param0 *rds.DescribeDBSnapshotsInput) (*request.Request, *rds.DescribeDBSnapshotsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeDBSnapshotsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeDBSnapshotsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBSnapshotsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSnapshotsRequest", arg0)
+}
+
 func (_m *MockRDSAPI) DescribeDBSnapshotsPages(_param0 *rds.DescribeDBSnapshotsInput, _param1 func(*rds.DescribeDBSnapshotsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeDBSnapshotsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1112,15 +1939,19 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBSnapshotsPages(arg0, arg1 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSnapshotsPages", arg0, arg1)
 }
 
-func (_m *MockRDSAPI) DescribeDBSubnetGroupsRequest(_param0 *rds.DescribeDBSubnetGroupsInput) (*request.Request, *rds.DescribeDBSubnetGroupsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeDBSubnetGroupsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeDBSubnetGroupsOutput)
-	return ret0, ret1
+func (_m *MockRDSAPI) DescribeDBSnapshotsPagesWithContext(_param0 aws.Context, _param1 *rds.DescribeDBSnapshotsInput, _param2 func(*rds.DescribeDBSnapshotsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBSnapshotsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeDBSubnetGroupsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSubnetGroupsRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeDBSnapshotsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSnapshotsPagesWithContext", _s...)
 }
 
 func (_m *MockRDSAPI) DescribeDBSubnetGroups(_param0 *rds.DescribeDBSubnetGroupsInput) (*rds.DescribeDBSubnetGroupsOutput, error) {
@@ -1134,6 +1965,33 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBSubnetGroups(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSubnetGroups", arg0)
 }
 
+func (_m *MockRDSAPI) DescribeDBSubnetGroupsWithContext(_param0 aws.Context, _param1 *rds.DescribeDBSubnetGroupsInput, _param2 ...request.Option) (*rds.DescribeDBSubnetGroupsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBSubnetGroupsWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeDBSubnetGroupsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBSubnetGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSubnetGroupsWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeDBSubnetGroupsRequest(_param0 *rds.DescribeDBSubnetGroupsInput) (*request.Request, *rds.DescribeDBSubnetGroupsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeDBSubnetGroupsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeDBSubnetGroupsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeDBSubnetGroupsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSubnetGroupsRequest", arg0)
+}
+
 func (_m *MockRDSAPI) DescribeDBSubnetGroupsPages(_param0 *rds.DescribeDBSubnetGroupsInput, _param1 func(*rds.DescribeDBSubnetGroupsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeDBSubnetGroupsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1144,15 +2002,19 @@ func (_mr *_MockRDSAPIRecorder) DescribeDBSubnetGroupsPages(arg0, arg1 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSubnetGroupsPages", arg0, arg1)
 }
 
-func (_m *MockRDSAPI) DescribeEngineDefaultClusterParametersRequest(_param0 *rds.DescribeEngineDefaultClusterParametersInput) (*request.Request, *rds.DescribeEngineDefaultClusterParametersOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeEngineDefaultClusterParametersRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeEngineDefaultClusterParametersOutput)
-	return ret0, ret1
+func (_m *MockRDSAPI) DescribeDBSubnetGroupsPagesWithContext(_param0 aws.Context, _param1 *rds.DescribeDBSubnetGroupsInput, _param2 func(*rds.DescribeDBSubnetGroupsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeDBSubnetGroupsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeEngineDefaultClusterParametersRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEngineDefaultClusterParametersRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeDBSubnetGroupsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeDBSubnetGroupsPagesWithContext", _s...)
 }
 
 func (_m *MockRDSAPI) DescribeEngineDefaultClusterParameters(_param0 *rds.DescribeEngineDefaultClusterParametersInput) (*rds.DescribeEngineDefaultClusterParametersOutput, error) {
@@ -1166,15 +2028,31 @@ func (_mr *_MockRDSAPIRecorder) DescribeEngineDefaultClusterParameters(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEngineDefaultClusterParameters", arg0)
 }
 
-func (_m *MockRDSAPI) DescribeEngineDefaultParametersRequest(_param0 *rds.DescribeEngineDefaultParametersInput) (*request.Request, *rds.DescribeEngineDefaultParametersOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeEngineDefaultParametersRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeEngineDefaultParametersOutput)
+func (_m *MockRDSAPI) DescribeEngineDefaultClusterParametersWithContext(_param0 aws.Context, _param1 *rds.DescribeEngineDefaultClusterParametersInput, _param2 ...request.Option) (*rds.DescribeEngineDefaultClusterParametersOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeEngineDefaultClusterParametersWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeEngineDefaultClusterParametersOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeEngineDefaultParametersRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEngineDefaultParametersRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeEngineDefaultClusterParametersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEngineDefaultClusterParametersWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeEngineDefaultClusterParametersRequest(_param0 *rds.DescribeEngineDefaultClusterParametersInput) (*request.Request, *rds.DescribeEngineDefaultClusterParametersOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeEngineDefaultClusterParametersRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeEngineDefaultClusterParametersOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeEngineDefaultClusterParametersRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEngineDefaultClusterParametersRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DescribeEngineDefaultParameters(_param0 *rds.DescribeEngineDefaultParametersInput) (*rds.DescribeEngineDefaultParametersOutput, error) {
@@ -1188,6 +2066,33 @@ func (_mr *_MockRDSAPIRecorder) DescribeEngineDefaultParameters(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEngineDefaultParameters", arg0)
 }
 
+func (_m *MockRDSAPI) DescribeEngineDefaultParametersWithContext(_param0 aws.Context, _param1 *rds.DescribeEngineDefaultParametersInput, _param2 ...request.Option) (*rds.DescribeEngineDefaultParametersOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeEngineDefaultParametersWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeEngineDefaultParametersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeEngineDefaultParametersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEngineDefaultParametersWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeEngineDefaultParametersRequest(_param0 *rds.DescribeEngineDefaultParametersInput) (*request.Request, *rds.DescribeEngineDefaultParametersOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeEngineDefaultParametersRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeEngineDefaultParametersOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeEngineDefaultParametersRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEngineDefaultParametersRequest", arg0)
+}
+
 func (_m *MockRDSAPI) DescribeEngineDefaultParametersPages(_param0 *rds.DescribeEngineDefaultParametersInput, _param1 func(*rds.DescribeEngineDefaultParametersOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeEngineDefaultParametersPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1198,15 +2103,19 @@ func (_mr *_MockRDSAPIRecorder) DescribeEngineDefaultParametersPages(arg0, arg1 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEngineDefaultParametersPages", arg0, arg1)
 }
 
-func (_m *MockRDSAPI) DescribeEventCategoriesRequest(_param0 *rds.DescribeEventCategoriesInput) (*request.Request, *rds.DescribeEventCategoriesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeEventCategoriesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeEventCategoriesOutput)
-	return ret0, ret1
+func (_m *MockRDSAPI) DescribeEngineDefaultParametersPagesWithContext(_param0 aws.Context, _param1 *rds.DescribeEngineDefaultParametersInput, _param2 func(*rds.DescribeEngineDefaultParametersOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeEngineDefaultParametersPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeEventCategoriesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventCategoriesRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeEngineDefaultParametersPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEngineDefaultParametersPagesWithContext", _s...)
 }
 
 func (_m *MockRDSAPI) DescribeEventCategories(_param0 *rds.DescribeEventCategoriesInput) (*rds.DescribeEventCategoriesOutput, error) {
@@ -1220,15 +2129,31 @@ func (_mr *_MockRDSAPIRecorder) DescribeEventCategories(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventCategories", arg0)
 }
 
-func (_m *MockRDSAPI) DescribeEventSubscriptionsRequest(_param0 *rds.DescribeEventSubscriptionsInput) (*request.Request, *rds.DescribeEventSubscriptionsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeEventSubscriptionsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeEventSubscriptionsOutput)
+func (_m *MockRDSAPI) DescribeEventCategoriesWithContext(_param0 aws.Context, _param1 *rds.DescribeEventCategoriesInput, _param2 ...request.Option) (*rds.DescribeEventCategoriesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeEventCategoriesWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeEventCategoriesOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeEventSubscriptionsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventSubscriptionsRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeEventCategoriesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventCategoriesWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeEventCategoriesRequest(_param0 *rds.DescribeEventCategoriesInput) (*request.Request, *rds.DescribeEventCategoriesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeEventCategoriesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeEventCategoriesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeEventCategoriesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventCategoriesRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DescribeEventSubscriptions(_param0 *rds.DescribeEventSubscriptionsInput) (*rds.DescribeEventSubscriptionsOutput, error) {
@@ -1242,6 +2167,33 @@ func (_mr *_MockRDSAPIRecorder) DescribeEventSubscriptions(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventSubscriptions", arg0)
 }
 
+func (_m *MockRDSAPI) DescribeEventSubscriptionsWithContext(_param0 aws.Context, _param1 *rds.DescribeEventSubscriptionsInput, _param2 ...request.Option) (*rds.DescribeEventSubscriptionsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeEventSubscriptionsWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeEventSubscriptionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeEventSubscriptionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventSubscriptionsWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeEventSubscriptionsRequest(_param0 *rds.DescribeEventSubscriptionsInput) (*request.Request, *rds.DescribeEventSubscriptionsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeEventSubscriptionsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeEventSubscriptionsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeEventSubscriptionsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventSubscriptionsRequest", arg0)
+}
+
 func (_m *MockRDSAPI) DescribeEventSubscriptionsPages(_param0 *rds.DescribeEventSubscriptionsInput, _param1 func(*rds.DescribeEventSubscriptionsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeEventSubscriptionsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1252,15 +2204,19 @@ func (_mr *_MockRDSAPIRecorder) DescribeEventSubscriptionsPages(arg0, arg1 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventSubscriptionsPages", arg0, arg1)
 }
 
-func (_m *MockRDSAPI) DescribeEventsRequest(_param0 *rds.DescribeEventsInput) (*request.Request, *rds.DescribeEventsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeEventsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeEventsOutput)
-	return ret0, ret1
+func (_m *MockRDSAPI) DescribeEventSubscriptionsPagesWithContext(_param0 aws.Context, _param1 *rds.DescribeEventSubscriptionsInput, _param2 func(*rds.DescribeEventSubscriptionsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeEventSubscriptionsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeEventsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventsRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeEventSubscriptionsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventSubscriptionsPagesWithContext", _s...)
 }
 
 func (_m *MockRDSAPI) DescribeEvents(_param0 *rds.DescribeEventsInput) (*rds.DescribeEventsOutput, error) {
@@ -1274,6 +2230,33 @@ func (_mr *_MockRDSAPIRecorder) DescribeEvents(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEvents", arg0)
 }
 
+func (_m *MockRDSAPI) DescribeEventsWithContext(_param0 aws.Context, _param1 *rds.DescribeEventsInput, _param2 ...request.Option) (*rds.DescribeEventsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeEventsWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeEventsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeEventsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventsWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeEventsRequest(_param0 *rds.DescribeEventsInput) (*request.Request, *rds.DescribeEventsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeEventsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeEventsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeEventsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventsRequest", arg0)
+}
+
 func (_m *MockRDSAPI) DescribeEventsPages(_param0 *rds.DescribeEventsInput, _param1 func(*rds.DescribeEventsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeEventsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1284,15 +2267,19 @@ func (_mr *_MockRDSAPIRecorder) DescribeEventsPages(arg0, arg1 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventsPages", arg0, arg1)
 }
 
-func (_m *MockRDSAPI) DescribeOptionGroupOptionsRequest(_param0 *rds.DescribeOptionGroupOptionsInput) (*request.Request, *rds.DescribeOptionGroupOptionsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeOptionGroupOptionsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeOptionGroupOptionsOutput)
-	return ret0, ret1
+func (_m *MockRDSAPI) DescribeEventsPagesWithContext(_param0 aws.Context, _param1 *rds.DescribeEventsInput, _param2 func(*rds.DescribeEventsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeEventsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeOptionGroupOptionsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeOptionGroupOptionsRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeEventsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeEventsPagesWithContext", _s...)
 }
 
 func (_m *MockRDSAPI) DescribeOptionGroupOptions(_param0 *rds.DescribeOptionGroupOptionsInput) (*rds.DescribeOptionGroupOptionsOutput, error) {
@@ -1306,6 +2293,33 @@ func (_mr *_MockRDSAPIRecorder) DescribeOptionGroupOptions(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeOptionGroupOptions", arg0)
 }
 
+func (_m *MockRDSAPI) DescribeOptionGroupOptionsWithContext(_param0 aws.Context, _param1 *rds.DescribeOptionGroupOptionsInput, _param2 ...request.Option) (*rds.DescribeOptionGroupOptionsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeOptionGroupOptionsWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeOptionGroupOptionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeOptionGroupOptionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeOptionGroupOptionsWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeOptionGroupOptionsRequest(_param0 *rds.DescribeOptionGroupOptionsInput) (*request.Request, *rds.DescribeOptionGroupOptionsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeOptionGroupOptionsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeOptionGroupOptionsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeOptionGroupOptionsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeOptionGroupOptionsRequest", arg0)
+}
+
 func (_m *MockRDSAPI) DescribeOptionGroupOptionsPages(_param0 *rds.DescribeOptionGroupOptionsInput, _param1 func(*rds.DescribeOptionGroupOptionsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeOptionGroupOptionsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1316,15 +2330,19 @@ func (_mr *_MockRDSAPIRecorder) DescribeOptionGroupOptionsPages(arg0, arg1 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeOptionGroupOptionsPages", arg0, arg1)
 }
 
-func (_m *MockRDSAPI) DescribeOptionGroupsRequest(_param0 *rds.DescribeOptionGroupsInput) (*request.Request, *rds.DescribeOptionGroupsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeOptionGroupsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeOptionGroupsOutput)
-	return ret0, ret1
+func (_m *MockRDSAPI) DescribeOptionGroupOptionsPagesWithContext(_param0 aws.Context, _param1 *rds.DescribeOptionGroupOptionsInput, _param2 func(*rds.DescribeOptionGroupOptionsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeOptionGroupOptionsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeOptionGroupsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeOptionGroupsRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeOptionGroupOptionsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeOptionGroupOptionsPagesWithContext", _s...)
 }
 
 func (_m *MockRDSAPI) DescribeOptionGroups(_param0 *rds.DescribeOptionGroupsInput) (*rds.DescribeOptionGroupsOutput, error) {
@@ -1338,6 +2356,33 @@ func (_mr *_MockRDSAPIRecorder) DescribeOptionGroups(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeOptionGroups", arg0)
 }
 
+func (_m *MockRDSAPI) DescribeOptionGroupsWithContext(_param0 aws.Context, _param1 *rds.DescribeOptionGroupsInput, _param2 ...request.Option) (*rds.DescribeOptionGroupsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeOptionGroupsWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeOptionGroupsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeOptionGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeOptionGroupsWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeOptionGroupsRequest(_param0 *rds.DescribeOptionGroupsInput) (*request.Request, *rds.DescribeOptionGroupsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeOptionGroupsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeOptionGroupsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeOptionGroupsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeOptionGroupsRequest", arg0)
+}
+
 func (_m *MockRDSAPI) DescribeOptionGroupsPages(_param0 *rds.DescribeOptionGroupsInput, _param1 func(*rds.DescribeOptionGroupsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeOptionGroupsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1348,15 +2393,19 @@ func (_mr *_MockRDSAPIRecorder) DescribeOptionGroupsPages(arg0, arg1 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeOptionGroupsPages", arg0, arg1)
 }
 
-func (_m *MockRDSAPI) DescribeOrderableDBInstanceOptionsRequest(_param0 *rds.DescribeOrderableDBInstanceOptionsInput) (*request.Request, *rds.DescribeOrderableDBInstanceOptionsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeOrderableDBInstanceOptionsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeOrderableDBInstanceOptionsOutput)
-	return ret0, ret1
+func (_m *MockRDSAPI) DescribeOptionGroupsPagesWithContext(_param0 aws.Context, _param1 *rds.DescribeOptionGroupsInput, _param2 func(*rds.DescribeOptionGroupsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeOptionGroupsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeOrderableDBInstanceOptionsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeOrderableDBInstanceOptionsRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeOptionGroupsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeOptionGroupsPagesWithContext", _s...)
 }
 
 func (_m *MockRDSAPI) DescribeOrderableDBInstanceOptions(_param0 *rds.DescribeOrderableDBInstanceOptionsInput) (*rds.DescribeOrderableDBInstanceOptionsOutput, error) {
@@ -1370,6 +2419,33 @@ func (_mr *_MockRDSAPIRecorder) DescribeOrderableDBInstanceOptions(arg0 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeOrderableDBInstanceOptions", arg0)
 }
 
+func (_m *MockRDSAPI) DescribeOrderableDBInstanceOptionsWithContext(_param0 aws.Context, _param1 *rds.DescribeOrderableDBInstanceOptionsInput, _param2 ...request.Option) (*rds.DescribeOrderableDBInstanceOptionsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeOrderableDBInstanceOptionsWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeOrderableDBInstanceOptionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeOrderableDBInstanceOptionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeOrderableDBInstanceOptionsWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeOrderableDBInstanceOptionsRequest(_param0 *rds.DescribeOrderableDBInstanceOptionsInput) (*request.Request, *rds.DescribeOrderableDBInstanceOptionsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeOrderableDBInstanceOptionsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeOrderableDBInstanceOptionsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeOrderableDBInstanceOptionsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeOrderableDBInstanceOptionsRequest", arg0)
+}
+
 func (_m *MockRDSAPI) DescribeOrderableDBInstanceOptionsPages(_param0 *rds.DescribeOrderableDBInstanceOptionsInput, _param1 func(*rds.DescribeOrderableDBInstanceOptionsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeOrderableDBInstanceOptionsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1380,15 +2456,19 @@ func (_mr *_MockRDSAPIRecorder) DescribeOrderableDBInstanceOptionsPages(arg0, ar
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeOrderableDBInstanceOptionsPages", arg0, arg1)
 }
 
-func (_m *MockRDSAPI) DescribePendingMaintenanceActionsRequest(_param0 *rds.DescribePendingMaintenanceActionsInput) (*request.Request, *rds.DescribePendingMaintenanceActionsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribePendingMaintenanceActionsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribePendingMaintenanceActionsOutput)
-	return ret0, ret1
+func (_m *MockRDSAPI) DescribeOrderableDBInstanceOptionsPagesWithContext(_param0 aws.Context, _param1 *rds.DescribeOrderableDBInstanceOptionsInput, _param2 func(*rds.DescribeOrderableDBInstanceOptionsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeOrderableDBInstanceOptionsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribePendingMaintenanceActionsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribePendingMaintenanceActionsRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeOrderableDBInstanceOptionsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeOrderableDBInstanceOptionsPagesWithContext", _s...)
 }
 
 func (_m *MockRDSAPI) DescribePendingMaintenanceActions(_param0 *rds.DescribePendingMaintenanceActionsInput) (*rds.DescribePendingMaintenanceActionsOutput, error) {
@@ -1402,15 +2482,31 @@ func (_mr *_MockRDSAPIRecorder) DescribePendingMaintenanceActions(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribePendingMaintenanceActions", arg0)
 }
 
-func (_m *MockRDSAPI) DescribeReservedDBInstancesRequest(_param0 *rds.DescribeReservedDBInstancesInput) (*request.Request, *rds.DescribeReservedDBInstancesOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeReservedDBInstancesRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeReservedDBInstancesOutput)
+func (_m *MockRDSAPI) DescribePendingMaintenanceActionsWithContext(_param0 aws.Context, _param1 *rds.DescribePendingMaintenanceActionsInput, _param2 ...request.Option) (*rds.DescribePendingMaintenanceActionsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribePendingMaintenanceActionsWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribePendingMaintenanceActionsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeReservedDBInstancesRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedDBInstancesRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribePendingMaintenanceActionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribePendingMaintenanceActionsWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribePendingMaintenanceActionsRequest(_param0 *rds.DescribePendingMaintenanceActionsInput) (*request.Request, *rds.DescribePendingMaintenanceActionsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribePendingMaintenanceActionsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribePendingMaintenanceActionsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribePendingMaintenanceActionsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribePendingMaintenanceActionsRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DescribeReservedDBInstances(_param0 *rds.DescribeReservedDBInstancesInput) (*rds.DescribeReservedDBInstancesOutput, error) {
@@ -1424,6 +2520,33 @@ func (_mr *_MockRDSAPIRecorder) DescribeReservedDBInstances(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedDBInstances", arg0)
 }
 
+func (_m *MockRDSAPI) DescribeReservedDBInstancesWithContext(_param0 aws.Context, _param1 *rds.DescribeReservedDBInstancesInput, _param2 ...request.Option) (*rds.DescribeReservedDBInstancesOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeReservedDBInstancesWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeReservedDBInstancesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeReservedDBInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedDBInstancesWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeReservedDBInstancesRequest(_param0 *rds.DescribeReservedDBInstancesInput) (*request.Request, *rds.DescribeReservedDBInstancesOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeReservedDBInstancesRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeReservedDBInstancesOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeReservedDBInstancesRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedDBInstancesRequest", arg0)
+}
+
 func (_m *MockRDSAPI) DescribeReservedDBInstancesPages(_param0 *rds.DescribeReservedDBInstancesInput, _param1 func(*rds.DescribeReservedDBInstancesOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeReservedDBInstancesPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1434,15 +2557,19 @@ func (_mr *_MockRDSAPIRecorder) DescribeReservedDBInstancesPages(arg0, arg1 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedDBInstancesPages", arg0, arg1)
 }
 
-func (_m *MockRDSAPI) DescribeReservedDBInstancesOfferingsRequest(_param0 *rds.DescribeReservedDBInstancesOfferingsInput) (*request.Request, *rds.DescribeReservedDBInstancesOfferingsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeReservedDBInstancesOfferingsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeReservedDBInstancesOfferingsOutput)
-	return ret0, ret1
+func (_m *MockRDSAPI) DescribeReservedDBInstancesPagesWithContext(_param0 aws.Context, _param1 *rds.DescribeReservedDBInstancesInput, _param2 func(*rds.DescribeReservedDBInstancesOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeReservedDBInstancesPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeReservedDBInstancesOfferingsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedDBInstancesOfferingsRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeReservedDBInstancesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedDBInstancesPagesWithContext", _s...)
 }
 
 func (_m *MockRDSAPI) DescribeReservedDBInstancesOfferings(_param0 *rds.DescribeReservedDBInstancesOfferingsInput) (*rds.DescribeReservedDBInstancesOfferingsOutput, error) {
@@ -1456,6 +2583,33 @@ func (_mr *_MockRDSAPIRecorder) DescribeReservedDBInstancesOfferings(arg0 interf
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedDBInstancesOfferings", arg0)
 }
 
+func (_m *MockRDSAPI) DescribeReservedDBInstancesOfferingsWithContext(_param0 aws.Context, _param1 *rds.DescribeReservedDBInstancesOfferingsInput, _param2 ...request.Option) (*rds.DescribeReservedDBInstancesOfferingsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeReservedDBInstancesOfferingsWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeReservedDBInstancesOfferingsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeReservedDBInstancesOfferingsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedDBInstancesOfferingsWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeReservedDBInstancesOfferingsRequest(_param0 *rds.DescribeReservedDBInstancesOfferingsInput) (*request.Request, *rds.DescribeReservedDBInstancesOfferingsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeReservedDBInstancesOfferingsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeReservedDBInstancesOfferingsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeReservedDBInstancesOfferingsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedDBInstancesOfferingsRequest", arg0)
+}
+
 func (_m *MockRDSAPI) DescribeReservedDBInstancesOfferingsPages(_param0 *rds.DescribeReservedDBInstancesOfferingsInput, _param1 func(*rds.DescribeReservedDBInstancesOfferingsOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DescribeReservedDBInstancesOfferingsPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1466,15 +2620,19 @@ func (_mr *_MockRDSAPIRecorder) DescribeReservedDBInstancesOfferingsPages(arg0, 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedDBInstancesOfferingsPages", arg0, arg1)
 }
 
-func (_m *MockRDSAPI) DescribeSourceRegionsRequest(_param0 *rds.DescribeSourceRegionsInput) (*request.Request, *rds.DescribeSourceRegionsOutput) {
-	ret := _m.ctrl.Call(_m, "DescribeSourceRegionsRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DescribeSourceRegionsOutput)
-	return ret0, ret1
+func (_m *MockRDSAPI) DescribeReservedDBInstancesOfferingsPagesWithContext(_param0 aws.Context, _param1 *rds.DescribeReservedDBInstancesOfferingsInput, _param2 func(*rds.DescribeReservedDBInstancesOfferingsOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeReservedDBInstancesOfferingsPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockRDSAPIRecorder) DescribeSourceRegionsRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSourceRegionsRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeReservedDBInstancesOfferingsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeReservedDBInstancesOfferingsPagesWithContext", _s...)
 }
 
 func (_m *MockRDSAPI) DescribeSourceRegions(_param0 *rds.DescribeSourceRegionsInput) (*rds.DescribeSourceRegionsOutput, error) {
@@ -1488,15 +2646,31 @@ func (_mr *_MockRDSAPIRecorder) DescribeSourceRegions(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSourceRegions", arg0)
 }
 
-func (_m *MockRDSAPI) DownloadDBLogFilePortionRequest(_param0 *rds.DownloadDBLogFilePortionInput) (*request.Request, *rds.DownloadDBLogFilePortionOutput) {
-	ret := _m.ctrl.Call(_m, "DownloadDBLogFilePortionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DownloadDBLogFilePortionOutput)
+func (_m *MockRDSAPI) DescribeSourceRegionsWithContext(_param0 aws.Context, _param1 *rds.DescribeSourceRegionsInput, _param2 ...request.Option) (*rds.DescribeSourceRegionsOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DescribeSourceRegionsWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DescribeSourceRegionsOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) DownloadDBLogFilePortionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DownloadDBLogFilePortionRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DescribeSourceRegionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSourceRegionsWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DescribeSourceRegionsRequest(_param0 *rds.DescribeSourceRegionsInput) (*request.Request, *rds.DescribeSourceRegionsOutput) {
+	ret := _m.ctrl.Call(_m, "DescribeSourceRegionsRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DescribeSourceRegionsOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DescribeSourceRegionsRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeSourceRegionsRequest", arg0)
 }
 
 func (_m *MockRDSAPI) DownloadDBLogFilePortion(_param0 *rds.DownloadDBLogFilePortionInput) (*rds.DownloadDBLogFilePortionOutput, error) {
@@ -1510,6 +2684,33 @@ func (_mr *_MockRDSAPIRecorder) DownloadDBLogFilePortion(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DownloadDBLogFilePortion", arg0)
 }
 
+func (_m *MockRDSAPI) DownloadDBLogFilePortionWithContext(_param0 aws.Context, _param1 *rds.DownloadDBLogFilePortionInput, _param2 ...request.Option) (*rds.DownloadDBLogFilePortionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DownloadDBLogFilePortionWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DownloadDBLogFilePortionOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DownloadDBLogFilePortionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DownloadDBLogFilePortionWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) DownloadDBLogFilePortionRequest(_param0 *rds.DownloadDBLogFilePortionInput) (*request.Request, *rds.DownloadDBLogFilePortionOutput) {
+	ret := _m.ctrl.Call(_m, "DownloadDBLogFilePortionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DownloadDBLogFilePortionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) DownloadDBLogFilePortionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DownloadDBLogFilePortionRequest", arg0)
+}
+
 func (_m *MockRDSAPI) DownloadDBLogFilePortionPages(_param0 *rds.DownloadDBLogFilePortionInput, _param1 func(*rds.DownloadDBLogFilePortionOutput, bool) bool) error {
 	ret := _m.ctrl.Call(_m, "DownloadDBLogFilePortionPages", _param0, _param1)
 	ret0, _ := ret[0].(error)
@@ -1520,15 +2721,19 @@ func (_mr *_MockRDSAPIRecorder) DownloadDBLogFilePortionPages(arg0, arg1 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DownloadDBLogFilePortionPages", arg0, arg1)
 }
 
-func (_m *MockRDSAPI) FailoverDBClusterRequest(_param0 *rds.FailoverDBClusterInput) (*request.Request, *rds.FailoverDBClusterOutput) {
-	ret := _m.ctrl.Call(_m, "FailoverDBClusterRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.FailoverDBClusterOutput)
-	return ret0, ret1
+func (_m *MockRDSAPI) DownloadDBLogFilePortionPagesWithContext(_param0 aws.Context, _param1 *rds.DownloadDBLogFilePortionInput, _param2 func(*rds.DownloadDBLogFilePortionOutput, bool) bool, _param3 ...request.Option) error {
+	_s := []interface{}{_param0, _param1, _param2}
+	for _, _x := range _param3 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "DownloadDBLogFilePortionPagesWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockRDSAPIRecorder) FailoverDBClusterRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "FailoverDBClusterRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) DownloadDBLogFilePortionPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DownloadDBLogFilePortionPagesWithContext", _s...)
 }
 
 func (_m *MockRDSAPI) FailoverDBCluster(_param0 *rds.FailoverDBClusterInput) (*rds.FailoverDBClusterOutput, error) {
@@ -1542,15 +2747,31 @@ func (_mr *_MockRDSAPIRecorder) FailoverDBCluster(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FailoverDBCluster", arg0)
 }
 
-func (_m *MockRDSAPI) ListTagsForResourceRequest(_param0 *rds.ListTagsForResourceInput) (*request.Request, *rds.ListTagsForResourceOutput) {
-	ret := _m.ctrl.Call(_m, "ListTagsForResourceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.ListTagsForResourceOutput)
+func (_m *MockRDSAPI) FailoverDBClusterWithContext(_param0 aws.Context, _param1 *rds.FailoverDBClusterInput, _param2 ...request.Option) (*rds.FailoverDBClusterOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "FailoverDBClusterWithContext", _s...)
+	ret0, _ := ret[0].(*rds.FailoverDBClusterOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) ListTagsForResourceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListTagsForResourceRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) FailoverDBClusterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FailoverDBClusterWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) FailoverDBClusterRequest(_param0 *rds.FailoverDBClusterInput) (*request.Request, *rds.FailoverDBClusterOutput) {
+	ret := _m.ctrl.Call(_m, "FailoverDBClusterRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.FailoverDBClusterOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) FailoverDBClusterRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FailoverDBClusterRequest", arg0)
 }
 
 func (_m *MockRDSAPI) ListTagsForResource(_param0 *rds.ListTagsForResourceInput) (*rds.ListTagsForResourceOutput, error) {
@@ -1564,15 +2785,31 @@ func (_mr *_MockRDSAPIRecorder) ListTagsForResource(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListTagsForResource", arg0)
 }
 
-func (_m *MockRDSAPI) ModifyDBClusterRequest(_param0 *rds.ModifyDBClusterInput) (*request.Request, *rds.ModifyDBClusterOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyDBClusterRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.ModifyDBClusterOutput)
+func (_m *MockRDSAPI) ListTagsForResourceWithContext(_param0 aws.Context, _param1 *rds.ListTagsForResourceInput, _param2 ...request.Option) (*rds.ListTagsForResourceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ListTagsForResourceWithContext", _s...)
+	ret0, _ := ret[0].(*rds.ListTagsForResourceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) ModifyDBClusterRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBClusterRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) ListTagsForResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListTagsForResourceWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) ListTagsForResourceRequest(_param0 *rds.ListTagsForResourceInput) (*request.Request, *rds.ListTagsForResourceOutput) {
+	ret := _m.ctrl.Call(_m, "ListTagsForResourceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.ListTagsForResourceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) ListTagsForResourceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListTagsForResourceRequest", arg0)
 }
 
 func (_m *MockRDSAPI) ModifyDBCluster(_param0 *rds.ModifyDBClusterInput) (*rds.ModifyDBClusterOutput, error) {
@@ -1586,15 +2823,31 @@ func (_mr *_MockRDSAPIRecorder) ModifyDBCluster(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBCluster", arg0)
 }
 
-func (_m *MockRDSAPI) ModifyDBClusterParameterGroupRequest(_param0 *rds.ModifyDBClusterParameterGroupInput) (*request.Request, *rds.DBClusterParameterGroupNameMessage) {
-	ret := _m.ctrl.Call(_m, "ModifyDBClusterParameterGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DBClusterParameterGroupNameMessage)
+func (_m *MockRDSAPI) ModifyDBClusterWithContext(_param0 aws.Context, _param1 *rds.ModifyDBClusterInput, _param2 ...request.Option) (*rds.ModifyDBClusterOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyDBClusterWithContext", _s...)
+	ret0, _ := ret[0].(*rds.ModifyDBClusterOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) ModifyDBClusterParameterGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBClusterParameterGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) ModifyDBClusterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBClusterWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) ModifyDBClusterRequest(_param0 *rds.ModifyDBClusterInput) (*request.Request, *rds.ModifyDBClusterOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyDBClusterRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.ModifyDBClusterOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) ModifyDBClusterRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBClusterRequest", arg0)
 }
 
 func (_m *MockRDSAPI) ModifyDBClusterParameterGroup(_param0 *rds.ModifyDBClusterParameterGroupInput) (*rds.DBClusterParameterGroupNameMessage, error) {
@@ -1608,15 +2861,31 @@ func (_mr *_MockRDSAPIRecorder) ModifyDBClusterParameterGroup(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBClusterParameterGroup", arg0)
 }
 
-func (_m *MockRDSAPI) ModifyDBClusterSnapshotAttributeRequest(_param0 *rds.ModifyDBClusterSnapshotAttributeInput) (*request.Request, *rds.ModifyDBClusterSnapshotAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyDBClusterSnapshotAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.ModifyDBClusterSnapshotAttributeOutput)
+func (_m *MockRDSAPI) ModifyDBClusterParameterGroupWithContext(_param0 aws.Context, _param1 *rds.ModifyDBClusterParameterGroupInput, _param2 ...request.Option) (*rds.DBClusterParameterGroupNameMessage, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyDBClusterParameterGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DBClusterParameterGroupNameMessage)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) ModifyDBClusterSnapshotAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBClusterSnapshotAttributeRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) ModifyDBClusterParameterGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBClusterParameterGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) ModifyDBClusterParameterGroupRequest(_param0 *rds.ModifyDBClusterParameterGroupInput) (*request.Request, *rds.DBClusterParameterGroupNameMessage) {
+	ret := _m.ctrl.Call(_m, "ModifyDBClusterParameterGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DBClusterParameterGroupNameMessage)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) ModifyDBClusterParameterGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBClusterParameterGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) ModifyDBClusterSnapshotAttribute(_param0 *rds.ModifyDBClusterSnapshotAttributeInput) (*rds.ModifyDBClusterSnapshotAttributeOutput, error) {
@@ -1630,15 +2899,31 @@ func (_mr *_MockRDSAPIRecorder) ModifyDBClusterSnapshotAttribute(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBClusterSnapshotAttribute", arg0)
 }
 
-func (_m *MockRDSAPI) ModifyDBInstanceRequest(_param0 *rds.ModifyDBInstanceInput) (*request.Request, *rds.ModifyDBInstanceOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyDBInstanceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.ModifyDBInstanceOutput)
+func (_m *MockRDSAPI) ModifyDBClusterSnapshotAttributeWithContext(_param0 aws.Context, _param1 *rds.ModifyDBClusterSnapshotAttributeInput, _param2 ...request.Option) (*rds.ModifyDBClusterSnapshotAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyDBClusterSnapshotAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*rds.ModifyDBClusterSnapshotAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) ModifyDBInstanceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBInstanceRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) ModifyDBClusterSnapshotAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBClusterSnapshotAttributeWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) ModifyDBClusterSnapshotAttributeRequest(_param0 *rds.ModifyDBClusterSnapshotAttributeInput) (*request.Request, *rds.ModifyDBClusterSnapshotAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyDBClusterSnapshotAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.ModifyDBClusterSnapshotAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) ModifyDBClusterSnapshotAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBClusterSnapshotAttributeRequest", arg0)
 }
 
 func (_m *MockRDSAPI) ModifyDBInstance(_param0 *rds.ModifyDBInstanceInput) (*rds.ModifyDBInstanceOutput, error) {
@@ -1652,15 +2937,31 @@ func (_mr *_MockRDSAPIRecorder) ModifyDBInstance(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBInstance", arg0)
 }
 
-func (_m *MockRDSAPI) ModifyDBParameterGroupRequest(_param0 *rds.ModifyDBParameterGroupInput) (*request.Request, *rds.DBParameterGroupNameMessage) {
-	ret := _m.ctrl.Call(_m, "ModifyDBParameterGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DBParameterGroupNameMessage)
+func (_m *MockRDSAPI) ModifyDBInstanceWithContext(_param0 aws.Context, _param1 *rds.ModifyDBInstanceInput, _param2 ...request.Option) (*rds.ModifyDBInstanceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyDBInstanceWithContext", _s...)
+	ret0, _ := ret[0].(*rds.ModifyDBInstanceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) ModifyDBParameterGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBParameterGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) ModifyDBInstanceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBInstanceWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) ModifyDBInstanceRequest(_param0 *rds.ModifyDBInstanceInput) (*request.Request, *rds.ModifyDBInstanceOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyDBInstanceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.ModifyDBInstanceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) ModifyDBInstanceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBInstanceRequest", arg0)
 }
 
 func (_m *MockRDSAPI) ModifyDBParameterGroup(_param0 *rds.ModifyDBParameterGroupInput) (*rds.DBParameterGroupNameMessage, error) {
@@ -1674,15 +2975,31 @@ func (_mr *_MockRDSAPIRecorder) ModifyDBParameterGroup(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBParameterGroup", arg0)
 }
 
-func (_m *MockRDSAPI) ModifyDBSnapshotRequest(_param0 *rds.ModifyDBSnapshotInput) (*request.Request, *rds.ModifyDBSnapshotOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyDBSnapshotRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.ModifyDBSnapshotOutput)
+func (_m *MockRDSAPI) ModifyDBParameterGroupWithContext(_param0 aws.Context, _param1 *rds.ModifyDBParameterGroupInput, _param2 ...request.Option) (*rds.DBParameterGroupNameMessage, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyDBParameterGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DBParameterGroupNameMessage)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) ModifyDBSnapshotRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBSnapshotRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) ModifyDBParameterGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBParameterGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) ModifyDBParameterGroupRequest(_param0 *rds.ModifyDBParameterGroupInput) (*request.Request, *rds.DBParameterGroupNameMessage) {
+	ret := _m.ctrl.Call(_m, "ModifyDBParameterGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DBParameterGroupNameMessage)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) ModifyDBParameterGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBParameterGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) ModifyDBSnapshot(_param0 *rds.ModifyDBSnapshotInput) (*rds.ModifyDBSnapshotOutput, error) {
@@ -1696,15 +3013,31 @@ func (_mr *_MockRDSAPIRecorder) ModifyDBSnapshot(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBSnapshot", arg0)
 }
 
-func (_m *MockRDSAPI) ModifyDBSnapshotAttributeRequest(_param0 *rds.ModifyDBSnapshotAttributeInput) (*request.Request, *rds.ModifyDBSnapshotAttributeOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyDBSnapshotAttributeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.ModifyDBSnapshotAttributeOutput)
+func (_m *MockRDSAPI) ModifyDBSnapshotWithContext(_param0 aws.Context, _param1 *rds.ModifyDBSnapshotInput, _param2 ...request.Option) (*rds.ModifyDBSnapshotOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyDBSnapshotWithContext", _s...)
+	ret0, _ := ret[0].(*rds.ModifyDBSnapshotOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) ModifyDBSnapshotAttributeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBSnapshotAttributeRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) ModifyDBSnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBSnapshotWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) ModifyDBSnapshotRequest(_param0 *rds.ModifyDBSnapshotInput) (*request.Request, *rds.ModifyDBSnapshotOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyDBSnapshotRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.ModifyDBSnapshotOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) ModifyDBSnapshotRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBSnapshotRequest", arg0)
 }
 
 func (_m *MockRDSAPI) ModifyDBSnapshotAttribute(_param0 *rds.ModifyDBSnapshotAttributeInput) (*rds.ModifyDBSnapshotAttributeOutput, error) {
@@ -1718,15 +3051,31 @@ func (_mr *_MockRDSAPIRecorder) ModifyDBSnapshotAttribute(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBSnapshotAttribute", arg0)
 }
 
-func (_m *MockRDSAPI) ModifyDBSubnetGroupRequest(_param0 *rds.ModifyDBSubnetGroupInput) (*request.Request, *rds.ModifyDBSubnetGroupOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyDBSubnetGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.ModifyDBSubnetGroupOutput)
+func (_m *MockRDSAPI) ModifyDBSnapshotAttributeWithContext(_param0 aws.Context, _param1 *rds.ModifyDBSnapshotAttributeInput, _param2 ...request.Option) (*rds.ModifyDBSnapshotAttributeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyDBSnapshotAttributeWithContext", _s...)
+	ret0, _ := ret[0].(*rds.ModifyDBSnapshotAttributeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) ModifyDBSubnetGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBSubnetGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) ModifyDBSnapshotAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBSnapshotAttributeWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) ModifyDBSnapshotAttributeRequest(_param0 *rds.ModifyDBSnapshotAttributeInput) (*request.Request, *rds.ModifyDBSnapshotAttributeOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyDBSnapshotAttributeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.ModifyDBSnapshotAttributeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) ModifyDBSnapshotAttributeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBSnapshotAttributeRequest", arg0)
 }
 
 func (_m *MockRDSAPI) ModifyDBSubnetGroup(_param0 *rds.ModifyDBSubnetGroupInput) (*rds.ModifyDBSubnetGroupOutput, error) {
@@ -1740,15 +3089,31 @@ func (_mr *_MockRDSAPIRecorder) ModifyDBSubnetGroup(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBSubnetGroup", arg0)
 }
 
-func (_m *MockRDSAPI) ModifyEventSubscriptionRequest(_param0 *rds.ModifyEventSubscriptionInput) (*request.Request, *rds.ModifyEventSubscriptionOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyEventSubscriptionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.ModifyEventSubscriptionOutput)
+func (_m *MockRDSAPI) ModifyDBSubnetGroupWithContext(_param0 aws.Context, _param1 *rds.ModifyDBSubnetGroupInput, _param2 ...request.Option) (*rds.ModifyDBSubnetGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyDBSubnetGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.ModifyDBSubnetGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) ModifyEventSubscriptionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyEventSubscriptionRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) ModifyDBSubnetGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBSubnetGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) ModifyDBSubnetGroupRequest(_param0 *rds.ModifyDBSubnetGroupInput) (*request.Request, *rds.ModifyDBSubnetGroupOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyDBSubnetGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.ModifyDBSubnetGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) ModifyDBSubnetGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyDBSubnetGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) ModifyEventSubscription(_param0 *rds.ModifyEventSubscriptionInput) (*rds.ModifyEventSubscriptionOutput, error) {
@@ -1762,15 +3127,31 @@ func (_mr *_MockRDSAPIRecorder) ModifyEventSubscription(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyEventSubscription", arg0)
 }
 
-func (_m *MockRDSAPI) ModifyOptionGroupRequest(_param0 *rds.ModifyOptionGroupInput) (*request.Request, *rds.ModifyOptionGroupOutput) {
-	ret := _m.ctrl.Call(_m, "ModifyOptionGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.ModifyOptionGroupOutput)
+func (_m *MockRDSAPI) ModifyEventSubscriptionWithContext(_param0 aws.Context, _param1 *rds.ModifyEventSubscriptionInput, _param2 ...request.Option) (*rds.ModifyEventSubscriptionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyEventSubscriptionWithContext", _s...)
+	ret0, _ := ret[0].(*rds.ModifyEventSubscriptionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) ModifyOptionGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyOptionGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) ModifyEventSubscriptionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyEventSubscriptionWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) ModifyEventSubscriptionRequest(_param0 *rds.ModifyEventSubscriptionInput) (*request.Request, *rds.ModifyEventSubscriptionOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyEventSubscriptionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.ModifyEventSubscriptionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) ModifyEventSubscriptionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyEventSubscriptionRequest", arg0)
 }
 
 func (_m *MockRDSAPI) ModifyOptionGroup(_param0 *rds.ModifyOptionGroupInput) (*rds.ModifyOptionGroupOutput, error) {
@@ -1784,15 +3165,31 @@ func (_mr *_MockRDSAPIRecorder) ModifyOptionGroup(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyOptionGroup", arg0)
 }
 
-func (_m *MockRDSAPI) PromoteReadReplicaRequest(_param0 *rds.PromoteReadReplicaInput) (*request.Request, *rds.PromoteReadReplicaOutput) {
-	ret := _m.ctrl.Call(_m, "PromoteReadReplicaRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.PromoteReadReplicaOutput)
+func (_m *MockRDSAPI) ModifyOptionGroupWithContext(_param0 aws.Context, _param1 *rds.ModifyOptionGroupInput, _param2 ...request.Option) (*rds.ModifyOptionGroupOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ModifyOptionGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.ModifyOptionGroupOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) PromoteReadReplicaRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PromoteReadReplicaRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) ModifyOptionGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyOptionGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) ModifyOptionGroupRequest(_param0 *rds.ModifyOptionGroupInput) (*request.Request, *rds.ModifyOptionGroupOutput) {
+	ret := _m.ctrl.Call(_m, "ModifyOptionGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.ModifyOptionGroupOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) ModifyOptionGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ModifyOptionGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) PromoteReadReplica(_param0 *rds.PromoteReadReplicaInput) (*rds.PromoteReadReplicaOutput, error) {
@@ -1806,15 +3203,31 @@ func (_mr *_MockRDSAPIRecorder) PromoteReadReplica(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PromoteReadReplica", arg0)
 }
 
-func (_m *MockRDSAPI) PromoteReadReplicaDBClusterRequest(_param0 *rds.PromoteReadReplicaDBClusterInput) (*request.Request, *rds.PromoteReadReplicaDBClusterOutput) {
-	ret := _m.ctrl.Call(_m, "PromoteReadReplicaDBClusterRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.PromoteReadReplicaDBClusterOutput)
+func (_m *MockRDSAPI) PromoteReadReplicaWithContext(_param0 aws.Context, _param1 *rds.PromoteReadReplicaInput, _param2 ...request.Option) (*rds.PromoteReadReplicaOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "PromoteReadReplicaWithContext", _s...)
+	ret0, _ := ret[0].(*rds.PromoteReadReplicaOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) PromoteReadReplicaDBClusterRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PromoteReadReplicaDBClusterRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) PromoteReadReplicaWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PromoteReadReplicaWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) PromoteReadReplicaRequest(_param0 *rds.PromoteReadReplicaInput) (*request.Request, *rds.PromoteReadReplicaOutput) {
+	ret := _m.ctrl.Call(_m, "PromoteReadReplicaRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.PromoteReadReplicaOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) PromoteReadReplicaRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PromoteReadReplicaRequest", arg0)
 }
 
 func (_m *MockRDSAPI) PromoteReadReplicaDBCluster(_param0 *rds.PromoteReadReplicaDBClusterInput) (*rds.PromoteReadReplicaDBClusterOutput, error) {
@@ -1828,15 +3241,31 @@ func (_mr *_MockRDSAPIRecorder) PromoteReadReplicaDBCluster(arg0 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PromoteReadReplicaDBCluster", arg0)
 }
 
-func (_m *MockRDSAPI) PurchaseReservedDBInstancesOfferingRequest(_param0 *rds.PurchaseReservedDBInstancesOfferingInput) (*request.Request, *rds.PurchaseReservedDBInstancesOfferingOutput) {
-	ret := _m.ctrl.Call(_m, "PurchaseReservedDBInstancesOfferingRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.PurchaseReservedDBInstancesOfferingOutput)
+func (_m *MockRDSAPI) PromoteReadReplicaDBClusterWithContext(_param0 aws.Context, _param1 *rds.PromoteReadReplicaDBClusterInput, _param2 ...request.Option) (*rds.PromoteReadReplicaDBClusterOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "PromoteReadReplicaDBClusterWithContext", _s...)
+	ret0, _ := ret[0].(*rds.PromoteReadReplicaDBClusterOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) PurchaseReservedDBInstancesOfferingRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseReservedDBInstancesOfferingRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) PromoteReadReplicaDBClusterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PromoteReadReplicaDBClusterWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) PromoteReadReplicaDBClusterRequest(_param0 *rds.PromoteReadReplicaDBClusterInput) (*request.Request, *rds.PromoteReadReplicaDBClusterOutput) {
+	ret := _m.ctrl.Call(_m, "PromoteReadReplicaDBClusterRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.PromoteReadReplicaDBClusterOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) PromoteReadReplicaDBClusterRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PromoteReadReplicaDBClusterRequest", arg0)
 }
 
 func (_m *MockRDSAPI) PurchaseReservedDBInstancesOffering(_param0 *rds.PurchaseReservedDBInstancesOfferingInput) (*rds.PurchaseReservedDBInstancesOfferingOutput, error) {
@@ -1850,15 +3279,31 @@ func (_mr *_MockRDSAPIRecorder) PurchaseReservedDBInstancesOffering(arg0 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseReservedDBInstancesOffering", arg0)
 }
 
-func (_m *MockRDSAPI) RebootDBInstanceRequest(_param0 *rds.RebootDBInstanceInput) (*request.Request, *rds.RebootDBInstanceOutput) {
-	ret := _m.ctrl.Call(_m, "RebootDBInstanceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.RebootDBInstanceOutput)
+func (_m *MockRDSAPI) PurchaseReservedDBInstancesOfferingWithContext(_param0 aws.Context, _param1 *rds.PurchaseReservedDBInstancesOfferingInput, _param2 ...request.Option) (*rds.PurchaseReservedDBInstancesOfferingOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "PurchaseReservedDBInstancesOfferingWithContext", _s...)
+	ret0, _ := ret[0].(*rds.PurchaseReservedDBInstancesOfferingOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) RebootDBInstanceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RebootDBInstanceRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) PurchaseReservedDBInstancesOfferingWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseReservedDBInstancesOfferingWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) PurchaseReservedDBInstancesOfferingRequest(_param0 *rds.PurchaseReservedDBInstancesOfferingInput) (*request.Request, *rds.PurchaseReservedDBInstancesOfferingOutput) {
+	ret := _m.ctrl.Call(_m, "PurchaseReservedDBInstancesOfferingRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.PurchaseReservedDBInstancesOfferingOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) PurchaseReservedDBInstancesOfferingRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PurchaseReservedDBInstancesOfferingRequest", arg0)
 }
 
 func (_m *MockRDSAPI) RebootDBInstance(_param0 *rds.RebootDBInstanceInput) (*rds.RebootDBInstanceOutput, error) {
@@ -1872,15 +3317,31 @@ func (_mr *_MockRDSAPIRecorder) RebootDBInstance(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RebootDBInstance", arg0)
 }
 
-func (_m *MockRDSAPI) RemoveRoleFromDBClusterRequest(_param0 *rds.RemoveRoleFromDBClusterInput) (*request.Request, *rds.RemoveRoleFromDBClusterOutput) {
-	ret := _m.ctrl.Call(_m, "RemoveRoleFromDBClusterRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.RemoveRoleFromDBClusterOutput)
+func (_m *MockRDSAPI) RebootDBInstanceWithContext(_param0 aws.Context, _param1 *rds.RebootDBInstanceInput, _param2 ...request.Option) (*rds.RebootDBInstanceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RebootDBInstanceWithContext", _s...)
+	ret0, _ := ret[0].(*rds.RebootDBInstanceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) RemoveRoleFromDBClusterRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveRoleFromDBClusterRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) RebootDBInstanceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RebootDBInstanceWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) RebootDBInstanceRequest(_param0 *rds.RebootDBInstanceInput) (*request.Request, *rds.RebootDBInstanceOutput) {
+	ret := _m.ctrl.Call(_m, "RebootDBInstanceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.RebootDBInstanceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) RebootDBInstanceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RebootDBInstanceRequest", arg0)
 }
 
 func (_m *MockRDSAPI) RemoveRoleFromDBCluster(_param0 *rds.RemoveRoleFromDBClusterInput) (*rds.RemoveRoleFromDBClusterOutput, error) {
@@ -1894,15 +3355,31 @@ func (_mr *_MockRDSAPIRecorder) RemoveRoleFromDBCluster(arg0 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveRoleFromDBCluster", arg0)
 }
 
-func (_m *MockRDSAPI) RemoveSourceIdentifierFromSubscriptionRequest(_param0 *rds.RemoveSourceIdentifierFromSubscriptionInput) (*request.Request, *rds.RemoveSourceIdentifierFromSubscriptionOutput) {
-	ret := _m.ctrl.Call(_m, "RemoveSourceIdentifierFromSubscriptionRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.RemoveSourceIdentifierFromSubscriptionOutput)
+func (_m *MockRDSAPI) RemoveRoleFromDBClusterWithContext(_param0 aws.Context, _param1 *rds.RemoveRoleFromDBClusterInput, _param2 ...request.Option) (*rds.RemoveRoleFromDBClusterOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RemoveRoleFromDBClusterWithContext", _s...)
+	ret0, _ := ret[0].(*rds.RemoveRoleFromDBClusterOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) RemoveSourceIdentifierFromSubscriptionRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveSourceIdentifierFromSubscriptionRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) RemoveRoleFromDBClusterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveRoleFromDBClusterWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) RemoveRoleFromDBClusterRequest(_param0 *rds.RemoveRoleFromDBClusterInput) (*request.Request, *rds.RemoveRoleFromDBClusterOutput) {
+	ret := _m.ctrl.Call(_m, "RemoveRoleFromDBClusterRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.RemoveRoleFromDBClusterOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) RemoveRoleFromDBClusterRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveRoleFromDBClusterRequest", arg0)
 }
 
 func (_m *MockRDSAPI) RemoveSourceIdentifierFromSubscription(_param0 *rds.RemoveSourceIdentifierFromSubscriptionInput) (*rds.RemoveSourceIdentifierFromSubscriptionOutput, error) {
@@ -1916,15 +3393,31 @@ func (_mr *_MockRDSAPIRecorder) RemoveSourceIdentifierFromSubscription(arg0 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveSourceIdentifierFromSubscription", arg0)
 }
 
-func (_m *MockRDSAPI) RemoveTagsFromResourceRequest(_param0 *rds.RemoveTagsFromResourceInput) (*request.Request, *rds.RemoveTagsFromResourceOutput) {
-	ret := _m.ctrl.Call(_m, "RemoveTagsFromResourceRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.RemoveTagsFromResourceOutput)
+func (_m *MockRDSAPI) RemoveSourceIdentifierFromSubscriptionWithContext(_param0 aws.Context, _param1 *rds.RemoveSourceIdentifierFromSubscriptionInput, _param2 ...request.Option) (*rds.RemoveSourceIdentifierFromSubscriptionOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RemoveSourceIdentifierFromSubscriptionWithContext", _s...)
+	ret0, _ := ret[0].(*rds.RemoveSourceIdentifierFromSubscriptionOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) RemoveTagsFromResourceRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveTagsFromResourceRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) RemoveSourceIdentifierFromSubscriptionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveSourceIdentifierFromSubscriptionWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) RemoveSourceIdentifierFromSubscriptionRequest(_param0 *rds.RemoveSourceIdentifierFromSubscriptionInput) (*request.Request, *rds.RemoveSourceIdentifierFromSubscriptionOutput) {
+	ret := _m.ctrl.Call(_m, "RemoveSourceIdentifierFromSubscriptionRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.RemoveSourceIdentifierFromSubscriptionOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) RemoveSourceIdentifierFromSubscriptionRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveSourceIdentifierFromSubscriptionRequest", arg0)
 }
 
 func (_m *MockRDSAPI) RemoveTagsFromResource(_param0 *rds.RemoveTagsFromResourceInput) (*rds.RemoveTagsFromResourceOutput, error) {
@@ -1938,15 +3431,31 @@ func (_mr *_MockRDSAPIRecorder) RemoveTagsFromResource(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveTagsFromResource", arg0)
 }
 
-func (_m *MockRDSAPI) ResetDBClusterParameterGroupRequest(_param0 *rds.ResetDBClusterParameterGroupInput) (*request.Request, *rds.DBClusterParameterGroupNameMessage) {
-	ret := _m.ctrl.Call(_m, "ResetDBClusterParameterGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DBClusterParameterGroupNameMessage)
+func (_m *MockRDSAPI) RemoveTagsFromResourceWithContext(_param0 aws.Context, _param1 *rds.RemoveTagsFromResourceInput, _param2 ...request.Option) (*rds.RemoveTagsFromResourceOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RemoveTagsFromResourceWithContext", _s...)
+	ret0, _ := ret[0].(*rds.RemoveTagsFromResourceOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) ResetDBClusterParameterGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetDBClusterParameterGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) RemoveTagsFromResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveTagsFromResourceWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) RemoveTagsFromResourceRequest(_param0 *rds.RemoveTagsFromResourceInput) (*request.Request, *rds.RemoveTagsFromResourceOutput) {
+	ret := _m.ctrl.Call(_m, "RemoveTagsFromResourceRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.RemoveTagsFromResourceOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) RemoveTagsFromResourceRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveTagsFromResourceRequest", arg0)
 }
 
 func (_m *MockRDSAPI) ResetDBClusterParameterGroup(_param0 *rds.ResetDBClusterParameterGroupInput) (*rds.DBClusterParameterGroupNameMessage, error) {
@@ -1960,15 +3469,31 @@ func (_mr *_MockRDSAPIRecorder) ResetDBClusterParameterGroup(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetDBClusterParameterGroup", arg0)
 }
 
-func (_m *MockRDSAPI) ResetDBParameterGroupRequest(_param0 *rds.ResetDBParameterGroupInput) (*request.Request, *rds.DBParameterGroupNameMessage) {
-	ret := _m.ctrl.Call(_m, "ResetDBParameterGroupRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.DBParameterGroupNameMessage)
+func (_m *MockRDSAPI) ResetDBClusterParameterGroupWithContext(_param0 aws.Context, _param1 *rds.ResetDBClusterParameterGroupInput, _param2 ...request.Option) (*rds.DBClusterParameterGroupNameMessage, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ResetDBClusterParameterGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DBClusterParameterGroupNameMessage)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) ResetDBParameterGroupRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetDBParameterGroupRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) ResetDBClusterParameterGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetDBClusterParameterGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) ResetDBClusterParameterGroupRequest(_param0 *rds.ResetDBClusterParameterGroupInput) (*request.Request, *rds.DBClusterParameterGroupNameMessage) {
+	ret := _m.ctrl.Call(_m, "ResetDBClusterParameterGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DBClusterParameterGroupNameMessage)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) ResetDBClusterParameterGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetDBClusterParameterGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) ResetDBParameterGroup(_param0 *rds.ResetDBParameterGroupInput) (*rds.DBParameterGroupNameMessage, error) {
@@ -1982,15 +3507,31 @@ func (_mr *_MockRDSAPIRecorder) ResetDBParameterGroup(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetDBParameterGroup", arg0)
 }
 
-func (_m *MockRDSAPI) RestoreDBClusterFromS3Request(_param0 *rds.RestoreDBClusterFromS3Input) (*request.Request, *rds.RestoreDBClusterFromS3Output) {
-	ret := _m.ctrl.Call(_m, "RestoreDBClusterFromS3Request", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.RestoreDBClusterFromS3Output)
+func (_m *MockRDSAPI) ResetDBParameterGroupWithContext(_param0 aws.Context, _param1 *rds.ResetDBParameterGroupInput, _param2 ...request.Option) (*rds.DBParameterGroupNameMessage, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "ResetDBParameterGroupWithContext", _s...)
+	ret0, _ := ret[0].(*rds.DBParameterGroupNameMessage)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) RestoreDBClusterFromS3Request(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBClusterFromS3Request", arg0)
+func (_mr *_MockRDSAPIRecorder) ResetDBParameterGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetDBParameterGroupWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) ResetDBParameterGroupRequest(_param0 *rds.ResetDBParameterGroupInput) (*request.Request, *rds.DBParameterGroupNameMessage) {
+	ret := _m.ctrl.Call(_m, "ResetDBParameterGroupRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.DBParameterGroupNameMessage)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) ResetDBParameterGroupRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetDBParameterGroupRequest", arg0)
 }
 
 func (_m *MockRDSAPI) RestoreDBClusterFromS3(_param0 *rds.RestoreDBClusterFromS3Input) (*rds.RestoreDBClusterFromS3Output, error) {
@@ -2004,15 +3545,31 @@ func (_mr *_MockRDSAPIRecorder) RestoreDBClusterFromS3(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBClusterFromS3", arg0)
 }
 
-func (_m *MockRDSAPI) RestoreDBClusterFromSnapshotRequest(_param0 *rds.RestoreDBClusterFromSnapshotInput) (*request.Request, *rds.RestoreDBClusterFromSnapshotOutput) {
-	ret := _m.ctrl.Call(_m, "RestoreDBClusterFromSnapshotRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.RestoreDBClusterFromSnapshotOutput)
+func (_m *MockRDSAPI) RestoreDBClusterFromS3WithContext(_param0 aws.Context, _param1 *rds.RestoreDBClusterFromS3Input, _param2 ...request.Option) (*rds.RestoreDBClusterFromS3Output, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RestoreDBClusterFromS3WithContext", _s...)
+	ret0, _ := ret[0].(*rds.RestoreDBClusterFromS3Output)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) RestoreDBClusterFromSnapshotRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBClusterFromSnapshotRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) RestoreDBClusterFromS3WithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBClusterFromS3WithContext", _s...)
+}
+
+func (_m *MockRDSAPI) RestoreDBClusterFromS3Request(_param0 *rds.RestoreDBClusterFromS3Input) (*request.Request, *rds.RestoreDBClusterFromS3Output) {
+	ret := _m.ctrl.Call(_m, "RestoreDBClusterFromS3Request", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.RestoreDBClusterFromS3Output)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) RestoreDBClusterFromS3Request(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBClusterFromS3Request", arg0)
 }
 
 func (_m *MockRDSAPI) RestoreDBClusterFromSnapshot(_param0 *rds.RestoreDBClusterFromSnapshotInput) (*rds.RestoreDBClusterFromSnapshotOutput, error) {
@@ -2026,15 +3583,31 @@ func (_mr *_MockRDSAPIRecorder) RestoreDBClusterFromSnapshot(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBClusterFromSnapshot", arg0)
 }
 
-func (_m *MockRDSAPI) RestoreDBClusterToPointInTimeRequest(_param0 *rds.RestoreDBClusterToPointInTimeInput) (*request.Request, *rds.RestoreDBClusterToPointInTimeOutput) {
-	ret := _m.ctrl.Call(_m, "RestoreDBClusterToPointInTimeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.RestoreDBClusterToPointInTimeOutput)
+func (_m *MockRDSAPI) RestoreDBClusterFromSnapshotWithContext(_param0 aws.Context, _param1 *rds.RestoreDBClusterFromSnapshotInput, _param2 ...request.Option) (*rds.RestoreDBClusterFromSnapshotOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RestoreDBClusterFromSnapshotWithContext", _s...)
+	ret0, _ := ret[0].(*rds.RestoreDBClusterFromSnapshotOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) RestoreDBClusterToPointInTimeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBClusterToPointInTimeRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) RestoreDBClusterFromSnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBClusterFromSnapshotWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) RestoreDBClusterFromSnapshotRequest(_param0 *rds.RestoreDBClusterFromSnapshotInput) (*request.Request, *rds.RestoreDBClusterFromSnapshotOutput) {
+	ret := _m.ctrl.Call(_m, "RestoreDBClusterFromSnapshotRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.RestoreDBClusterFromSnapshotOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) RestoreDBClusterFromSnapshotRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBClusterFromSnapshotRequest", arg0)
 }
 
 func (_m *MockRDSAPI) RestoreDBClusterToPointInTime(_param0 *rds.RestoreDBClusterToPointInTimeInput) (*rds.RestoreDBClusterToPointInTimeOutput, error) {
@@ -2048,15 +3621,31 @@ func (_mr *_MockRDSAPIRecorder) RestoreDBClusterToPointInTime(arg0 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBClusterToPointInTime", arg0)
 }
 
-func (_m *MockRDSAPI) RestoreDBInstanceFromDBSnapshotRequest(_param0 *rds.RestoreDBInstanceFromDBSnapshotInput) (*request.Request, *rds.RestoreDBInstanceFromDBSnapshotOutput) {
-	ret := _m.ctrl.Call(_m, "RestoreDBInstanceFromDBSnapshotRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.RestoreDBInstanceFromDBSnapshotOutput)
+func (_m *MockRDSAPI) RestoreDBClusterToPointInTimeWithContext(_param0 aws.Context, _param1 *rds.RestoreDBClusterToPointInTimeInput, _param2 ...request.Option) (*rds.RestoreDBClusterToPointInTimeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RestoreDBClusterToPointInTimeWithContext", _s...)
+	ret0, _ := ret[0].(*rds.RestoreDBClusterToPointInTimeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) RestoreDBInstanceFromDBSnapshotRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBInstanceFromDBSnapshotRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) RestoreDBClusterToPointInTimeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBClusterToPointInTimeWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) RestoreDBClusterToPointInTimeRequest(_param0 *rds.RestoreDBClusterToPointInTimeInput) (*request.Request, *rds.RestoreDBClusterToPointInTimeOutput) {
+	ret := _m.ctrl.Call(_m, "RestoreDBClusterToPointInTimeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.RestoreDBClusterToPointInTimeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) RestoreDBClusterToPointInTimeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBClusterToPointInTimeRequest", arg0)
 }
 
 func (_m *MockRDSAPI) RestoreDBInstanceFromDBSnapshot(_param0 *rds.RestoreDBInstanceFromDBSnapshotInput) (*rds.RestoreDBInstanceFromDBSnapshotOutput, error) {
@@ -2070,15 +3659,31 @@ func (_mr *_MockRDSAPIRecorder) RestoreDBInstanceFromDBSnapshot(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBInstanceFromDBSnapshot", arg0)
 }
 
-func (_m *MockRDSAPI) RestoreDBInstanceToPointInTimeRequest(_param0 *rds.RestoreDBInstanceToPointInTimeInput) (*request.Request, *rds.RestoreDBInstanceToPointInTimeOutput) {
-	ret := _m.ctrl.Call(_m, "RestoreDBInstanceToPointInTimeRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.RestoreDBInstanceToPointInTimeOutput)
+func (_m *MockRDSAPI) RestoreDBInstanceFromDBSnapshotWithContext(_param0 aws.Context, _param1 *rds.RestoreDBInstanceFromDBSnapshotInput, _param2 ...request.Option) (*rds.RestoreDBInstanceFromDBSnapshotOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RestoreDBInstanceFromDBSnapshotWithContext", _s...)
+	ret0, _ := ret[0].(*rds.RestoreDBInstanceFromDBSnapshotOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) RestoreDBInstanceToPointInTimeRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBInstanceToPointInTimeRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) RestoreDBInstanceFromDBSnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBInstanceFromDBSnapshotWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) RestoreDBInstanceFromDBSnapshotRequest(_param0 *rds.RestoreDBInstanceFromDBSnapshotInput) (*request.Request, *rds.RestoreDBInstanceFromDBSnapshotOutput) {
+	ret := _m.ctrl.Call(_m, "RestoreDBInstanceFromDBSnapshotRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.RestoreDBInstanceFromDBSnapshotOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) RestoreDBInstanceFromDBSnapshotRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBInstanceFromDBSnapshotRequest", arg0)
 }
 
 func (_m *MockRDSAPI) RestoreDBInstanceToPointInTime(_param0 *rds.RestoreDBInstanceToPointInTimeInput) (*rds.RestoreDBInstanceToPointInTimeOutput, error) {
@@ -2092,15 +3697,31 @@ func (_mr *_MockRDSAPIRecorder) RestoreDBInstanceToPointInTime(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBInstanceToPointInTime", arg0)
 }
 
-func (_m *MockRDSAPI) RevokeDBSecurityGroupIngressRequest(_param0 *rds.RevokeDBSecurityGroupIngressInput) (*request.Request, *rds.RevokeDBSecurityGroupIngressOutput) {
-	ret := _m.ctrl.Call(_m, "RevokeDBSecurityGroupIngressRequest", _param0)
-	ret0, _ := ret[0].(*request.Request)
-	ret1, _ := ret[1].(*rds.RevokeDBSecurityGroupIngressOutput)
+func (_m *MockRDSAPI) RestoreDBInstanceToPointInTimeWithContext(_param0 aws.Context, _param1 *rds.RestoreDBInstanceToPointInTimeInput, _param2 ...request.Option) (*rds.RestoreDBInstanceToPointInTimeOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RestoreDBInstanceToPointInTimeWithContext", _s...)
+	ret0, _ := ret[0].(*rds.RestoreDBInstanceToPointInTimeOutput)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockRDSAPIRecorder) RevokeDBSecurityGroupIngressRequest(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevokeDBSecurityGroupIngressRequest", arg0)
+func (_mr *_MockRDSAPIRecorder) RestoreDBInstanceToPointInTimeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBInstanceToPointInTimeWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) RestoreDBInstanceToPointInTimeRequest(_param0 *rds.RestoreDBInstanceToPointInTimeInput) (*request.Request, *rds.RestoreDBInstanceToPointInTimeOutput) {
+	ret := _m.ctrl.Call(_m, "RestoreDBInstanceToPointInTimeRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.RestoreDBInstanceToPointInTimeOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) RestoreDBInstanceToPointInTimeRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RestoreDBInstanceToPointInTimeRequest", arg0)
 }
 
 func (_m *MockRDSAPI) RevokeDBSecurityGroupIngress(_param0 *rds.RevokeDBSecurityGroupIngressInput) (*rds.RevokeDBSecurityGroupIngressOutput, error) {
@@ -2114,6 +3735,33 @@ func (_mr *_MockRDSAPIRecorder) RevokeDBSecurityGroupIngress(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevokeDBSecurityGroupIngress", arg0)
 }
 
+func (_m *MockRDSAPI) RevokeDBSecurityGroupIngressWithContext(_param0 aws.Context, _param1 *rds.RevokeDBSecurityGroupIngressInput, _param2 ...request.Option) (*rds.RevokeDBSecurityGroupIngressOutput, error) {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "RevokeDBSecurityGroupIngressWithContext", _s...)
+	ret0, _ := ret[0].(*rds.RevokeDBSecurityGroupIngressOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) RevokeDBSecurityGroupIngressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevokeDBSecurityGroupIngressWithContext", _s...)
+}
+
+func (_m *MockRDSAPI) RevokeDBSecurityGroupIngressRequest(_param0 *rds.RevokeDBSecurityGroupIngressInput) (*request.Request, *rds.RevokeDBSecurityGroupIngressOutput) {
+	ret := _m.ctrl.Call(_m, "RevokeDBSecurityGroupIngressRequest", _param0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*rds.RevokeDBSecurityGroupIngressOutput)
+	return ret0, ret1
+}
+
+func (_mr *_MockRDSAPIRecorder) RevokeDBSecurityGroupIngressRequest(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevokeDBSecurityGroupIngressRequest", arg0)
+}
+
 func (_m *MockRDSAPI) WaitUntilDBInstanceAvailable(_param0 *rds.DescribeDBInstancesInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilDBInstanceAvailable", _param0)
 	ret0, _ := ret[0].(error)
@@ -2124,6 +3772,21 @@ func (_mr *_MockRDSAPIRecorder) WaitUntilDBInstanceAvailable(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilDBInstanceAvailable", arg0)
 }
 
+func (_m *MockRDSAPI) WaitUntilDBInstanceAvailableWithContext(_param0 aws.Context, _param1 *rds.DescribeDBInstancesInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilDBInstanceAvailableWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockRDSAPIRecorder) WaitUntilDBInstanceAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilDBInstanceAvailableWithContext", _s...)
+}
+
 func (_m *MockRDSAPI) WaitUntilDBInstanceDeleted(_param0 *rds.DescribeDBInstancesInput) error {
 	ret := _m.ctrl.Call(_m, "WaitUntilDBInstanceDeleted", _param0)
 	ret0, _ := ret[0].(error)
@@ -2132,4 +3795,19 @@ func (_m *MockRDSAPI) WaitUntilDBInstanceDeleted(_param0 *rds.DescribeDBInstance
 
 func (_mr *_MockRDSAPIRecorder) WaitUntilDBInstanceDeleted(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilDBInstanceDeleted", arg0)
+}
+
+func (_m *MockRDSAPI) WaitUntilDBInstanceDeletedWithContext(_param0 aws.Context, _param1 *rds.DescribeDBInstancesInput, _param2 ...request.WaiterOption) error {
+	_s := []interface{}{_param0, _param1}
+	for _, _x := range _param2 {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "WaitUntilDBInstanceDeletedWithContext", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockRDSAPIRecorder) WaitUntilDBInstanceDeletedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "WaitUntilDBInstanceDeletedWithContext", _s...)
 }


### PR DESCRIPTION
Fix #70 

We specify shared credentials by `--aws-profile` options or `profile` attributes. This credentials used in deep check mode.