### PR TITLE
Interpolate module attributes

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -21,10 +21,6 @@ func NewEvaluator(templates map[string]*hclast.File, varfile []*hclast.File, c *
 	if err != nil {
 		return nil, err
 	}
-	moduleMap, err := detectModules(templates, c)
-	if err != nil {
-		return nil, err
-	}
 
 	evaluator := &Evaluator{
 		Config: hil.EvalConfig{
@@ -32,8 +28,13 @@ func NewEvaluator(templates map[string]*hclast.File, varfile []*hclast.File, c *
 				VarMap: varMap,
 			},
 		},
-		ModuleConfig: moduleMap,
 	}
+
+	moduleMap, err := evaluator.detectModules(templates, c)
+	if err != nil {
+		return nil, err
+	}
+	evaluator.ModuleConfig = moduleMap
 
 	return evaluator, nil
 }

--- a/evaluator/variable.go
+++ b/evaluator/variable.go
@@ -124,9 +124,13 @@ func parseVariable(val interface{}, varType string) hilast.Variable {
 		// Correct:
 		//
 		// []map[string]string{
-		//     map[string]string{
-		//         "name":  "test",
-		//         "value": "hcl",
+		//     {
+		//         "key": []map[string]string{
+		//             {
+		//                 "name":  "test",
+		//                 "value": "hcl",
+		//             },
+		//         },
 		//     },
 		// }
 		//


### PR DESCRIPTION
Fix #104 

Until now, value of modules directly converts to Go variables after decode, So HIL variables was not supported in module attributes.
This PR changes the behavior to interpolate HIL variables.