### PR TITLE
Fix panic when security groups are on EC2-Classic

### DIFF
--- a/config/aws.go
+++ b/config/aws.go
@@ -85,6 +85,7 @@ type ResponseCache struct {
 	DescribeSecurityGroupsOutput       *ec2.DescribeSecurityGroupsOutput
 	DescribeVpcsOutput                 *ec2.DescribeVpcsOutput
 	DescribeInstancesOutput            *ec2.DescribeInstancesOutput
+	DescribeAccountAttributesOutput    *ec2.DescribeAccountAttributesOutput
 	ListInstanceProfilesOutput         *iam.ListInstanceProfilesOutput
 	DescribeDBSubnetGroupsOutput       *rds.DescribeDBSubnetGroupsOutput
 	DescribeDBParameterGroupsOutput    *rds.DescribeDBParameterGroupsOutput
@@ -161,6 +162,17 @@ func (c *AwsClient) DescribeInstances() (*ec2.DescribeInstancesOutput, error) {
 		c.Cache.DescribeInstancesOutput = resp
 	}
 	return c.Cache.DescribeInstancesOutput, nil
+}
+
+func (c AwsClient) DescribeAccountAttributes() (*ec2.DescribeAccountAttributesOutput, error) {
+	if c.Cache.DescribeAccountAttributesOutput == nil {
+		resp, err := c.Ec2.DescribeAccountAttributes(&ec2.DescribeAccountAttributesInput{})
+		if err != nil {
+			return nil, err
+		}
+		c.Cache.DescribeAccountAttributesOutput = resp
+	}
+	return c.Cache.DescribeAccountAttributesOutput, nil
 }
 
 func (c *AwsClient) ListInstanceProfiles() (*iam.ListInstanceProfilesOutput, error) {

--- a/detector/aws_security_group_duplicate_name.go
+++ b/detector/aws_security_group_duplicate_name.go
@@ -42,7 +42,14 @@ func (d *AwsSecurityGroupDuplicateDetector) PreProcess() {
 	}
 
 	for _, securityGroup := range securityGroupsResp.SecurityGroups {
-		d.securiyGroups[*securityGroup.VpcId+"."+*securityGroup.GroupName] = true
+		var vpcId string
+		// If vpcId is nil, it is on EC2-Classic.
+		if securityGroup.VpcId == nil {
+			vpcId = "none"
+		} else {
+			vpcId = *securityGroup.VpcId
+		}
+		d.securiyGroups[vpcId+"."+*securityGroup.GroupName] = true
 	}
 	for _, attr := range attrsResp.AccountAttributes {
 		if *attr.AttributeName == "default-vpc" {

--- a/detector/aws_security_group_duplicate_name.go
+++ b/detector/aws_security_group_duplicate_name.go
@@ -34,7 +34,7 @@ func (d *AwsSecurityGroupDuplicateDetector) PreProcess() {
 		d.Error = true
 		return
 	}
-	vpcsResp, err := d.AwsClient.DescribeVpcs()
+	attrsResp, err := d.AwsClient.DescribeAccountAttributes()
 	if err != nil {
 		d.Logger.Error(err)
 		d.Error = true
@@ -44,9 +44,9 @@ func (d *AwsSecurityGroupDuplicateDetector) PreProcess() {
 	for _, securityGroup := range securityGroupsResp.SecurityGroups {
 		d.securiyGroups[*securityGroup.VpcId+"."+*securityGroup.GroupName] = true
 	}
-	for _, vpcResource := range vpcsResp.Vpcs {
-		if *vpcResource.IsDefault {
-			d.defaultVpc = *vpcResource.VpcId
+	for _, attr := range attrsResp.AccountAttributes {
+		if *attr.AttributeName == "default-vpc" {
+			d.defaultVpc = *attr.AttributeValues[0].AttributeValue
 			break
 		}
 	}

--- a/detector/aws_security_group_duplicate_name_test.go
+++ b/detector/aws_security_group_duplicate_name_test.go
@@ -15,12 +15,12 @@ import (
 
 func TestDetectAwsSecurityGroupDuplicateName(t *testing.T) {
 	cases := []struct {
-		Name           string
-		Src            string
-		State          string
-		SecurityGroups []*ec2.SecurityGroup
-		Vpcs           []*ec2.Vpc
-		Issues         []*issue.Issue
+		Name              string
+		Src               string
+		State             string
+		SecurityGroups    []*ec2.SecurityGroup
+		AccountAttributes []*ec2.AccountAttribute
+		Issues            []*issue.Issue
 	}{
 		{
 			Name: "security group name is duplicate",
@@ -30,23 +30,35 @@ resource "aws_security_group" "test" {
     vpc_id = "vpc-1234abcd"
 }`,
 			SecurityGroups: []*ec2.SecurityGroup{
-				&ec2.SecurityGroup{
+				{
 					GroupName: aws.String("default"),
 					VpcId:     aws.String("vpc-1234abcd"),
 				},
-				&ec2.SecurityGroup{
+				{
 					GroupName: aws.String("custom"),
 					VpcId:     aws.String("vpc-1234abcd"),
 				},
 			},
-			Vpcs: []*ec2.Vpc{
-				&ec2.Vpc{
-					VpcId:     aws.String("vpc-1234abcd"),
-					IsDefault: aws.Bool(true),
+			AccountAttributes: []*ec2.AccountAttribute{
+				{
+					AttributeName: aws.String("supported-platforms"),
+					AttributeValues: []*ec2.AccountAttributeValue{
+						{
+							AttributeValue: aws.String("VPC"),
+						},
+					},
+				},
+				{
+					AttributeName: aws.String("default-vpc"),
+					AttributeValues: []*ec2.AccountAttributeValue{
+						{
+							AttributeValue: aws.String("vpc-1234abcd"),
+						},
+					},
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"default\" is duplicate name. It must be unique.",
 					Line:    3,
@@ -62,19 +74,31 @@ resource "aws_security_group" "test" {
     vpc_id = "vpc-1234abcd"
 }`,
 			SecurityGroups: []*ec2.SecurityGroup{
-				&ec2.SecurityGroup{
+				{
 					GroupName: aws.String("default"),
 					VpcId:     aws.String("vpc-1234abcd"),
 				},
-				&ec2.SecurityGroup{
+				{
 					GroupName: aws.String("custom"),
 					VpcId:     aws.String("vpc-1234abcd"),
 				},
 			},
-			Vpcs: []*ec2.Vpc{
-				&ec2.Vpc{
-					VpcId:     aws.String("vpc-1234abcd"),
-					IsDefault: aws.Bool(true),
+			AccountAttributes: []*ec2.AccountAttribute{
+				{
+					AttributeName: aws.String("supported-platforms"),
+					AttributeValues: []*ec2.AccountAttributeValue{
+						{
+							AttributeValue: aws.String("VPC"),
+						},
+					},
+				},
+				{
+					AttributeName: aws.String("default-vpc"),
+					AttributeValues: []*ec2.AccountAttributeValue{
+						{
+							AttributeValue: aws.String("vpc-1234abcd"),
+						},
+					},
 				},
 			},
 			Issues: []*issue.Issue{},
@@ -87,19 +111,31 @@ resource "aws_security_group" "test" {
     vpc_id = "vpc-1234abcd"
 }`,
 			SecurityGroups: []*ec2.SecurityGroup{
-				&ec2.SecurityGroup{
+				{
 					GroupName: aws.String("default"),
 					VpcId:     aws.String("vpc-abcd1234"),
 				},
-				&ec2.SecurityGroup{
+				{
 					GroupName: aws.String("custom"),
 					VpcId:     aws.String("vpc-abcd1234"),
 				},
 			},
-			Vpcs: []*ec2.Vpc{
-				&ec2.Vpc{
-					VpcId:     aws.String("vpc-1234abcd"),
-					IsDefault: aws.Bool(true),
+			AccountAttributes: []*ec2.AccountAttribute{
+				{
+					AttributeName: aws.String("supported-platforms"),
+					AttributeValues: []*ec2.AccountAttributeValue{
+						{
+							AttributeValue: aws.String("VPC"),
+						},
+					},
+				},
+				{
+					AttributeName: aws.String("default-vpc"),
+					AttributeValues: []*ec2.AccountAttributeValue{
+						{
+							AttributeValue: aws.String("vpc-1234abcd"),
+						},
+					},
 				},
 			},
 			Issues: []*issue.Issue{},
@@ -111,23 +147,31 @@ resource "aws_security_group" "test" {
     name   = "default"
 }`,
 			SecurityGroups: []*ec2.SecurityGroup{
-				&ec2.SecurityGroup{
+				{
 					GroupName: aws.String("default"),
 					VpcId:     aws.String("vpc-1234abcd"),
 				},
-				&ec2.SecurityGroup{
+				{
 					GroupName: aws.String("custom"),
 					VpcId:     aws.String("vpc-1234abcd"),
 				},
 			},
-			Vpcs: []*ec2.Vpc{
-				&ec2.Vpc{
-					VpcId:     aws.String("vpc-1234abcd"),
-					IsDefault: aws.Bool(false),
+			AccountAttributes: []*ec2.AccountAttribute{
+				{
+					AttributeName: aws.String("supported-platforms"),
+					AttributeValues: []*ec2.AccountAttributeValue{
+						{
+							AttributeValue: aws.String("VPC"),
+						},
+					},
 				},
-				&ec2.Vpc{
-					VpcId:     aws.String("vpc-abcd1234"),
-					IsDefault: aws.Bool(true),
+				{
+					AttributeName: aws.String("default-vpc"),
+					AttributeValues: []*ec2.AccountAttributeValue{
+						{
+							AttributeValue: aws.String("vpc-abcd1234"),
+						},
+					},
 				},
 			},
 			Issues: []*issue.Issue{},
@@ -139,27 +183,35 @@ resource "aws_security_group" "test" {
     name   = "default"
 }`,
 			SecurityGroups: []*ec2.SecurityGroup{
-				&ec2.SecurityGroup{
+				{
 					GroupName: aws.String("default"),
 					VpcId:     aws.String("vpc-1234abcd"),
 				},
-				&ec2.SecurityGroup{
+				{
 					GroupName: aws.String("custom"),
 					VpcId:     aws.String("vpc-1234abcd"),
 				},
 			},
-			Vpcs: []*ec2.Vpc{
-				&ec2.Vpc{
-					VpcId:     aws.String("vpc-1234abcd"),
-					IsDefault: aws.Bool(true),
+			AccountAttributes: []*ec2.AccountAttribute{
+				{
+					AttributeName: aws.String("supported-platforms"),
+					AttributeValues: []*ec2.AccountAttributeValue{
+						{
+							AttributeValue: aws.String("VPC"),
+						},
+					},
 				},
-				&ec2.Vpc{
-					VpcId:     aws.String("vpc-abcd1234"),
-					IsDefault: aws.Bool(false),
+				{
+					AttributeName: aws.String("default-vpc"),
+					AttributeValues: []*ec2.AccountAttributeValue{
+						{
+							AttributeValue: aws.String("vpc-1234abcd"),
+						},
+					},
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"default\" is duplicate name. It must be unique.",
 					Line:    3,
@@ -198,19 +250,31 @@ resource "aws_security_group" "test" {
 }
 `,
 			SecurityGroups: []*ec2.SecurityGroup{
-				&ec2.SecurityGroup{
+				{
 					GroupName: aws.String("default"),
 					VpcId:     aws.String("vpc-1234abcd"),
 				},
-				&ec2.SecurityGroup{
+				{
 					GroupName: aws.String("custom"),
 					VpcId:     aws.String("vpc-1234abcd"),
 				},
 			},
-			Vpcs: []*ec2.Vpc{
-				&ec2.Vpc{
-					VpcId:     aws.String("vpc-1234abcd"),
-					IsDefault: aws.Bool(true),
+			AccountAttributes: []*ec2.AccountAttribute{
+				{
+					AttributeName: aws.String("supported-platforms"),
+					AttributeValues: []*ec2.AccountAttributeValue{
+						{
+							AttributeValue: aws.String("VPC"),
+						},
+					},
+				},
+				{
+					AttributeName: aws.String("default-vpc"),
+					AttributeValues: []*ec2.AccountAttributeValue{
+						{
+							AttributeValue: aws.String("vpc-1234abcd"),
+						},
+					},
 				},
 			},
 			Issues: []*issue.Issue{},
@@ -228,8 +292,8 @@ resource "aws_security_group" "test" {
 		ec2mock.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{}).Return(&ec2.DescribeSecurityGroupsOutput{
 			SecurityGroups: tc.SecurityGroups,
 		}, nil)
-		ec2mock.EXPECT().DescribeVpcs(&ec2.DescribeVpcsInput{}).Return(&ec2.DescribeVpcsOutput{
-			Vpcs: tc.Vpcs,
+		ec2mock.EXPECT().DescribeAccountAttributes(&ec2.DescribeAccountAttributesInput{}).Return(&ec2.DescribeAccountAttributesOutput{
+			AccountAttributes: tc.AccountAttributes,
 		}, nil)
 		awsClient.Ec2 = ec2mock
 

--- a/detector/aws_security_group_duplicate_name_test.go
+++ b/detector/aws_security_group_duplicate_name_test.go
@@ -279,6 +279,50 @@ resource "aws_security_group" "test" {
 			},
 			Issues: []*issue.Issue{},
 		},
+		{
+			Name: "security group name is duplicate when omitted vpc_id on EC2-Classic",
+			Src: `
+resource "aws_security_group" "test" {
+    name   = "default"
+}`,
+			SecurityGroups: []*ec2.SecurityGroup{
+				{
+					GroupName: aws.String("default"),
+				},
+				{
+					GroupName: aws.String("custom"),
+				},
+			},
+			AccountAttributes: []*ec2.AccountAttribute{
+				{
+					AttributeName: aws.String("supported-platforms"),
+					AttributeValues: []*ec2.AccountAttributeValue{
+						{
+							AttributeValue: aws.String("EC2"),
+						},
+						{
+							AttributeValue: aws.String("VPC"),
+						},
+					},
+				},
+				{
+					AttributeName: aws.String("default-vpc"),
+					AttributeValues: []*ec2.AccountAttributeValue{
+						{
+							AttributeValue: aws.String("none"),
+						},
+					},
+				},
+			},
+			Issues: []*issue.Issue{
+				{
+					Type:    "ERROR",
+					Message: "\"default\" is duplicate name. It must be unique.",
+					Line:    3,
+					File:    "test.tf",
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fix #88 

When security groups are on EC2-Classic, VPC ID is nil.
ref: https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#SecurityGroup

So, use DescribeAccountAttirbutes API instead of DescribeVpcs API to detect the default VPC. This response is `none` when support EC2-Classic platform.