### PR TITLE
Add AwsRouteInvalidVpcPeeringConnectionDetector

### DIFF
--- a/config/aws.go
+++ b/config/aws.go
@@ -90,6 +90,7 @@ type ResponseCache struct {
 	DescribeInternetGatewaysOutput           *ec2.DescribeInternetGatewaysOutput
 	DescribeEgressOnlyInternetGatewaysOutput *ec2.DescribeEgressOnlyInternetGatewaysOutput
 	DescribeNatGatewaysOutput                *ec2.DescribeNatGatewaysOutput
+	DescribeVpcPeeringConnectionsOutput      *ec2.DescribeVpcPeeringConnectionsOutput
 	ListInstanceProfilesOutput               *iam.ListInstanceProfilesOutput
 	DescribeDBSubnetGroupsOutput             *rds.DescribeDBSubnetGroupsOutput
 	DescribeDBParameterGroupsOutput          *rds.DescribeDBParameterGroupsOutput
@@ -221,6 +222,17 @@ func (c AwsClient) DescribeNatGateways() (*ec2.DescribeNatGatewaysOutput, error)
 		c.Cache.DescribeNatGatewaysOutput = resp
 	}
 	return c.Cache.DescribeNatGatewaysOutput, nil
+}
+
+func (c AwsClient) DescribeVpcPeeringConnections() (*ec2.DescribeVpcPeeringConnectionsOutput, error) {
+	if c.Cache.DescribeVpcPeeringConnectionsOutput == nil {
+		resp, err := c.Ec2.DescribeVpcPeeringConnections(&ec2.DescribeVpcPeeringConnectionsInput{})
+		if err != nil {
+			return nil, err
+		}
+		c.Cache.DescribeVpcPeeringConnectionsOutput = resp
+	}
+	return c.Cache.DescribeVpcPeeringConnectionsOutput, nil
 }
 
 func (c *AwsClient) ListInstanceProfiles() (*iam.ListInstanceProfilesOutput, error) {

--- a/detector/aws_route_invalid_vpc_peering_connection.go
+++ b/detector/aws_route_invalid_vpc_peering_connection.go
@@ -1,0 +1,64 @@
+package detector
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/wata727/tflint/issue"
+)
+
+type AwsRouteInvalidVpcPeeringConnectionDetector struct {
+	*Detector
+	IssueType             string
+	Target                string
+	DeepCheck             bool
+	vpcPeeringConnections map[string]bool
+}
+
+func (d *Detector) CreateAwsRouteInvalidVpcPeeringConnectionDetector() *AwsRouteInvalidVpcPeeringConnectionDetector {
+	return &AwsRouteInvalidVpcPeeringConnectionDetector{
+		Detector:              d,
+		IssueType:             issue.ERROR,
+		Target:                "aws_route",
+		DeepCheck:             true,
+		vpcPeeringConnections: map[string]bool{},
+	}
+}
+
+func (d *AwsRouteInvalidVpcPeeringConnectionDetector) PreProcess() {
+	resp, err := d.AwsClient.DescribeVpcPeeringConnections()
+	if err != nil {
+		d.Logger.Error(err)
+		d.Error = true
+		return
+	}
+
+	for _, vpcPeeringConnection := range resp.VpcPeeringConnections {
+		d.vpcPeeringConnections[*vpcPeeringConnection.VpcPeeringConnectionId] = true
+	}
+}
+
+func (d *AwsRouteInvalidVpcPeeringConnectionDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+	vpcPeeringConnectionToken, err := hclLiteralToken(item, "vpc_peering_connection_id")
+	if err != nil {
+		d.Logger.Error(err)
+		d.Error = true
+		return
+	}
+	vpcPeeringConnection, err := d.evalToString(vpcPeeringConnectionToken.Text)
+	if err != nil {
+		d.Logger.Error(err)
+		d.Error = true
+		return
+	}
+
+	if !d.vpcPeeringConnections[vpcPeeringConnection] {
+		issue := &issue.Issue{
+			Type:    d.IssueType,
+			Message: fmt.Sprintf("\"%s\" is invalid VPC peering connection ID.", vpcPeeringConnection),
+			Line:    vpcPeeringConnectionToken.Pos.Line,
+			File:    file,
+		}
+		*issues = append(*issues, issue)
+	}
+}

