### PR TITLE
Add AwsRouteInvalidRouteTableDetector

### DIFF
--- a/config/aws.go
+++ b/config/aws.go
@@ -86,6 +86,7 @@ type ResponseCache struct {
 	DescribeVpcsOutput                 *ec2.DescribeVpcsOutput
 	DescribeInstancesOutput            *ec2.DescribeInstancesOutput
 	DescribeAccountAttributesOutput    *ec2.DescribeAccountAttributesOutput
+	DescribeRouteTablesOutput          *ec2.DescribeRouteTablesOutput
 	ListInstanceProfilesOutput         *iam.ListInstanceProfilesOutput
 	DescribeDBSubnetGroupsOutput       *rds.DescribeDBSubnetGroupsOutput
 	DescribeDBParameterGroupsOutput    *rds.DescribeDBParameterGroupsOutput
@@ -173,6 +174,17 @@ func (c AwsClient) DescribeAccountAttributes() (*ec2.DescribeAccountAttributesOu
 		c.Cache.DescribeAccountAttributesOutput = resp
 	}
 	return c.Cache.DescribeAccountAttributesOutput, nil
+}
+
+func (c AwsClient) DescribeRouteTables() (*ec2.DescribeRouteTablesOutput, error) {
+	if c.Cache.DescribeRouteTablesOutput == nil {
+		resp, err := c.Ec2.DescribeRouteTables(&ec2.DescribeRouteTablesInput{})
+		if err != nil {
+			return nil, err
+		}
+		c.Cache.DescribeRouteTablesOutput = resp
+	}
+	return c.Cache.DescribeRouteTablesOutput, nil
 }
 
 func (c *AwsClient) ListInstanceProfiles() (*iam.ListInstanceProfilesOutput, error) {

--- a/detector/aws_route_invalid_route_table.go
+++ b/detector/aws_route_invalid_route_table.go
@@ -1,0 +1,62 @@
+package detector
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/wata727/tflint/issue"
+)
+
+type AwsRouteInvalidRouteTableDetector struct {
+	*Detector
+	IssueType   string
+	Target      string
+	DeepCheck   bool
+	routeTables map[string]bool
+}
+
+func (d *Detector) CreateAwsRouteInvalidRouteTableDetector() *AwsRouteInvalidRouteTableDetector {
+	return &AwsRouteInvalidRouteTableDetector{
+		Detector:    d,
+		IssueType:   issue.ERROR,
+		Target:      "aws_route",
+		DeepCheck:   true,
+		routeTables: map[string]bool{},
+	}
+}
+
+func (d *AwsRouteInvalidRouteTableDetector) PreProcess() {
+	resp, err := d.AwsClient.DescribeRouteTables()
+	if err != nil {
+		d.Logger.Error(err)
+		d.Error = true
+		return
+	}
+
+	for _, routeTable := range resp.RouteTables {
+		d.routeTables[*routeTable.RouteTableId] = true
+	}
+}
+
+func (d *AwsRouteInvalidRouteTableDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	routeTableToken, err := hclLiteralToken(item, "route_table_id")
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
+	routeTable, err := d.evalToString(routeTableToken.Text)
+	if err != nil {
+		d.Logger.Error(err)
+		return
+	}
+
+	if !d.routeTables[routeTable] {
+		issue := &issue.Issue{
+			Type:    d.IssueType,
+			Message: fmt.Sprintf("\"%s\" is invalid route table ID.", routeTable),
+			Line:    routeTableToken.Pos.Line,
+			File:    file,
+		}
+		*issues = append(*issues, issue)
+	}
+}

