### PR TITLE
Add checkstyle format

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Please show `tflint --help`
 ```
 -h, --help                              show usage of TFLint. This page.
 -v, --version                           print version information.
--f, --format <format>                   choose output format from "default" or "json"
+-f, --format <format>                   choose output format from "default", "json" or "checkstyle"
 -c, --config <file>                     specify config file. default is ".tflint.hcl"
 --ignore-module <source1,source2...>    ignore module by specified source.
 --ignore-rule <rule1,rule2...>          ignore rules.

--- a/cli.go
+++ b/cli.go
@@ -71,7 +71,7 @@ func (cli *CLI) Run(args []string) int {
 	flags.BoolVar(&help, "h", false, "alias for --help")
 	flags.BoolVar(&configArgs.Debug, "debug", false, "enable debug mode.")
 	flags.BoolVar(&configArgs.Debug, "d", false, "alias for --debug")
-	flags.StringVar(&format, "format", "default", "choose output format from \"default\" or \"json\"")
+	flags.StringVar(&format, "format", "default", "choose output format from \"default\", \"json\" or \"checkstyle\"")
 	flags.StringVar(&format, "f", "default", "alias for --format")
 	flags.StringVar(&configArgs.IgnoreModule, "ignore-module", "", "ignore module by specified source.")
 	flags.StringVar(&configArgs.IgnoreRule, "ignore-rule", "", "ignore rules.")

--- a/cli_test.go
+++ b/cli_test.go
@@ -280,6 +280,21 @@ func TestCLIRun(t *testing.T) {
 			},
 		},
 		{
+			Name:              "specify checkstyle format",
+			Command:           "./tflint --format checkstyle",
+			LoaderGenerator:   loaderDefaultBehavior,
+			DetectorGenerator: detectorNoErrorNoIssuesBehavior,
+			PrinterGenerator: func(ctrl *gomock.Controller) printer.PrinterIF {
+				printer := mock.NewMockPrinterIF(ctrl)
+				printer.EXPECT().Print([]*issue.Issue{}, "checkstyle")
+				return printer
+			},
+			Result: Result{
+				Status:     ExitCodeOK,
+				CLIOptions: defaultCLIOptions,
+			},
+		},
+		{
 			Name:              "specify invalid format",
 			Command:           "./tflint --format awesome",
 			LoaderGenerator:   func(ctrl *gomock.Controller) loader.LoaderIF { return mock.NewMockLoaderIF(ctrl) },

--- a/help.go
+++ b/help.go
@@ -7,7 +7,7 @@ Usage: tflint [<options>] <args>
 Available Options:
     -h, --help                              show usage of TFLint. This page.
     -v, --version                           print version information.
-    -f, --format <format>                   choose output format from "default" or "json"
+    -f, --format <format>                   choose output format from "default", "json" or "checkstyle"
     -c, --config <file>                     specify config file. default is ".tflint.hcl"
     --ignore-module <source1,source2...>    ignore module by specified source.
     --ignore-rule <rule1,rule2...>          ignore rules.

--- a/printer/checkstyle.go
+++ b/printer/checkstyle.go
@@ -1,0 +1,59 @@
+package printer
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	"sort"
+
+	"github.com/wata727/tflint/issue"
+)
+
+type Error struct {
+	Line     int    `xml:"line,attr"`
+	Severity string `xml:"severity,attr"`
+	Message  string `xml:"message,attr"`
+}
+
+type File struct {
+	Name   string  `xml:"name,attr"`
+	Errors []Error `xml:"error"`
+}
+
+type Checkstyle struct {
+	XMLName xml.Name `xml:"checkstyle"`
+	Files   []File   `xml:"file"`
+}
+
+func (p *Printer) CheckstylePrint(issues []*issue.Issue) {
+	sort.Sort(issue.ByFile{Issues: issue.Issues(issues)})
+
+	v := &Checkstyle{}
+
+	for _, i := range issues {
+		if len(v.Files) == 0 || v.Files[len(v.Files)-1].Name != i.File {
+			v.Files = append(v.Files, File{Name: i.File})
+		}
+		v.Files[len(v.Files)-1].Errors = append(v.Files[len(v.Files)-1].Errors, Error{Line: i.Line, Severity: toSeverity(i.Type), Message: i.Message})
+	}
+
+	result, err := xml.MarshalIndent(v, "", "  ")
+	if err != nil {
+		fmt.Fprint(p.stderr, err)
+	}
+	fmt.Fprint(p.stdout, xml.Header)
+	fmt.Fprint(p.stdout, string(result))
+}
+
+func toSeverity(lintType string) string {
+	switch lintType {
+	case issue.ERROR:
+		return "error"
+	case issue.WARNING:
+		return "warning"
+	case issue.NOTICE:
+		return "info"
+	default:
+		return "unknown"
+	}
+}

--- a/printer/checkstyle_test.go
+++ b/printer/checkstyle_test.go
@@ -1,0 +1,69 @@
+package printer
+
+import (
+	"testing"
+
+	"bytes"
+
+	"github.com/wata727/tflint/issue"
+)
+
+func TestCheckstylePrint(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Input  []*issue.Issue
+		Result string
+	}{
+		{
+			Name:  "no issues",
+			Input: []*issue.Issue{},
+			Result: `<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle></checkstyle>`,
+		},
+		{
+			Name: "multi files",
+			Input: []*issue.Issue{
+				{
+					File:    "template.tf",
+					Line:    1,
+					Type:    "ERROR",
+					Message: "example error message",
+				},
+				{
+					File:    "application.tf",
+					Line:    10,
+					Type:    "NOTICE",
+					Message: "example notice message",
+				},
+				{
+					File:    "template.tf",
+					Line:    3,
+					Type:    "WARNING",
+					Message: "example warning message",
+				},
+			},
+			Result: `<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle>
+  <file name="application.tf">
+    <error line="10" severity="info" message="example notice message"></error>
+  </file>
+  <file name="template.tf">
+    <error line="1" severity="error" message="example error message"></error>
+    <error line="3" severity="warning" message="example warning message"></error>
+  </file>
+</checkstyle>`,
+		},
+	}
+
+	for _, tc := range cases {
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		p := NewPrinter(stdout, stderr)
+		p.CheckstylePrint(tc.Input)
+		result := stdout.String()
+
+		if result != tc.Result {
+			t.Fatalf("\nBad: %s\nExpected: %s\n\ntestcase: %s", result, tc.Result, tc.Name)
+		}
+	}
+}

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -16,8 +16,9 @@ type Printer struct {
 }
 
 var validFormat = map[string]bool{
-	"default": true,
-	"json":    true,
+	"default":    true,
+	"json":       true,
+	"checkstyle": true,
 }
 
 func NewPrinter(stdout io.Writer, stderr io.Writer) *Printer {
@@ -37,6 +38,8 @@ func (p *Printer) Print(issues []*issue.Issue, format string) {
 		p.DefaultPrint(issues)
 	case "json":
 		p.JSONPrint(issues)
+	case "checkstyle":
+		p.CheckstylePrint(issues)
 	default:
 		p.DefaultPrint(issues)
 	}

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -21,6 +21,11 @@ func TestValidateFormat(t *testing.T) {
 			Result: true,
 		},
 		{
+			Name:   "checkstyle is valid format",
+			Input:  "checkstyle",
+			Result: true,
+		},
+		{
 			Name:   "yaml is invalid format",
 			Input:  "yaml",
 			Result: false,


### PR DESCRIPTION
Fix #76 

Introduce new output format called [checkstyle](http://checkstyle.sourceforge.net/).
The output of this format can be parsed with Jenkins plugin.