--- a/detector/aws_route_invalid_vpc_peering_connection_test.go
+++ b/detector/aws_route_invalid_vpc_peering_connection_test.go
@@ -1,0 +1,94 @@
+package detector
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/k0kubun/pp"
+	"github.com/wata727/tflint/config"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+)
+
+func TestDetectAwsRouteInvalidVpcPeeringConnection(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Src      string
+		Response []*ec2.VpcPeeringConnection
+		Issues   []*issue.Issue
+	}{
+		{
+			Name: "VPC peering connection id is invalid",
+			Src: `
+resource "aws_route" "foo" {
+    vpc_peering_connection_id = "pcx-1234abcd"
+}`,
+			Response: []*ec2.VpcPeeringConnection{
+				{
+					VpcPeeringConnectionId: aws.String("pcx-5678abcd"),
+				},
+				{
+					VpcPeeringConnectionId: aws.String("pcx-abcd1234"),
+				},
+			},
+			Issues: []*issue.Issue{
+				{
+					Type:    "ERROR",
+					Message: "\"pcx-1234abcd\" is invalid VPC peering connection ID.",
+					Line:    3,
+					File:    "test.tf",
+				},
+			},
+		},
+		{
+			Name: "VPC peering connection id is valid",
+			Src: `
+resource "aws_route" "foo" {
+    vpc_peering_connection_id = "pcx-1234abcd"
+}`,
+			Response: []*ec2.VpcPeeringConnection{
+				{
+					VpcPeeringConnectionId: aws.String("pcx-1234abcd"),
+				},
+				{
+					VpcPeeringConnectionId: aws.String("pcx-abcd1234"),
+				},
+			},
+			Issues: []*issue.Issue{},
+		},
+	}
+
+	for _, tc := range cases {
+		c := config.Init()
+		c.DeepCheck = true
+
+		awsClient := c.NewAwsClient()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		ec2mock := mock.NewMockEC2API(ctrl)
+		ec2mock.EXPECT().DescribeVpcPeeringConnections(&ec2.DescribeVpcPeeringConnectionsInput{}).Return(&ec2.DescribeVpcPeeringConnectionsOutput{
+			VpcPeeringConnections: tc.Response,
+		}, nil)
+		awsClient.Ec2 = ec2mock
+
+		var issues = []*issue.Issue{}
+		err := TestDetectByCreatorName(
+			"CreateAwsRouteInvalidVpcPeeringConnectionDetector",
+			tc.Src,
+			"",
+			c,
+			awsClient,
+			&issues,
+		)
+		if err != nil {
+			t.Fatalf("\nERROR: %s", err)
+		}
+
+		if !reflect.DeepEqual(issues, tc.Issues) {
+			t.Fatalf("\nBad: %s\nExpected: %s\n\ntestcase: %s", pp.Sprint(issues), pp.Sprint(tc.Issues), tc.Name)
+		}
+	}
+}

--- a/detector/detector.go
+++ b/detector/detector.go
@@ -69,6 +69,7 @@ var detectors = map[string]string{
 	"aws_route_invalid_gateway":                       "CreateAwsRouteInvalidGatewayDetector",
 	"aws_route_invalid_egress_only_gateway":           "CreateAwsRouteInvalidEgressOnlyGatewayDetector",
 	"aws_route_invalid_nat_gateway":                   "CreateAwsRouteInvalidNatGatewayDetector",
+	"aws_route_invalid_vpc_peering_connection":        "CreateAwsRouteInvalidVpcPeeringConnectionDetector",
 }
 
 func NewDetector(templates map[string]*ast.File, state *state.TFState, tfvars []*ast.File, c *config.Config) (*Detector, error) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,7 @@ Report these issues if you have specified invalid resource ID, name, etc. All is
     - aws_route_invalid_gateway
     - aws_route_invalid_egress_only_gateway
     - aws_route_invalid_nat_gateway
+    - aws_route_invalid_vpc_peering_connection
 
 ### Duplicate Resource Issue
 Report these issues if you have specified resource ID, name, etc that already existed and must be unique. All issues are reported as ERROR. These issues are reported when enabled deep check. For example, it happens when resources with the same name is already created. Please check the actual resources again.


### PR DESCRIPTION
This detector detects invalid VPC peering connection references.
Please read documents for details.