--- a/detector/aws_route_invalid_route_table_test.go
+++ b/detector/aws_route_invalid_route_table_test.go
@@ -1,0 +1,94 @@
+package detector
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/k0kubun/pp"
+	"github.com/wata727/tflint/config"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+)
+
+func TestDetectAwsRouteInvalidRouteTable(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Src      string
+		Response []*ec2.RouteTable
+		Issues   []*issue.Issue
+	}{
+		{
+			Name: "route table id is invalid",
+			Src: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-nat-gw-a"
+}`,
+			Response: []*ec2.RouteTable{
+				{
+					RouteTableId: aws.String("rtb-1234abcd"),
+				},
+				{
+					RouteTableId: aws.String("rtb-abcd1234"),
+				},
+			},
+			Issues: []*issue.Issue{
+				{
+					Type:    "ERROR",
+					Message: "\"rtb-nat-gw-a\" is invalid route table ID.",
+					Line:    3,
+					File:    "test.tf",
+				},
+			},
+		},
+		{
+			Name: "route table id is valid",
+			Src: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+}`,
+			Response: []*ec2.RouteTable{
+				{
+					RouteTableId: aws.String("rtb-1234abcd"),
+				},
+				{
+					RouteTableId: aws.String("rtb-abcd1234"),
+				},
+			},
+			Issues: []*issue.Issue{},
+		},
+	}
+
+	for _, tc := range cases {
+		c := config.Init()
+		c.DeepCheck = true
+
+		awsClient := c.NewAwsClient()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		ec2mock := mock.NewMockEC2API(ctrl)
+		ec2mock.EXPECT().DescribeRouteTables(&ec2.DescribeRouteTablesInput{}).Return(&ec2.DescribeRouteTablesOutput{
+			RouteTables: tc.Response,
+		}, nil)
+		awsClient.Ec2 = ec2mock
+
+		var issues = []*issue.Issue{}
+		err := TestDetectByCreatorName(
+			"CreateAwsRouteInvalidRouteTableDetector",
+			tc.Src,
+			"",
+			c,
+			awsClient,
+			&issues,
+		)
+		if err != nil {
+			t.Fatalf("\nERROR: %s", err)
+		}
+
+		if !reflect.DeepEqual(issues, tc.Issues) {
+			t.Fatalf("\nBad: %s\nExpected: %s\n\ntestcase: %s", pp.Sprint(issues), pp.Sprint(tc.Issues), tc.Name)
+		}
+	}
+}

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -63,6 +63,7 @@ var detectors = map[string]string{
 	"aws_elasticache_cluster_previous_type":           "CreateAwsElastiCacheClusterPreviousTypeDetector",
 	"aws_elasticache_cluster_duplicate_id":            "CreateAwsElastiCacheClusterDuplicateIDDetector",
 	"aws_security_group_duplicate_name":               "CreateAwsSecurityGroupDuplicateDetector",
+	"aws_route_invalid_route_table":                   "CreateAwsRouteInvalidRouteTableDetector",
 }
 
 func NewDetector(templates map[string]*ast.File, state *state.TFState, tfvars []*ast.File, c *config.Config) (*Detector, error) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,8 @@ Report these issues if you have specified invalid resource ID, name, etc. All is
     - aws_elasticache_cluster_invalid_parameter_group
     - aws_elasticache_cluster_invalid_subnet_group
     - aws_elasticache_cluster_invalid_security_group
+- **AWS Route**
+    - aws_route_invalid_route_table
 
 ### Duplicate Resource Issue
 Report these issues if you have specified resource ID, name, etc that already existed and must be unique. All issues are reported as ERROR. These issues are reported when enabled deep check. For example, it happens when resources with the same name is already created. Please check the actual resources again.


### PR DESCRIPTION
Fix #87 

This detector detects invalid route table ID references. For example:

```
resource "aws_route" "foo" {
    route_table_id = "rtb-nat-gw-a" # invalid route table ID
}
```

Terraform result: 
```
Error applying plan:

1 error(s) occurred:

* aws_route.r: 1 error(s) occurred:

* aws_route.r: Error creating route: InvalidRouteTableId.Malformed: Invalid id: "rtb-nat-gw-a"
        status code: 400, request id: hogehoge

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```

TFLint result:
```
template.tf
        ERROR:2 "rtb-nat-gw-a" is invalid route table ID.

Result: 1 issues  (1 errors , 0 warnings , 0 notices)
```