### PR TITLE
Provide abstract HCL access

### DIFF
--- a/detector/aws_alb_duplicate_name.go
+++ b/detector/aws_alb_duplicate_name.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsALBDuplicateNameDetector struct {
@@ -38,10 +38,9 @@ func (d *AwsALBDuplicateNameDetector) PreProcess() {
 	}
 }
 
-func (d *AwsALBDuplicateNameDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	nameToken, err := hclLiteralToken(item, "name")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsALBDuplicateNameDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	nameToken, ok := resource.GetToken("name")
+	if !ok {
 		return
 	}
 	name, err := d.evalToString(nameToken.Text)
@@ -50,12 +49,12 @@ func (d *AwsALBDuplicateNameDetector) Detect(file string, item *ast.ObjectItem, 
 		return
 	}
 
-	if d.loadBalancers[name] && !d.State.Exists(d.Target, hclObjectKeyText(item)) {
+	if d.loadBalancers[name] && !d.State.Exists(d.Target, resource.Id) {
 		issue := &issue.Issue{
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is duplicate name. It must be unique.", name),
 			Line:    nameToken.Pos.Line,
-			File:    file,
+			File:    nameToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_alb_duplicate_name_test.go
+++ b/detector/aws_alb_duplicate_name_test.go
@@ -28,15 +28,15 @@ resource "aws_alb" "test" {
     name = "test-alb-tf"
 }`,
 			Response: []*elbv2.LoadBalancer{
-				&elbv2.LoadBalancer{
+				{
 					LoadBalancerName: aws.String("test-alb-tf"),
 				},
-				&elbv2.LoadBalancer{
+				{
 					LoadBalancerName: aws.String("production-alb-tf"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"test-alb-tf\" is duplicate name. It must be unique.",
 					Line:    3,
@@ -51,10 +51,10 @@ resource "aws_alb" "test" {
     name = "test-alb-tf"
 }`,
 			Response: []*elbv2.LoadBalancer{
-				&elbv2.LoadBalancer{
+				{
 					LoadBalancerName: aws.String("staging-alb-tf"),
 				},
-				&elbv2.LoadBalancer{
+				{
 					LoadBalancerName: aws.String("production-alb-tf"),
 				},
 			},
@@ -113,10 +113,10 @@ resource "aws_alb" "test" {
 }
 `,
 			Response: []*elbv2.LoadBalancer{
-				&elbv2.LoadBalancer{
+				{
 					LoadBalancerName: aws.String("test-alb-tf"),
 				},
-				&elbv2.LoadBalancer{
+				{
 					LoadBalancerName: aws.String("production-alb-tf"),
 				},
 			},

--- a/detector/aws_alb_invaid_security_group.go
+++ b/detector/aws_alb_invaid_security_group.go
@@ -3,9 +3,9 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsALBInvalidSecurityGroupDetector struct {
@@ -39,21 +39,20 @@ func (d *AwsALBInvalidSecurityGroupDetector) PreProcess() {
 	}
 }
 
-func (d *AwsALBInvalidSecurityGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+func (d *AwsALBInvalidSecurityGroupDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
 	var varToken token.Token
 	var securityGroupTokens []token.Token
-	var err error
-	if varToken, err = hclLiteralToken(item, "security_groups"); err == nil {
+	var ok bool
+	if varToken, ok = resource.GetToken("security_groups"); ok {
+		var err error
 		securityGroupTokens, err = d.evalToStringTokens(varToken)
 		if err != nil {
 			d.Logger.Error(err)
 			return
 		}
 	} else {
-		d.Logger.Error(err)
-		securityGroupTokens, err = hclLiteralListToken(item, "security_groups")
-		if err != nil {
-			d.Logger.Error(err)
+		securityGroupTokens, ok = resource.GetListToken("security_groups")
+		if !ok {
 			return
 		}
 	}
@@ -65,12 +64,16 @@ func (d *AwsALBInvalidSecurityGroupDetector) Detect(file string, item *ast.Objec
 			continue
 		}
 
+		// If `security_groups` is interpolated by list variable, Filename is empty.
+		if securityGroupToken.Pos.Filename == "" {
+			securityGroupToken.Pos.Filename = varToken.Pos.Filename
+		}
 		if !d.securityGroups[securityGroup] {
 			issue := &issue.Issue{
 				Type:    d.IssueType,
 				Message: fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
 				Line:    securityGroupToken.Pos.Line,
-				File:    file,
+				File:    securityGroupToken.Pos.Filename,
 			}
 			*issues = append(*issues, issue)
 		}

--- a/detector/aws_alb_invalid_security_group_test.go
+++ b/detector/aws_alb_invalid_security_group_test.go
@@ -30,21 +30,21 @@ resource "aws_alb" "balancer" {
     ]
 }`,
 			Response: []*ec2.SecurityGroup{
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-12345678"),
 				},
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-abcdefgh"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"sg-1234abcd\" is invalid security group.",
 					Line:    4,
 					File:    "test.tf",
 				},
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"sg-abcd1234\" is invalid security group.",
 					Line:    5,
@@ -62,14 +62,47 @@ resource "aws_alb" "balancer" {
     ]
 }`,
 			Response: []*ec2.SecurityGroup{
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-1234abcd"),
 				},
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-abcd1234"),
 				},
 			},
 			Issues: []*issue.Issue{},
+		},
+		{
+			Name: "use list variables",
+			Src: `
+variable "security_groups" {
+    default = ["sg-1234abcd", "sg-abcd1234"]
+}
+
+resource "aws_alb" "balancer" {
+    security_groups = "${var.security_groups}"
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-12345678"),
+				},
+				{
+					GroupId: aws.String("sg-abcdefgh"),
+				},
+			},
+			Issues: []*issue.Issue{
+				{
+					Type:    "ERROR",
+					Message: "\"sg-1234abcd\" is invalid security group.",
+					Line:    7,
+					File:    "test.tf",
+				},
+				{
+					Type:    "ERROR",
+					Message: "\"sg-abcd1234\" is invalid security group.",
+					Line:    7,
+					File:    "test.tf",
+				},
+			},
 		},
 	}
 

--- a/detector/aws_alb_invalid_subnet.go
+++ b/detector/aws_alb_invalid_subnet.go
@@ -3,9 +3,9 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsALBInvalidSubnetDetector struct {
@@ -39,21 +39,20 @@ func (d *AwsALBInvalidSubnetDetector) PreProcess() {
 	}
 }
 
-func (d *AwsALBInvalidSubnetDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+func (d *AwsALBInvalidSubnetDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
 	var varToken token.Token
 	var subnetTokens []token.Token
-	var err error
-	if varToken, err = hclLiteralToken(item, "subnets"); err == nil {
+	var ok bool
+	if varToken, ok = resource.GetToken("subnets"); ok {
+		var err error
 		subnetTokens, err = d.evalToStringTokens(varToken)
 		if err != nil {
 			d.Logger.Error(err)
 			return
 		}
 	} else {
-		d.Logger.Error(err)
-		subnetTokens, err = hclLiteralListToken(item, "subnets")
-		if err != nil {
-			d.Logger.Error(err)
+		subnetTokens, ok = resource.GetListToken("subnets")
+		if !ok {
 			return
 		}
 	}
@@ -65,12 +64,16 @@ func (d *AwsALBInvalidSubnetDetector) Detect(file string, item *ast.ObjectItem, 
 			continue
 		}
 
+		// If `subnets` is interpolated by list variable, Filename is empty.
+		if subnetToken.Pos.Filename == "" {
+			subnetToken.Pos.Filename = varToken.Pos.Filename
+		}
 		if !d.subnets[subnet] {
 			issue := &issue.Issue{
 				Type:    d.IssueType,
 				Message: fmt.Sprintf("\"%s\" is invalid subnet ID.", subnet),
 				Line:    subnetToken.Pos.Line,
-				File:    file,
+				File:    subnetToken.Pos.Filename,
 			}
 			*issues = append(*issues, issue)
 		}

--- a/detector/aws_alb_invalid_subnet_test.go
+++ b/detector/aws_alb_invalid_subnet_test.go
@@ -30,21 +30,21 @@ resource "aws_alb" "balancer" {
     ]
 }`,
 			Response: []*ec2.Subnet{
-				&ec2.Subnet{
+				{
 					SubnetId: aws.String("subnet-12345678"),
 				},
-				&ec2.Subnet{
+				{
 					SubnetId: aws.String("subnet-abcdefgh"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"subnet-1234abcd\" is invalid subnet ID.",
 					Line:    4,
 					File:    "test.tf",
 				},
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"subnet-abcd1234\" is invalid subnet ID.",
 					Line:    5,
@@ -62,10 +62,30 @@ resource "aws_alb" "balancer" {
     ]
 }`,
 			Response: []*ec2.Subnet{
-				&ec2.Subnet{
+				{
 					SubnetId: aws.String("subnet-1234abcd"),
 				},
-				&ec2.Subnet{
+				{
+					SubnetId: aws.String("subnet-abcd1234"),
+				},
+			},
+			Issues: []*issue.Issue{},
+		},
+		{
+			Name: "use list variables",
+			Src: `
+varaible "subnets" {
+    default = ["subnet-1234abcd", "subnet-abcd1234"]
+}
+
+resource "aws_alb" "balancer" {
+    subnets = "${var.subnets}"
+}`,
+			Response: []*ec2.Subnet{
+				{
+					SubnetId: aws.String("subnet-1234abcd"),
+				},
+				{
 					SubnetId: aws.String("subnet-abcd1234"),
 				},
 			},

--- a/detector/aws_cloudwatch_metric_alarm_invalid_unit.go
+++ b/detector/aws_cloudwatch_metric_alarm_invalid_unit.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsCloudWatchMetricAlarmInvalidUnitDetector struct {
@@ -58,10 +58,9 @@ func (d *AwsCloudWatchMetricAlarmInvalidUnitDetector) PreProcess() {
 	}
 }
 
-func (d *AwsCloudWatchMetricAlarmInvalidUnitDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	unitToken, err := hclLiteralToken(item, "unit")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsCloudWatchMetricAlarmInvalidUnitDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	unitToken, ok := resource.GetToken("unit")
+	if !ok {
 		return
 	}
 	unit, err := d.evalToString(unitToken.Text)
@@ -75,7 +74,7 @@ func (d *AwsCloudWatchMetricAlarmInvalidUnitDetector) Detect(file string, item *
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid unit.", unit),
 			Line:    unitToken.Pos.Line,
-			File:    file,
+			File:    unitToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_db_instance_default_parameter_group.go
+++ b/detector/aws_db_instance_default_parameter_group.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsDBInstanceDefaultParameterGroupDetector struct {
@@ -24,10 +24,9 @@ func (d *Detector) CreateAwsDBInstanceDefaultParameterGroupDetector() *AwsDBInst
 	}
 }
 
-func (d *AwsDBInstanceDefaultParameterGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	parameterGroupToken, err := hclLiteralToken(item, "parameter_group_name")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsDBInstanceDefaultParameterGroupDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	parameterGroupToken, ok := resource.GetToken("parameter_group_name")
+	if !ok {
 		return
 	}
 	parameterGroup, err := d.evalToString(parameterGroupToken.Text)
@@ -41,7 +40,7 @@ func (d *AwsDBInstanceDefaultParameterGroupDetector) Detect(file string, item *a
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is default parameter group. You cannot edit it.", parameterGroup),
 			Line:    parameterGroupToken.Pos.Line,
-			File:    file,
+			File:    parameterGroupToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_db_instance_default_parameter_group_test.go
+++ b/detector/aws_db_instance_default_parameter_group_test.go
@@ -22,7 +22,7 @@ resource "aws_db_instance" "db" {
     parameter_group_name = "default.mysql5.6"
 }`,
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "NOTICE",
 					Message: "\"default.mysql5.6\" is default parameter group. You cannot edit it.",
 					Line:    3,

--- a/detector/aws_db_instance_duplicate_identifier_test.go
+++ b/detector/aws_db_instance_duplicate_identifier_test.go
@@ -28,15 +28,15 @@ resource "aws_db_instance" "test" {
     identifier = "my-db"
 }`,
 			Response: []*rds.DBInstance{
-				&rds.DBInstance{
+				{
 					DBInstanceIdentifier: aws.String("my-db"),
 				},
-				&rds.DBInstance{
+				{
 					DBInstanceIdentifier: aws.String("your-db"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"my-db\" is duplicate identifier. It must be unique.",
 					Line:    3,
@@ -51,10 +51,10 @@ resource "aws_db_instance" "test" {
     name = "my-db"
 }`,
 			Response: []*rds.DBInstance{
-				&rds.DBInstance{
+				{
 					DBInstanceIdentifier: aws.String("our-db"),
 				},
-				&rds.DBInstance{
+				{
 					DBInstanceIdentifier: aws.String("your-db"),
 				},
 			},
@@ -135,10 +135,10 @@ resource "aws_db_instance" "test" {
 }
 `,
 			Response: []*rds.DBInstance{
-				&rds.DBInstance{
+				{
 					DBInstanceIdentifier: aws.String("my-db"),
 				},
-				&rds.DBInstance{
+				{
 					DBInstanceIdentifier: aws.String("your-db"),
 				},
 			},

--- a/detector/aws_db_instance_invalid_db_subnet_group.go
+++ b/detector/aws_db_instance_invalid_db_subnet_group.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsDBInstanceInvalidDBSubnetGroupDetector struct {
@@ -38,10 +38,9 @@ func (d *AwsDBInstanceInvalidDBSubnetGroupDetector) PreProcess() {
 	}
 }
 
-func (d *AwsDBInstanceInvalidDBSubnetGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	subnetGroupToken, err := hclLiteralToken(item, "db_subnet_group_name")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsDBInstanceInvalidDBSubnetGroupDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	subnetGroupToken, ok := resource.GetToken("db_subnet_group_name")
+	if !ok {
 		return
 	}
 	subnetGroup, err := d.evalToString(subnetGroupToken.Text)
@@ -55,7 +54,7 @@ func (d *AwsDBInstanceInvalidDBSubnetGroupDetector) Detect(file string, item *as
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid DB subnet group name.", subnetGroup),
 			Line:    subnetGroupToken.Pos.Line,
-			File:    file,
+			File:    subnetGroupToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_db_instance_invalid_db_subnet_group_test.go
+++ b/detector/aws_db_instance_invalid_db_subnet_group_test.go
@@ -27,15 +27,15 @@ resource "aws_db_instance" "mysql" {
     db_subnet_group_name = "app-server"
 }`,
 			Response: []*rds.DBSubnetGroup{
-				&rds.DBSubnetGroup{
+				{
 					DBSubnetGroupName: aws.String("app-server1"),
 				},
-				&rds.DBSubnetGroup{
+				{
 					DBSubnetGroupName: aws.String("app-server2"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"app-server\" is invalid DB subnet group name.",
 					Line:    3,
@@ -50,13 +50,13 @@ resource "aws_db_instance" "mysql" {
     db_subnet_group_name = "app-server"
 }`,
 			Response: []*rds.DBSubnetGroup{
-				&rds.DBSubnetGroup{
+				{
 					DBSubnetGroupName: aws.String("app-server1"),
 				},
-				&rds.DBSubnetGroup{
+				{
 					DBSubnetGroupName: aws.String("app-server2"),
 				},
-				&rds.DBSubnetGroup{
+				{
 					DBSubnetGroupName: aws.String("app-server"),
 				},
 			},

--- a/detector/aws_db_instance_invalid_option_group.go
+++ b/detector/aws_db_instance_invalid_option_group.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsDBInstanceInvalidOptionGroupDetector struct {
@@ -38,10 +38,9 @@ func (d *AwsDBInstanceInvalidOptionGroupDetector) PreProcess() {
 	}
 }
 
-func (d *AwsDBInstanceInvalidOptionGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	optionGroupToken, err := hclLiteralToken(item, "option_group_name")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsDBInstanceInvalidOptionGroupDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	optionGroupToken, ok := resource.GetToken("option_group_name")
+	if !ok {
 		return
 	}
 	optionGroup, err := d.evalToString(optionGroupToken.Text)
@@ -55,7 +54,7 @@ func (d *AwsDBInstanceInvalidOptionGroupDetector) Detect(file string, item *ast.
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid option group name.", optionGroup),
 			Line:    optionGroupToken.Pos.Line,
-			File:    file,
+			File:    optionGroupToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_db_instance_invalid_option_group_test.go
+++ b/detector/aws_db_instance_invalid_option_group_test.go
@@ -27,15 +27,15 @@ resource "aws_db_instance" "mysql" {
     option_group_name = "app-server"
 }`,
 			Response: []*rds.OptionGroup{
-				&rds.OptionGroup{
+				{
 					OptionGroupName: aws.String("app-server1"),
 				},
-				&rds.OptionGroup{
+				{
 					OptionGroupName: aws.String("app-server2"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"app-server\" is invalid option group name.",
 					Line:    3,
@@ -50,13 +50,13 @@ resource "aws_db_instance" "mysql" {
     option_group_name = "app-server"
 }`,
 			Response: []*rds.OptionGroup{
-				&rds.OptionGroup{
+				{
 					OptionGroupName: aws.String("app-server1"),
 				},
-				&rds.OptionGroup{
+				{
 					OptionGroupName: aws.String("app-server2"),
 				},
-				&rds.OptionGroup{
+				{
 					OptionGroupName: aws.String("app-server"),
 				},
 			},

--- a/detector/aws_db_instance_invalid_parameter_group.go
+++ b/detector/aws_db_instance_invalid_parameter_group.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsDBInstanceInvalidParameterGroupDetector struct {
@@ -38,10 +38,9 @@ func (d *AwsDBInstanceInvalidParameterGroupDetector) PreProcess() {
 	}
 }
 
-func (d *AwsDBInstanceInvalidParameterGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	parameterGroupToken, err := hclLiteralToken(item, "parameter_group_name")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsDBInstanceInvalidParameterGroupDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	parameterGroupToken, ok := resource.GetToken("parameter_group_name")
+	if !ok {
 		return
 	}
 	parameterGroup, err := d.evalToString(parameterGroupToken.Text)
@@ -55,7 +54,7 @@ func (d *AwsDBInstanceInvalidParameterGroupDetector) Detect(file string, item *a
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid parameter group name.", parameterGroup),
 			Line:    parameterGroupToken.Pos.Line,
-			File:    file,
+			File:    parameterGroupToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_db_instance_invalid_parameter_group_test.go
+++ b/detector/aws_db_instance_invalid_parameter_group_test.go
@@ -27,15 +27,15 @@ resource "aws_db_instance" "mysql" {
     parameter_group_name = "app-server"
 }`,
 			Response: []*rds.DBParameterGroup{
-				&rds.DBParameterGroup{
+				{
 					DBParameterGroupName: aws.String("app-server1"),
 				},
-				&rds.DBParameterGroup{
+				{
 					DBParameterGroupName: aws.String("app-server2"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"app-server\" is invalid parameter group name.",
 					Line:    3,
@@ -50,13 +50,13 @@ resource "aws_db_instance" "mysql" {
     parameter_group_name = "app-server"
 }`,
 			Response: []*rds.DBParameterGroup{
-				&rds.DBParameterGroup{
+				{
 					DBParameterGroupName: aws.String("app-server1"),
 				},
-				&rds.DBParameterGroup{
+				{
 					DBParameterGroupName: aws.String("app-server2"),
 				},
-				&rds.DBParameterGroup{
+				{
 					DBParameterGroupName: aws.String("app-server"),
 				},
 			},

--- a/detector/aws_db_instance_invalid_type.go
+++ b/detector/aws_db_instance_invalid_type.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsDBInstanceInvalidTypeDetector struct {
@@ -57,10 +57,9 @@ func (d *AwsDBInstanceInvalidTypeDetector) PreProcess() {
 	}
 }
 
-func (d *AwsDBInstanceInvalidTypeDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	instanceTypeToken, err := hclLiteralToken(item, "instance_class")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsDBInstanceInvalidTypeDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	instanceTypeToken, ok := resource.GetToken("instance_class")
+	if !ok {
 		return
 	}
 	instanceType, err := d.evalToString(instanceTypeToken.Text)
@@ -74,7 +73,7 @@ func (d *AwsDBInstanceInvalidTypeDetector) Detect(file string, item *ast.ObjectI
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid instance type.", instanceType),
 			Line:    instanceTypeToken.Pos.Line,
-			File:    file,
+			File:    instanceTypeToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_db_instance_invalid_type_test.go
+++ b/detector/aws_db_instance_invalid_type_test.go
@@ -22,7 +22,7 @@ resource "aws_db_instance" "mysql" {
     instance_class = "m4.2xlarge"
 }`,
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"m4.2xlarge\" is invalid instance type.",
 					Line:    3,

--- a/detector/aws_db_instance_invalid_vpc_security_group.go
+++ b/detector/aws_db_instance_invalid_vpc_security_group.go
@@ -3,9 +3,9 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsDBInstanceInvalidVPCSecurityGroupDetector struct {
@@ -39,21 +39,20 @@ func (d *AwsDBInstanceInvalidVPCSecurityGroupDetector) PreProcess() {
 	}
 }
 
-func (d *AwsDBInstanceInvalidVPCSecurityGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+func (d *AwsDBInstanceInvalidVPCSecurityGroupDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
 	var varToken token.Token
 	var securityGroupTokens []token.Token
-	var err error
-	if varToken, err = hclLiteralToken(item, "vpc_security_group_ids"); err == nil {
+	var ok bool
+	if varToken, ok = resource.GetToken("vpc_security_group_ids"); ok {
+		var err error
 		securityGroupTokens, err = d.evalToStringTokens(varToken)
 		if err != nil {
 			d.Logger.Error(err)
 			return
 		}
 	} else {
-		d.Logger.Error(err)
-		securityGroupTokens, err = hclLiteralListToken(item, "vpc_security_group_ids")
-		if err != nil {
-			d.Logger.Error(err)
+		securityGroupTokens, ok = resource.GetListToken("vpc_security_group_ids")
+		if !ok {
 			return
 		}
 	}
@@ -64,13 +63,16 @@ func (d *AwsDBInstanceInvalidVPCSecurityGroupDetector) Detect(file string, item 
 			d.Logger.Error(err)
 			continue
 		}
-
+		// If `security_groups` is interpolated by list variable, Filename is empty.
+		if securityGroupToken.Pos.Filename == "" {
+			securityGroupToken.Pos.Filename = varToken.Pos.Filename
+		}
 		if !d.securityGroups[securityGroup] {
 			issue := &issue.Issue{
 				Type:    d.IssueType,
 				Message: fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
 				Line:    securityGroupToken.Pos.Line,
-				File:    file,
+				File:    securityGroupToken.Pos.Filename,
 			}
 			*issues = append(*issues, issue)
 		}

--- a/detector/aws_db_instance_invalid_vpc_security_group_test.go
+++ b/detector/aws_db_instance_invalid_vpc_security_group_test.go
@@ -30,21 +30,21 @@ resource "aws_db_instance" "mysql" {
     ]
 }`,
 			Response: []*ec2.SecurityGroup{
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-12345678"),
 				},
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-abcdefgh"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"sg-1234abcd\" is invalid security group.",
 					Line:    4,
 					File:    "test.tf",
 				},
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"sg-abcd1234\" is invalid security group.",
 					Line:    5,
@@ -53,7 +53,7 @@ resource "aws_db_instance" "mysql" {
 			},
 		},
 		{
-			Name: "key name is valid",
+			Name: "security groups is valid",
 			Src: `
 resource "aws_db_instance" "mysql" {
     vpc_security_group_ids = [
@@ -62,14 +62,47 @@ resource "aws_db_instance" "mysql" {
     ]
 }`,
 			Response: []*ec2.SecurityGroup{
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-1234abcd"),
 				},
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-abcd1234"),
 				},
 			},
 			Issues: []*issue.Issue{},
+		},
+		{
+			Name: "use list variable",
+			Src: `
+variable "security_groups" {
+   default = ["sg-1234abcd", "sg-abcd1234"]
+}
+
+resource "aws_db_instance" "mysql" {
+    vpc_security_group_ids = "${var.security_groups}"
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-12345678"),
+				},
+				{
+					GroupId: aws.String("sg-abcdefgh"),
+				},
+			},
+			Issues: []*issue.Issue{
+				{
+					Type:    "ERROR",
+					Message: "\"sg-1234abcd\" is invalid security group.",
+					Line:    7,
+					File:    "test.tf",
+				},
+				{
+					Type:    "ERROR",
+					Message: "\"sg-abcd1234\" is invalid security group.",
+					Line:    7,
+					File:    "test.tf",
+				},
+			},
 		},
 	}
 

--- a/detector/aws_db_instance_previous_type.go
+++ b/detector/aws_db_instance_previous_type.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsDBInstancePreviousTypeDetector struct {
@@ -39,10 +39,9 @@ func (d *AwsDBInstancePreviousTypeDetector) PreProcess() {
 	}
 }
 
-func (d *AwsDBInstancePreviousTypeDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	instanceTypeToken, err := hclLiteralToken(item, "instance_class")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsDBInstancePreviousTypeDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	instanceTypeToken, ok := resource.GetToken("instance_class")
+	if !ok {
 		return
 	}
 	instanceType, err := d.evalToString(instanceTypeToken.Text)
@@ -56,7 +55,7 @@ func (d *AwsDBInstancePreviousTypeDetector) Detect(file string, item *ast.Object
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is previous generation instance type.", instanceType),
 			Line:    instanceTypeToken.Pos.Line,
-			File:    file,
+			File:    instanceTypeToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_db_instance_previous_type_test.go
+++ b/detector/aws_db_instance_previous_type_test.go
@@ -22,7 +22,7 @@ resource "aws_db_instance" "mysql" {
     instance_class = "db.t1.micro"
 }`,
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "WARNING",
 					Message: "\"db.t1.micro\" is previous generation instance type.",
 					Line:    3,

--- a/detector/aws_db_instance_readable_password.go
+++ b/detector/aws_db_instance_readable_password.go
@@ -1,8 +1,8 @@
 package detector
 
 import (
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsDBInstanceReadablePasswordDetector struct {
@@ -21,13 +21,12 @@ func (d *Detector) CreateAwsDBInstanceReadablePasswordDetector() *AwsDBInstanceR
 	}
 }
 
-func (d *AwsDBInstanceReadablePasswordDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	passwordToken, err := hclLiteralToken(item, "password")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsDBInstanceReadablePasswordDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	passwordToken, ok := resource.GetToken("password")
+	if !ok {
 		return
 	}
-	_, err = d.evalToString(passwordToken.Text)
+	_, err := d.evalToString(passwordToken.Text)
 	if err != nil {
 		d.Logger.Error(err)
 		return
@@ -37,7 +36,7 @@ func (d *AwsDBInstanceReadablePasswordDetector) Detect(file string, item *ast.Ob
 		Type:    d.IssueType,
 		Message: "Password for the master DB user is readable. recommend using environment variables.",
 		Line:    passwordToken.Pos.Line,
-		File:    file,
+		File:    passwordToken.Pos.Filename,
 	}
 	*issues = append(*issues, issue)
 }

--- a/detector/aws_db_instance_readable_password_test.go
+++ b/detector/aws_db_instance_readable_password_test.go
@@ -22,7 +22,7 @@ resource "aws_db_instance" "mysql" {
     password = "super_secret"
 }`,
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "WARNING",
 					Message: "Password for the master DB user is readable. recommend using environment variables.",
 					Line:    3,

--- a/detector/aws_elasticache_cluster_default_parameter_group.go
+++ b/detector/aws_elasticache_cluster_default_parameter_group.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsElastiCacheClusterDefaultParameterGroupDetector struct {
@@ -24,10 +24,9 @@ func (d *Detector) CreateAwsElastiCacheClusterDefaultParameterGroupDetector() *A
 	}
 }
 
-func (d *AwsElastiCacheClusterDefaultParameterGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	parameterGroupToken, err := hclLiteralToken(item, "parameter_group_name")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsElastiCacheClusterDefaultParameterGroupDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	parameterGroupToken, ok := resource.GetToken("parameter_group_name")
+	if !ok {
 		return
 	}
 	parameterGroup, err := d.evalToString(parameterGroupToken.Text)
@@ -41,7 +40,7 @@ func (d *AwsElastiCacheClusterDefaultParameterGroupDetector) Detect(file string,
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is default parameter group. You cannot edit it.", parameterGroup),
 			Line:    parameterGroupToken.Pos.Line,
-			File:    file,
+			File:    parameterGroupToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_elasticache_cluster_default_parameter_group_test.go
+++ b/detector/aws_elasticache_cluster_default_parameter_group_test.go
@@ -22,7 +22,7 @@ resource "aws_elasticache_cluster" "cache" {
     parameter_group_name = "default.redis3.2"
 }`,
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "NOTICE",
 					Message: "\"default.redis3.2\" is default parameter group. You cannot edit it.",
 					Line:    3,

--- a/detector/aws_elasticache_cluster_duplicate_id_test.go
+++ b/detector/aws_elasticache_cluster_duplicate_id_test.go
@@ -28,15 +28,15 @@ resource "aws_elasticache_cluster" "test" {
     cluster_id = "cluster-example"
 }`,
 			Response: []*elasticache.CacheCluster{
-				&elasticache.CacheCluster{
+				{
 					CacheClusterId: aws.String("cluster-example"),
 				},
-				&elasticache.CacheCluster{
+				{
 					CacheClusterId: aws.String("test-cluster"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"cluster-example\" is duplicate Cluster ID. It must be unique.",
 					Line:    3,
@@ -51,10 +51,10 @@ resource "aws_elasticache_cluster" "test" {
     cluster_id = "cluster-example"
 }`,
 			Response: []*elasticache.CacheCluster{
-				&elasticache.CacheCluster{
+				{
 					CacheClusterId: aws.String("example-cluster"),
 				},
-				&elasticache.CacheCluster{
+				{
 					CacheClusterId: aws.String("test-cluster"),
 				},
 			},
@@ -110,10 +110,10 @@ resource "aws_elasticache_cluster" "test" {
 }
 `,
 			Response: []*elasticache.CacheCluster{
-				&elasticache.CacheCluster{
+				{
 					CacheClusterId: aws.String("cluster-example"),
 				},
-				&elasticache.CacheCluster{
+				{
 					CacheClusterId: aws.String("test-cluster"),
 				},
 			},

--- a/detector/aws_elasticache_cluster_invalid_parameter_group.go
+++ b/detector/aws_elasticache_cluster_invalid_parameter_group.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsElastiCacheClusterInvalidParameterGroupDetector struct {
@@ -38,10 +38,9 @@ func (d *AwsElastiCacheClusterInvalidParameterGroupDetector) PreProcess() {
 	}
 }
 
-func (d *AwsElastiCacheClusterInvalidParameterGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	parameterGroupToken, err := hclLiteralToken(item, "parameter_group_name")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsElastiCacheClusterInvalidParameterGroupDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	parameterGroupToken, ok := resource.GetToken("parameter_group_name")
+	if !ok {
 		return
 	}
 	parameterGroup, err := d.evalToString(parameterGroupToken.Text)
@@ -55,7 +54,7 @@ func (d *AwsElastiCacheClusterInvalidParameterGroupDetector) Detect(file string,
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid parameter group name.", parameterGroup),
 			Line:    parameterGroupToken.Pos.Line,
-			File:    file,
+			File:    parameterGroupToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_elasticache_cluster_invalid_parameter_group_test.go
+++ b/detector/aws_elasticache_cluster_invalid_parameter_group_test.go
@@ -27,15 +27,15 @@ resource "aws_elasticache_cluster" "redis" {
     parameter_group_name = "app-server"
 }`,
 			Response: []*elasticache.CacheParameterGroup{
-				&elasticache.CacheParameterGroup{
+				{
 					CacheParameterGroupName: aws.String("app-server1"),
 				},
-				&elasticache.CacheParameterGroup{
+				{
 					CacheParameterGroupName: aws.String("app-server2"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"app-server\" is invalid parameter group name.",
 					Line:    3,
@@ -50,13 +50,13 @@ resource "aws_elasticache_cluster" "redis" {
     parameter_group_name = "app-server"
 }`,
 			Response: []*elasticache.CacheParameterGroup{
-				&elasticache.CacheParameterGroup{
+				{
 					CacheParameterGroupName: aws.String("app-server1"),
 				},
-				&elasticache.CacheParameterGroup{
+				{
 					CacheParameterGroupName: aws.String("app-server2"),
 				},
-				&elasticache.CacheParameterGroup{
+				{
 					CacheParameterGroupName: aws.String("app-server"),
 				},
 			},

--- a/detector/aws_elasticache_cluster_invalid_security_group_test.go
+++ b/detector/aws_elasticache_cluster_invalid_security_group_test.go
@@ -30,21 +30,21 @@ resource "aws_elasticache_cluster" "redis" {
     ]
 }`,
 			Response: []*ec2.SecurityGroup{
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-12345678"),
 				},
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-abcdefgh"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"sg-1234abcd\" is invalid security group.",
 					Line:    4,
 					File:    "test.tf",
 				},
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"sg-abcd1234\" is invalid security group.",
 					Line:    5,
@@ -62,14 +62,47 @@ resource "aws_elasticache_cluster" "redis" {
     ]
 }`,
 			Response: []*ec2.SecurityGroup{
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-1234abcd"),
 				},
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-abcd1234"),
 				},
 			},
 			Issues: []*issue.Issue{},
+		},
+		{
+			Name: "use list variable",
+			Src: `
+variable "security_groups" {
+    default = ["sg-1234abcd", "sg-abcd1234"]
+}
+
+resource "aws_elasticache_cluster" "redis" {
+    security_group_ids = "${var.security_groups}"
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-12345678"),
+				},
+				{
+					GroupId: aws.String("sg-abcdefgh"),
+				},
+			},
+			Issues: []*issue.Issue{
+				{
+					Type:    "ERROR",
+					Message: "\"sg-1234abcd\" is invalid security group.",
+					Line:    7,
+					File:    "test.tf",
+				},
+				{
+					Type:    "ERROR",
+					Message: "\"sg-abcd1234\" is invalid security group.",
+					Line:    7,
+					File:    "test.tf",
+				},
+			},
 		},
 	}
 

--- a/detector/aws_elasticache_cluster_invalid_subnet_group.go
+++ b/detector/aws_elasticache_cluster_invalid_subnet_group.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsElastiCacheClusterInvalidSubnetGroupDetector struct {
@@ -38,10 +38,9 @@ func (d *AwsElastiCacheClusterInvalidSubnetGroupDetector) PreProcess() {
 	}
 }
 
-func (d *AwsElastiCacheClusterInvalidSubnetGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	subnetGroupToken, err := hclLiteralToken(item, "subnet_group_name")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsElastiCacheClusterInvalidSubnetGroupDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	subnetGroupToken, ok := resource.GetToken("subnet_group_name")
+	if !ok {
 		return
 	}
 	subnetGroup, err := d.evalToString(subnetGroupToken.Text)
@@ -55,7 +54,7 @@ func (d *AwsElastiCacheClusterInvalidSubnetGroupDetector) Detect(file string, it
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid subnet group name.", subnetGroup),
 			Line:    subnetGroupToken.Pos.Line,
-			File:    file,
+			File:    subnetGroupToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_elasticache_cluster_invalid_subnet_group_test.go
+++ b/detector/aws_elasticache_cluster_invalid_subnet_group_test.go
@@ -27,15 +27,15 @@ resource "aws_elasticache_cluster" "redis" {
     subnet_group_name = "app-server"
 }`,
 			Response: []*elasticache.CacheSubnetGroup{
-				&elasticache.CacheSubnetGroup{
+				{
 					CacheSubnetGroupName: aws.String("app-server1"),
 				},
-				&elasticache.CacheSubnetGroup{
+				{
 					CacheSubnetGroupName: aws.String("app-server2"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"app-server\" is invalid subnet group name.",
 					Line:    3,
@@ -50,13 +50,13 @@ resource "aws_elasticache_cluster" "redis" {
     subnet_group_name = "app-server"
 }`,
 			Response: []*elasticache.CacheSubnetGroup{
-				&elasticache.CacheSubnetGroup{
+				{
 					CacheSubnetGroupName: aws.String("app-server1"),
 				},
-				&elasticache.CacheSubnetGroup{
+				{
 					CacheSubnetGroupName: aws.String("app-server2"),
 				},
-				&elasticache.CacheSubnetGroup{
+				{
 					CacheSubnetGroupName: aws.String("app-server"),
 				},
 			},

--- a/detector/aws_elasticache_cluster_invalid_type.go
+++ b/detector/aws_elasticache_cluster_invalid_type.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsElastiCacheClusterInvalidTypeDetector struct {
@@ -56,10 +56,9 @@ func (d *AwsElastiCacheClusterInvalidTypeDetector) PreProcess() {
 	}
 }
 
-func (d *AwsElastiCacheClusterInvalidTypeDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	nodeTypeToken, err := hclLiteralToken(item, "node_type")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsElastiCacheClusterInvalidTypeDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	nodeTypeToken, ok := resource.GetToken("node_type")
+	if !ok {
 		return
 	}
 	nodeType, err := d.evalToString(nodeTypeToken.Text)
@@ -73,7 +72,7 @@ func (d *AwsElastiCacheClusterInvalidTypeDetector) Detect(file string, item *ast
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid node type.", nodeType),
 			Line:    nodeTypeToken.Pos.Line,
-			File:    file,
+			File:    nodeTypeToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_elasticache_cluster_invalid_type_test.go
+++ b/detector/aws_elasticache_cluster_invalid_type_test.go
@@ -22,7 +22,7 @@ resource "aws_elasticache_cluster" "redis" {
     node_type = "t2.micro"
 }`,
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"t2.micro\" is invalid node type.",
 					Line:    3,

--- a/detector/aws_elasticache_cluster_previous_type.go
+++ b/detector/aws_elasticache_cluster_previous_type.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsElastiCacheClusterPreviousTypeDetector struct {
@@ -39,10 +39,9 @@ func (d *AwsElastiCacheClusterPreviousTypeDetector) PreProcess() {
 	}
 }
 
-func (d *AwsElastiCacheClusterPreviousTypeDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	nodeTypeToken, err := hclLiteralToken(item, "node_type")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsElastiCacheClusterPreviousTypeDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	nodeTypeToken, ok := resource.GetToken("node_type")
+	if !ok {
 		return
 	}
 	nodeType, err := d.evalToString(nodeTypeToken.Text)
@@ -56,7 +55,7 @@ func (d *AwsElastiCacheClusterPreviousTypeDetector) Detect(file string, item *as
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is previous generation node type.", nodeType),
 			Line:    nodeTypeToken.Pos.Line,
-			File:    file,
+			File:    nodeTypeToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_elasticache_cluster_previous_type_test.go
+++ b/detector/aws_elasticache_cluster_previous_type_test.go
@@ -22,7 +22,7 @@ resource "aws_elasticache_cluster" "redis" {
     node_type = "cache.t1.micro"
 }`,
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "WARNING",
 					Message: "\"cache.t1.micro\" is previous generation node type.",
 					Line:    3,

--- a/detector/aws_elb_duplicate_name_test.go
+++ b/detector/aws_elb_duplicate_name_test.go
@@ -28,15 +28,15 @@ resource "aws_elb" "test" {
     name = "test-elb-tf"
 }`,
 			Response: []*elb.LoadBalancerDescription{
-				&elb.LoadBalancerDescription{
+				{
 					LoadBalancerName: aws.String("test-elb-tf"),
 				},
-				&elb.LoadBalancerDescription{
+				{
 					LoadBalancerName: aws.String("production-elb-tf"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"test-elb-tf\" is duplicate name. It must be unique.",
 					Line:    3,
@@ -51,10 +51,10 @@ resource "aws_elb" "test" {
     name = "test-elb-tf"
 }`,
 			Response: []*elb.LoadBalancerDescription{
-				&elb.LoadBalancerDescription{
+				{
 					LoadBalancerName: aws.String("staging-elb-tf"),
 				},
-				&elb.LoadBalancerDescription{
+				{
 					LoadBalancerName: aws.String("production-elb-tf"),
 				},
 			},
@@ -129,10 +129,10 @@ resource "aws_elb" "test" {
 }
 `,
 			Response: []*elb.LoadBalancerDescription{
-				&elb.LoadBalancerDescription{
+				{
 					LoadBalancerName: aws.String("test-elb-tf"),
 				},
-				&elb.LoadBalancerDescription{
+				{
 					LoadBalancerName: aws.String("production-elb-tf"),
 				},
 			},

--- a/detector/aws_elb_invalid_instance_test.go
+++ b/detector/aws_elb_invalid_instance_test.go
@@ -30,21 +30,21 @@ resource "aws_elb" "balancer" {
     ]
 }`,
 			Response: []*ec2.Instance{
-				&ec2.Instance{
+				{
 					InstanceId: aws.String("i-12345678"),
 				},
-				&ec2.Instance{
+				{
 					InstanceId: aws.String("i-abcdefgh"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"i-1234abcd\" is invalid instance.",
 					Line:    4,
 					File:    "test.tf",
 				},
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"i-abcd1234\" is invalid instance.",
 					Line:    5,
@@ -62,14 +62,47 @@ resource "aws_elb" "balancer" {
     ]
 }`,
 			Response: []*ec2.Instance{
-				&ec2.Instance{
+				{
 					InstanceId: aws.String("i-1234abcd"),
 				},
-				&ec2.Instance{
+				{
 					InstanceId: aws.String("i-abcd1234"),
 				},
 			},
 			Issues: []*issue.Issue{},
+		},
+		{
+			Name: "use list variable",
+			Src: `
+variable "instances" {
+    default = ["i-1234abcd", "i-abcd1234"]
+}
+
+resource "aws_elb" "balancer" {
+    instances = "${var.instances}"
+}`,
+			Response: []*ec2.Instance{
+				{
+					InstanceId: aws.String("i-12345678"),
+				},
+				{
+					InstanceId: aws.String("i-abcdefgh"),
+				},
+			},
+			Issues: []*issue.Issue{
+				{
+					Type:    "ERROR",
+					Message: "\"i-1234abcd\" is invalid instance.",
+					Line:    7,
+					File:    "test.tf",
+				},
+				{
+					Type:    "ERROR",
+					Message: "\"i-abcd1234\" is invalid instance.",
+					Line:    7,
+					File:    "test.tf",
+				},
+			},
 		},
 	}
 
@@ -83,7 +116,7 @@ resource "aws_elb" "balancer" {
 		ec2mock := mock.NewMockEC2API(ctrl)
 		ec2mock.EXPECT().DescribeInstances(&ec2.DescribeInstancesInput{}).Return(&ec2.DescribeInstancesOutput{
 			Reservations: []*ec2.Reservation{
-				&ec2.Reservation{
+				{
 					Instances: tc.Response,
 				},
 			},

--- a/detector/aws_elb_invalid_security_group.go
+++ b/detector/aws_elb_invalid_security_group.go
@@ -3,9 +3,9 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsELBInvalidSecurityGroupDetector struct {
@@ -39,21 +39,20 @@ func (d *AwsELBInvalidSecurityGroupDetector) PreProcess() {
 	}
 }
 
-func (d *AwsELBInvalidSecurityGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+func (d *AwsELBInvalidSecurityGroupDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
 	var varToken token.Token
 	var securityGroupTokens []token.Token
-	var err error
-	if varToken, err = hclLiteralToken(item, "security_groups"); err == nil {
+	var ok bool
+	if varToken, ok = resource.GetToken("security_groups"); ok {
+		var err error
 		securityGroupTokens, err = d.evalToStringTokens(varToken)
 		if err != nil {
 			d.Logger.Error(err)
 			return
 		}
 	} else {
-		d.Logger.Error(err)
-		securityGroupTokens, err = hclLiteralListToken(item, "security_groups")
-		if err != nil {
-			d.Logger.Error(err)
+		securityGroupTokens, ok = resource.GetListToken("security_groups")
+		if !ok {
 			return
 		}
 	}
@@ -65,12 +64,16 @@ func (d *AwsELBInvalidSecurityGroupDetector) Detect(file string, item *ast.Objec
 			continue
 		}
 
+		// If `security_groups` is interpolated by list variable, Filename is empty
+		if securityGroupToken.Pos.Filename == "" {
+			securityGroupToken.Pos.Filename = varToken.Pos.Filename
+		}
 		if !d.securityGroups[securityGroup] {
 			issue := &issue.Issue{
 				Type:    d.IssueType,
 				Message: fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
 				Line:    securityGroupToken.Pos.Line,
-				File:    file,
+				File:    securityGroupToken.Pos.Filename,
 			}
 			*issues = append(*issues, issue)
 		}

--- a/detector/aws_elb_invalid_security_group_test.go
+++ b/detector/aws_elb_invalid_security_group_test.go
@@ -30,21 +30,21 @@ resource "aws_elb" "balancer" {
     ]
 }`,
 			Response: []*ec2.SecurityGroup{
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-12345678"),
 				},
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-abcdefgh"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"sg-1234abcd\" is invalid security group.",
 					Line:    4,
 					File:    "test.tf",
 				},
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"sg-abcd1234\" is invalid security group.",
 					Line:    5,
@@ -62,14 +62,47 @@ resource "aws_elb" "balancer" {
     ]
 }`,
 			Response: []*ec2.SecurityGroup{
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-1234abcd"),
 				},
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-abcd1234"),
 				},
 			},
 			Issues: []*issue.Issue{},
+		},
+		{
+			Name: "use list variable",
+			Src: `
+variable "security_groups" {
+    default = ["sg-1234abcd", "sg-abcd1234"]
+}
+
+resource "aws_elb" "balancer" {
+    security_groups = "${var.security_groups}"
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-12345678"),
+				},
+				{
+					GroupId: aws.String("sg-abcdefgh"),
+				},
+			},
+			Issues: []*issue.Issue{
+				{
+					Type:    "ERROR",
+					Message: "\"sg-1234abcd\" is invalid security group.",
+					Line:    7,
+					File:    "test.tf",
+				},
+				{
+					Type:    "ERROR",
+					Message: "\"sg-abcd1234\" is invalid security group.",
+					Line:    7,
+					File:    "test.tf",
+				},
+			},
 		},
 	}
 

--- a/detector/aws_elb_invalid_subnet.go
+++ b/detector/aws_elb_invalid_subnet.go
@@ -3,9 +3,9 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsELBInvalidSubnetDetector struct {
@@ -39,21 +39,20 @@ func (d *AwsELBInvalidSubnetDetector) PreProcess() {
 	}
 }
 
-func (d *AwsELBInvalidSubnetDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+func (d *AwsELBInvalidSubnetDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
 	var varToken token.Token
 	var subnetTokens []token.Token
-	var err error
-	if varToken, err = hclLiteralToken(item, "subnets"); err == nil {
+	var ok bool
+	if varToken, ok = resource.GetToken("subnets"); ok {
+		var err error
 		subnetTokens, err = d.evalToStringTokens(varToken)
 		if err != nil {
 			d.Logger.Error(err)
 			return
 		}
 	} else {
-		d.Logger.Error(err)
-		subnetTokens, err = hclLiteralListToken(item, "subnets")
-		if err != nil {
-			d.Logger.Error(err)
+		subnetTokens, ok = resource.GetListToken("subnets")
+		if !ok {
 			return
 		}
 	}
@@ -65,12 +64,16 @@ func (d *AwsELBInvalidSubnetDetector) Detect(file string, item *ast.ObjectItem, 
 			continue
 		}
 
+		// If `subnets` is interpolated by list variable, Filename is empty
+		if subnetToken.Pos.Filename == "" {
+			subnetToken.Pos.Filename = varToken.Pos.Filename
+		}
 		if !d.subnets[subnet] {
 			issue := &issue.Issue{
 				Type:    d.IssueType,
 				Message: fmt.Sprintf("\"%s\" is invalid subnet ID.", subnet),
 				Line:    subnetToken.Pos.Line,
-				File:    file,
+				File:    subnetToken.Pos.Filename,
 			}
 			*issues = append(*issues, issue)
 		}

--- a/detector/aws_elb_invalid_subnet_test.go
+++ b/detector/aws_elb_invalid_subnet_test.go
@@ -30,21 +30,21 @@ resource "aws_elb" "balancer" {
     ]
 }`,
 			Response: []*ec2.Subnet{
-				&ec2.Subnet{
+				{
 					SubnetId: aws.String("subnet-12345678"),
 				},
-				&ec2.Subnet{
+				{
 					SubnetId: aws.String("subnet-abcdefgh"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"subnet-1234abcd\" is invalid subnet ID.",
 					Line:    4,
 					File:    "test.tf",
 				},
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"subnet-abcd1234\" is invalid subnet ID.",
 					Line:    5,
@@ -62,14 +62,47 @@ resource "aws_elb" "balancer" {
     ]
 }`,
 			Response: []*ec2.Subnet{
-				&ec2.Subnet{
+				{
 					SubnetId: aws.String("subnet-1234abcd"),
 				},
-				&ec2.Subnet{
+				{
 					SubnetId: aws.String("subnet-abcd1234"),
 				},
 			},
 			Issues: []*issue.Issue{},
+		},
+		{
+			Name: "use list variable",
+			Src: `
+variable "subnets" {
+    default = ["subnet-1234abcd", "subnet-abcd1234"]
+}
+
+resource "aws_elb" "balancer" {
+    subnets = "${var.subnets}"
+}`,
+			Response: []*ec2.Subnet{
+				{
+					SubnetId: aws.String("subnet-12345678"),
+				},
+				{
+					SubnetId: aws.String("subnet-abcdefgh"),
+				},
+			},
+			Issues: []*issue.Issue{
+				{
+					Type:    "ERROR",
+					Message: "\"subnet-1234abcd\" is invalid subnet ID.",
+					Line:    7,
+					File:    "test.tf",
+				},
+				{
+					Type:    "ERROR",
+					Message: "\"subnet-abcd1234\" is invalid subnet ID.",
+					Line:    7,
+					File:    "test.tf",
+				},
+			},
 		},
 	}
 

--- a/detector/aws_instance_default_standard_volume.go
+++ b/detector/aws_instance_default_standard_volume.go
@@ -1,8 +1,8 @@
 package detector
 
 import (
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsInstanceDefaultStandardVolumeDetector struct {
@@ -21,28 +21,21 @@ func (d *Detector) CreateAwsInstanceDefaultStandardVolumeDetector() *AwsInstance
 	}
 }
 
-func (d *AwsInstanceDefaultStandardVolumeDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	d.detectForBlockDevices(issues, item, file, "root_block_device")
-	d.detectForBlockDevices(issues, item, file, "ebs_block_device")
-}
+func (d *AwsInstanceDefaultStandardVolumeDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	var devices []string = []string{"root_block_device", "ebs_block_device"}
 
-func (d *AwsInstanceDefaultStandardVolumeDetector) detectForBlockDevices(issues *[]*issue.Issue, item *ast.ObjectItem, file string, device string) {
-	if !IsKeyNotFound(item, device) {
-		deviceItems, err := hclObjectItems(item, device)
-		if err != nil {
-			d.Logger.Error(err)
-			return
-		}
-
-		for _, deviceItem := range deviceItems {
-			if IsKeyNotFound(deviceItem, "volume_type") {
-				issue := &issue.Issue{
-					Type:    d.IssueType,
-					Message: "\"volume_type\" is not specified. Default standard volume type is not recommended. You can use \"gp2\", \"io1\", etc instead.",
-					Line:    deviceItem.Assign.Line,
-					File:    file,
+	for _, device := range devices {
+		if deviceTokens, ok := resource.GetAllMapTokens(device); ok {
+			for i, deviceToken := range deviceTokens {
+				if deviceToken["volume_type"].Text == "" {
+					issue := &issue.Issue{
+						Type:    d.IssueType,
+						Message: "\"volume_type\" is not specified. Default standard volume type is not recommended. You can use \"gp2\", \"io1\", etc instead.",
+						Line:    resource.Attrs[device].Poses[i].Line,
+						File:    resource.Attrs[device].Poses[i].Filename,
+					}
+					*issues = append(*issues, issue)
 				}
-				*issues = append(*issues, issue)
 			}
 		}
 	}

--- a/detector/aws_instance_default_standard_volume_test.go
+++ b/detector/aws_instance_default_standard_volume_test.go
@@ -26,7 +26,7 @@ resource "aws_instance" "web" {
     }
 }`,
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "WARNING",
 					Message: "\"volume_type\" is not specified. Default standard volume type is not recommended. You can use \"gp2\", \"io1\", etc instead.",
 					Line:    5,
@@ -45,7 +45,7 @@ resource "aws_instance" "web" {
     }
 }`,
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "WARNING",
 					Message: "\"volume_type\" is not specified. Default standard volume type is not recommended. You can use \"gp2\", \"io1\", etc instead.",
 					Line:    5,
@@ -72,19 +72,19 @@ resource "aws_instance" "web" {
     }
 }`,
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "WARNING",
 					Message: "\"volume_type\" is not specified. Default standard volume type is not recommended. You can use \"gp2\", \"io1\", etc instead.",
 					Line:    5,
 					File:    "test.tf",
 				},
-				&issue.Issue{
+				{
 					Type:    "WARNING",
 					Message: "\"volume_type\" is not specified. Default standard volume type is not recommended. You can use \"gp2\", \"io1\", etc instead.",
 					Line:    9,
 					File:    "test.tf",
 				},
-				&issue.Issue{
+				{
 					Type:    "WARNING",
 					Message: "\"volume_type\" is not specified. Default standard volume type is not recommended. You can use \"gp2\", \"io1\", etc instead.",
 					Line:    13,

--- a/detector/aws_instance_invalid_ami.go
+++ b/detector/aws_instance_invalid_ami.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsInstanceInvalidAMIDetector struct {
@@ -38,10 +38,9 @@ func (d *AwsInstanceInvalidAMIDetector) PreProcess() {
 	}
 }
 
-func (d *AwsInstanceInvalidAMIDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	amiToken, err := hclLiteralToken(item, "ami")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsInstanceInvalidAMIDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	amiToken, ok := resource.GetToken("ami")
+	if !ok {
 		return
 	}
 	ami, err := d.evalToString(amiToken.Text)
@@ -55,7 +54,7 @@ func (d *AwsInstanceInvalidAMIDetector) Detect(file string, item *ast.ObjectItem
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid AMI.", ami),
 			Line:    amiToken.Pos.Line,
-			File:    file,
+			File:    amiToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_instance_invalid_ami_test.go
+++ b/detector/aws_instance_invalid_ami_test.go
@@ -27,15 +27,15 @@ resource "aws_instance" "web" {
     ami = "ami-1234abcd"
 }`,
 			Response: []*ec2.Image{
-				&ec2.Image{
+				{
 					ImageId: aws.String("ami-0c11b26d"),
 				},
-				&ec2.Image{
+				{
 					ImageId: aws.String("ami-9ad76sd1"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"ami-1234abcd\" is invalid AMI.",
 					Line:    3,
@@ -50,10 +50,10 @@ resource "aws_instance" "web" {
     ami = "ami-0c11b26d"
 }`,
 			Response: []*ec2.Image{
-				&ec2.Image{
+				{
 					ImageId: aws.String("ami-0c11b26d"),
 				},
-				&ec2.Image{
+				{
 					ImageId: aws.String("ami-9ad76sd1"),
 				},
 			},

--- a/detector/aws_instance_invalid_iam_profile.go
+++ b/detector/aws_instance_invalid_iam_profile.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsInstanceInvalidIAMProfileDetector struct {
@@ -38,10 +38,9 @@ func (d *AwsInstanceInvalidIAMProfileDetector) PreProcess() {
 	}
 }
 
-func (d *AwsInstanceInvalidIAMProfileDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	iamProfileToken, err := hclLiteralToken(item, "iam_instance_profile")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsInstanceInvalidIAMProfileDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	iamProfileToken, ok := resource.GetToken("iam_instance_profile")
+	if !ok {
 		return
 	}
 	iamProfile, err := d.evalToString(iamProfileToken.Text)
@@ -55,7 +54,7 @@ func (d *AwsInstanceInvalidIAMProfileDetector) Detect(file string, item *ast.Obj
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid IAM profile name.", iamProfile),
 			Line:    iamProfileToken.Pos.Line,
-			File:    file,
+			File:    iamProfileToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_instance_invalid_iam_profile_test.go
+++ b/detector/aws_instance_invalid_iam_profile_test.go
@@ -27,15 +27,15 @@ resource "aws_instance" "web" {
     iam_instance_profile = "app-server"
 }`,
 			Response: []*iam.InstanceProfile{
-				&iam.InstanceProfile{
+				{
 					InstanceProfileName: aws.String("app-server1"),
 				},
-				&iam.InstanceProfile{
+				{
 					InstanceProfileName: aws.String("app-server2"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"app-server\" is invalid IAM profile name.",
 					Line:    3,
@@ -50,13 +50,13 @@ resource "aws_instance" "web" {
     iam_instance_profile = "app-server"
 }`,
 			Response: []*iam.InstanceProfile{
-				&iam.InstanceProfile{
+				{
 					InstanceProfileName: aws.String("app-server1"),
 				},
-				&iam.InstanceProfile{
+				{
 					InstanceProfileName: aws.String("app-server2"),
 				},
-				&iam.InstanceProfile{
+				{
 					InstanceProfileName: aws.String("app-server"),
 				},
 			},

--- a/detector/aws_instance_invalid_key_name.go
+++ b/detector/aws_instance_invalid_key_name.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsInstanceInvalidKeyNameDetector struct {
@@ -38,10 +38,9 @@ func (d *AwsInstanceInvalidKeyNameDetector) PreProcess() {
 	}
 }
 
-func (d *AwsInstanceInvalidKeyNameDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	keyNameToken, err := hclLiteralToken(item, "key_name")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsInstanceInvalidKeyNameDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	keyNameToken, ok := resource.GetToken("key_name")
+	if !ok {
 		return
 	}
 	keyName, err := d.evalToString(keyNameToken.Text)
@@ -55,7 +54,7 @@ func (d *AwsInstanceInvalidKeyNameDetector) Detect(file string, item *ast.Object
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid key name.", keyName),
 			Line:    keyNameToken.Pos.Line,
-			File:    file,
+			File:    keyNameToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_instance_invalid_key_name_test.go
+++ b/detector/aws_instance_invalid_key_name_test.go
@@ -27,15 +27,15 @@ resource "aws_instance" "web" {
     key_name = "foo"
 }`,
 			Response: []*ec2.KeyPairInfo{
-				&ec2.KeyPairInfo{
+				{
 					KeyName: aws.String("hogehoge"),
 				},
-				&ec2.KeyPairInfo{
+				{
 					KeyName: aws.String("fugafuga"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"foo\" is invalid key name.",
 					Line:    3,
@@ -50,10 +50,10 @@ resource "aws_instance" "web" {
     key_name = "foo"
 }`,
 			Response: []*ec2.KeyPairInfo{
-				&ec2.KeyPairInfo{
+				{
 					KeyName: aws.String("foo"),
 				},
-				&ec2.KeyPairInfo{
+				{
 					KeyName: aws.String("bar"),
 				},
 			},

--- a/detector/aws_instance_invalid_subnet.go
+++ b/detector/aws_instance_invalid_subnet.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsInstanceInvalidSubnetDetector struct {
@@ -38,10 +38,9 @@ func (d *AwsInstanceInvalidSubnetDetector) PreProcess() {
 	}
 }
 
-func (d *AwsInstanceInvalidSubnetDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	subnetToken, err := hclLiteralToken(item, "subnet_id")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsInstanceInvalidSubnetDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	subnetToken, ok := resource.GetToken("subnet_id")
+	if !ok {
 		return
 	}
 	subnet, err := d.evalToString(subnetToken.Text)
@@ -55,7 +54,7 @@ func (d *AwsInstanceInvalidSubnetDetector) Detect(file string, item *ast.ObjectI
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid subnet ID.", subnet),
 			Line:    subnetToken.Pos.Line,
-			File:    file,
+			File:    subnetToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_instance_invalid_subnet_test.go
+++ b/detector/aws_instance_invalid_subnet_test.go
@@ -27,15 +27,15 @@ resource "aws_instance" "web" {
     subnet_id = "subnet-1234abcd"
 }`,
 			Response: []*ec2.Subnet{
-				&ec2.Subnet{
+				{
 					SubnetId: aws.String("subnet-12345678"),
 				},
-				&ec2.Subnet{
+				{
 					SubnetId: aws.String("subnet-abcdefgh"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"subnet-1234abcd\" is invalid subnet ID.",
 					Line:    3,
@@ -50,10 +50,10 @@ resource "aws_instance" "web" {
     subnet_id = "subnet-1234abcd"
 }`,
 			Response: []*ec2.Subnet{
-				&ec2.Subnet{
+				{
 					SubnetId: aws.String("subnet-1234abcd"),
 				},
-				&ec2.Subnet{
+				{
 					SubnetId: aws.String("subnet-abcd1234"),
 				},
 			},

--- a/detector/aws_instance_invalid_type.go
+++ b/detector/aws_instance_invalid_type.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsInstanceInvalidTypeDetector struct {
@@ -105,10 +105,9 @@ func (d *AwsInstanceInvalidTypeDetector) PreProcess() {
 	}
 }
 
-func (d *AwsInstanceInvalidTypeDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	instanceTypeToken, err := hclLiteralToken(item, "instance_type")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsInstanceInvalidTypeDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	instanceTypeToken, ok := resource.GetToken("instance_type")
+	if !ok {
 		return
 	}
 	instanceType, err := d.evalToString(instanceTypeToken.Text)
@@ -122,7 +121,7 @@ func (d *AwsInstanceInvalidTypeDetector) Detect(file string, item *ast.ObjectIte
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid instance type.", instanceType),
 			Line:    instanceTypeToken.Pos.Line,
-			File:    file,
+			File:    instanceTypeToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_instance_invalid_type_test.go
+++ b/detector/aws_instance_invalid_type_test.go
@@ -22,7 +22,7 @@ resource "aws_instance" "web" {
     instance_type = "t1.2xlarge"
 }`,
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"t1.2xlarge\" is invalid instance type.",
 					Line:    3,

--- a/detector/aws_instance_invalid_vpc_security_group.go
+++ b/detector/aws_instance_invalid_vpc_security_group.go
@@ -3,9 +3,9 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsInstanceInvalidVPCSecurityGroupDetector struct {
@@ -39,21 +39,20 @@ func (d *AwsInstanceInvalidVPCSecurityGroupDetector) PreProcess() {
 	}
 }
 
-func (d *AwsInstanceInvalidVPCSecurityGroupDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+func (d *AwsInstanceInvalidVPCSecurityGroupDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
 	var varToken token.Token
 	var securityGroupTokens []token.Token
-	var err error
-	if varToken, err = hclLiteralToken(item, "vpc_security_group_ids"); err == nil {
+	var ok bool
+	if varToken, ok = resource.GetToken("vpc_security_group_ids"); ok {
+		var err error
 		securityGroupTokens, err = d.evalToStringTokens(varToken)
 		if err != nil {
 			d.Logger.Error(err)
 			return
 		}
 	} else {
-		d.Logger.Error(err)
-		securityGroupTokens, err = hclLiteralListToken(item, "vpc_security_group_ids")
-		if err != nil {
-			d.Logger.Error(err)
+		securityGroupTokens, ok = resource.GetListToken("vpc_security_group_ids")
+		if !ok {
 			return
 		}
 	}
@@ -65,12 +64,16 @@ func (d *AwsInstanceInvalidVPCSecurityGroupDetector) Detect(file string, item *a
 			continue
 		}
 
+		// If `vpc_security_group_ids` is interpolated by list variable, file name is empty
+		if securityGroupToken.Pos.Filename == "" {
+			securityGroupToken.Pos.Filename = varToken.Pos.Filename
+		}
 		if !d.securityGroups[securityGroup] {
 			issue := &issue.Issue{
 				Type:    d.IssueType,
 				Message: fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
 				Line:    securityGroupToken.Pos.Line,
-				File:    file,
+				File:    securityGroupToken.Pos.Filename,
 			}
 			*issues = append(*issues, issue)
 		}

--- a/detector/aws_instance_invalid_vpc_security_group_test.go
+++ b/detector/aws_instance_invalid_vpc_security_group_test.go
@@ -30,21 +30,21 @@ resource "aws_instance" "web" {
     ]
 }`,
 			Response: []*ec2.SecurityGroup{
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-12345678"),
 				},
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-abcdefgh"),
 				},
 			},
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"sg-1234abcd\" is invalid security group.",
 					Line:    4,
 					File:    "test.tf",
 				},
-				&issue.Issue{
+				{
 					Type:    "ERROR",
 					Message: "\"sg-abcd1234\" is invalid security group.",
 					Line:    5,
@@ -62,14 +62,47 @@ resource "aws_instance" "web" {
     ]
 }`,
 			Response: []*ec2.SecurityGroup{
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-1234abcd"),
 				},
-				&ec2.SecurityGroup{
+				{
 					GroupId: aws.String("sg-abcd1234"),
 				},
 			},
 			Issues: []*issue.Issue{},
+		},
+		{
+			Name: "use list variable",
+			Src: `
+variable "security_groups" {
+    default = ["sg-1234abcd", "sg-abcd1234"]
+}
+
+resource "aws_instance" "web" {
+    vpc_security_group_ids = "${var.security_groups}"
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-12345678"),
+				},
+				{
+					GroupId: aws.String("sg-abcdefgh"),
+				},
+			},
+			Issues: []*issue.Issue{
+				{
+					Type:    "ERROR",
+					Message: "\"sg-1234abcd\" is invalid security group.",
+					Line:    7,
+					File:    "test.tf",
+				},
+				{
+					Type:    "ERROR",
+					Message: "\"sg-abcd1234\" is invalid security group.",
+					Line:    7,
+					File:    "test.tf",
+				},
+			},
 		},
 	}
 

--- a/detector/aws_instance_not_specified_iam_profile.go
+++ b/detector/aws_instance_not_specified_iam_profile.go
@@ -1,8 +1,8 @@
 package detector
 
 import (
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsInstanceNotSpecifiedIAMProfileDetector struct {
@@ -21,13 +21,13 @@ func (d *Detector) CreateAwsInstanceNotSpecifiedIAMProfileDetector() *AwsInstanc
 	}
 }
 
-func (d *AwsInstanceNotSpecifiedIAMProfileDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	if IsKeyNotFound(item, "iam_instance_profile") {
+func (d *AwsInstanceNotSpecifiedIAMProfileDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	if _, ok := resource.GetToken("iam_instance_profile"); !ok {
 		issue := &issue.Issue{
 			Type:    d.IssueType,
 			Message: "\"iam_instance_profile\" is not specified. If you want to change it, you need to recreate instance. (Only less than Terraform 0.8.8)",
-			Line:    item.Pos().Line,
-			File:    file,
+			Line:    resource.Pos.Line,
+			File:    resource.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_instance_not_specified_iam_profile_test.go
+++ b/detector/aws_instance_not_specified_iam_profile_test.go
@@ -22,7 +22,7 @@ resource "aws_instance" "web" {
     instance_type = "t2.2xlarge"
 }`,
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "NOTICE",
 					Message: "\"iam_instance_profile\" is not specified. If you want to change it, you need to recreate instance. (Only less than Terraform 0.8.8)",
 					Line:    2,

--- a/detector/aws_instance_previous_type.go
+++ b/detector/aws_instance_previous_type.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsInstancePreviousTypeDetector struct {
@@ -45,10 +45,9 @@ func (d *AwsInstancePreviousTypeDetector) PreProcess() {
 	}
 }
 
-func (d *AwsInstancePreviousTypeDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	instanceTypeToken, err := hclLiteralToken(item, "instance_type")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsInstancePreviousTypeDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	instanceTypeToken, ok := resource.GetToken("instance_type")
+	if !ok {
 		return
 	}
 	instanceType, err := d.evalToString(instanceTypeToken.Text)
@@ -62,7 +61,7 @@ func (d *AwsInstancePreviousTypeDetector) Detect(file string, item *ast.ObjectIt
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is previous generation instance type.", instanceType),
 			Line:    instanceTypeToken.Pos.Line,
-			File:    file,
+			File:    instanceTypeToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_instance_previous_type_test.go
+++ b/detector/aws_instance_previous_type_test.go
@@ -22,7 +22,7 @@ resource "aws_instance" "web" {
     instance_type = "t1.micro"
 }`,
 			Issues: []*issue.Issue{
-				&issue.Issue{
+				{
 					Type:    "WARNING",
 					Message: "\"t1.micro\" is previous generation instance type.",
 					Line:    3,

--- a/detector/aws_route_invalid_egress_only_gateway.go
+++ b/detector/aws_route_invalid_egress_only_gateway.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsRouteInvalidEgressOnlyGatewayDetector struct {
@@ -38,10 +38,9 @@ func (d *AwsRouteInvalidEgressOnlyGatewayDetector) PreProcess() {
 	}
 }
 
-func (d *AwsRouteInvalidEgressOnlyGatewayDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	egatewayToken, err := hclLiteralToken(item, "egress_only_gateway_id")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsRouteInvalidEgressOnlyGatewayDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	egatewayToken, ok := resource.GetToken("egress_only_gateway_id")
+	if !ok {
 		return
 	}
 	egateway, err := d.evalToString(egatewayToken.Text)
@@ -55,7 +54,7 @@ func (d *AwsRouteInvalidEgressOnlyGatewayDetector) Detect(file string, item *ast
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid egress only internet gateway ID.", egateway),
 			Line:    egatewayToken.Pos.Line,
-			File:    file,
+			File:    egatewayToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_route_invalid_gateway.go
+++ b/detector/aws_route_invalid_gateway.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsRouteInvalidGatewayDetector struct {
@@ -38,10 +38,9 @@ func (d *AwsRouteInvalidGatewayDetector) PreProcess() {
 	}
 }
 
-func (d *AwsRouteInvalidGatewayDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	gatewayToken, err := hclLiteralToken(item, "gateway_id")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsRouteInvalidGatewayDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	gatewayToken, ok := resource.GetToken("gateway_id")
+	if !ok {
 		return
 	}
 	gateway, err := d.evalToString(gatewayToken.Text)
@@ -55,7 +54,7 @@ func (d *AwsRouteInvalidGatewayDetector) Detect(file string, item *ast.ObjectIte
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid internet gateway ID.", gateway),
 			Line:    gatewayToken.Pos.Line,
-			File:    file,
+			File:    gatewayToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_route_invalid_instance.go
+++ b/detector/aws_route_invalid_instance.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsRouteInvalidInstanceDetector struct {
@@ -40,10 +40,9 @@ func (d *AwsRouteInvalidInstanceDetector) PreProcess() {
 	}
 }
 
-func (d *AwsRouteInvalidInstanceDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	instanceToken, err := hclLiteralToken(item, "instance_id")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsRouteInvalidInstanceDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	instanceToken, ok := resource.GetToken("instance_id")
+	if !ok {
 		return
 	}
 	instance, err := d.evalToString(instanceToken.Text)
@@ -57,7 +56,7 @@ func (d *AwsRouteInvalidInstanceDetector) Detect(file string, item *ast.ObjectIt
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid instance ID.", instance),
 			Line:    instanceToken.Pos.Line,
-			File:    file,
+			File:    instanceToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_route_invalid_nat_gateway.go
+++ b/detector/aws_route_invalid_nat_gateway.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsRouteInvalidNatGatewayDetector struct {
@@ -38,10 +38,9 @@ func (d *AwsRouteInvalidNatGatewayDetector) PreProcess() {
 	}
 }
 
-func (d *AwsRouteInvalidNatGatewayDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	ngatewayToken, err := hclLiteralToken(item, "nat_gateway_id")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsRouteInvalidNatGatewayDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	ngatewayToken, ok := resource.GetToken("nat_gateway_id")
+	if !ok {
 		return
 	}
 	ngateway, err := d.evalToString(ngatewayToken.Text)
@@ -55,7 +54,7 @@ func (d *AwsRouteInvalidNatGatewayDetector) Detect(file string, item *ast.Object
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid NAT gateway ID.", ngateway),
 			Line:    ngatewayToken.Pos.Line,
-			File:    file,
+			File:    ngatewayToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_route_invalid_network_interface.go
+++ b/detector/aws_route_invalid_network_interface.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsRouteInvalidNetworkInterfaceDetector struct {
@@ -38,10 +38,9 @@ func (d *AwsRouteInvalidNetworkInterfaceDetector) PreProcess() {
 	}
 }
 
-func (d *AwsRouteInvalidNetworkInterfaceDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	networkInterfaceToken, err := hclLiteralToken(item, "network_interface_id")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsRouteInvalidNetworkInterfaceDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	networkInterfaceToken, ok := resource.GetToken("network_interface_id")
+	if !ok {
 		return
 	}
 	networkInterface, err := d.evalToString(networkInterfaceToken.Text)
@@ -55,7 +54,7 @@ func (d *AwsRouteInvalidNetworkInterfaceDetector) Detect(file string, item *ast.
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid network interface ID.", networkInterface),
 			Line:    networkInterfaceToken.Pos.Line,
-			File:    file,
+			File:    networkInterfaceToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_route_invalid_route_table.go
+++ b/detector/aws_route_invalid_route_table.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsRouteInvalidRouteTableDetector struct {
@@ -38,10 +38,9 @@ func (d *AwsRouteInvalidRouteTableDetector) PreProcess() {
 	}
 }
 
-func (d *AwsRouteInvalidRouteTableDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	routeTableToken, err := hclLiteralToken(item, "route_table_id")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsRouteInvalidRouteTableDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	routeTableToken, ok := resource.GetToken("route_table_id")
+	if !ok {
 		return
 	}
 	routeTable, err := d.evalToString(routeTableToken.Text)
@@ -55,7 +54,7 @@ func (d *AwsRouteInvalidRouteTableDetector) Detect(file string, item *ast.Object
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid route table ID.", routeTable),
 			Line:    routeTableToken.Pos.Line,
-			File:    file,
+			File:    routeTableToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_route_invalid_vpc_peering_connection.go
+++ b/detector/aws_route_invalid_vpc_peering_connection.go
@@ -3,8 +3,8 @@ package detector
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsRouteInvalidVpcPeeringConnectionDetector struct {
@@ -38,10 +38,9 @@ func (d *AwsRouteInvalidVpcPeeringConnectionDetector) PreProcess() {
 	}
 }
 
-func (d *AwsRouteInvalidVpcPeeringConnectionDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
-	vpcPeeringConnectionToken, err := hclLiteralToken(item, "vpc_peering_connection_id")
-	if err != nil {
-		d.Logger.Error(err)
+func (d *AwsRouteInvalidVpcPeeringConnectionDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	vpcPeeringConnectionToken, ok := resource.GetToken("vpc_peering_connection_id")
+	if !ok {
 		return
 	}
 	vpcPeeringConnection, err := d.evalToString(vpcPeeringConnectionToken.Text)
@@ -55,7 +54,7 @@ func (d *AwsRouteInvalidVpcPeeringConnectionDetector) Detect(file string, item *
 			Type:    d.IssueType,
 			Message: fmt.Sprintf("\"%s\" is invalid VPC peering connection ID.", vpcPeeringConnection),
 			Line:    vpcPeeringConnectionToken.Pos.Line,
-			File:    file,
+			File:    vpcPeeringConnectionToken.Pos.Filename,
 		}
 		*issues = append(*issues, issue)
 	}

--- a/detector/aws_route_specified_multiple_targets.go
+++ b/detector/aws_route_specified_multiple_targets.go
@@ -1,8 +1,8 @@
 package detector
 
 import (
-	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
 )
 
 type AwsRouteSpecifiedMultipleTargetsDetector struct {
@@ -21,19 +21,19 @@ func (d *Detector) CreateAwsRouteSpecifiedMultipleTargetsDetector() *AwsRouteSpe
 	}
 }
 
-func (d *AwsRouteSpecifiedMultipleTargetsDetector) Detect(file string, item *ast.ObjectItem, issues *[]*issue.Issue) {
+func (d *AwsRouteSpecifiedMultipleTargetsDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
 	targets := []string{"gateway_id", "egress_only_gateway_id", "nat_gateway_id", "instance_id", "vpc_peering_connection_id", "network_interface_id"}
 
 	var targetCount int = 0
 	for _, target := range targets {
-		if _, err := hclLiteralToken(item, target); err == nil {
+		if _, ok := resource.GetToken(target); ok {
 			targetCount++
 			if targetCount > 1 {
 				issue := &issue.Issue{
 					Type:    d.IssueType,
 					Message: "more than 1 target specified, only 1 routing target can be specified.",
-					Line:    item.Pos().Line,
-					File:    file,
+					Line:    resource.Pos.Line,
+					File:    resource.Pos.Filename,
 				}
 				*issues = append(*issues, issue)
 				return

--- a/evaluator/module.go
+++ b/evaluator/module.go
@@ -13,6 +13,7 @@ import (
 	hilast "github.com/hashicorp/hil/ast"
 	"github.com/wata727/tflint/config"
 	"github.com/wata727/tflint/loader"
+	"github.com/wata727/tflint/schema"
 )
 
 type hclModule struct {
@@ -22,6 +23,7 @@ type hclModule struct {
 	File       string
 	Config     hil.EvalConfig
 	Templates  map[string]*hclast.File
+	Schema     []*schema.Template
 }
 
 func (e *Evaluator) detectModules(templates map[string]*hclast.File, c *config.Config) (map[string]*hclModule, error) {
@@ -44,7 +46,10 @@ func (e *Evaluator) detectModules(templates map[string]*hclast.File, c *config.C
 			}
 			moduleKey := moduleKey(name, moduleSource)
 			load := loader.NewLoader(c.Debug)
-			err := load.LoadModuleFile(moduleKey, moduleSource)
+			if err := load.LoadModuleFile(moduleKey, moduleSource); err != nil {
+				return nil, err
+			}
+			schema, err := schema.Make(load.Files)
 			if err != nil {
 				return nil, err
 			}
@@ -71,6 +76,7 @@ func (e *Evaluator) detectModules(templates map[string]*hclast.File, c *config.C
 					},
 				},
 				Templates: load.Templates,
+				Schema:    schema,
 			}
 		}
 	}

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -7,7 +7,7 @@
     "golint",
     "gotype",
     "lll",
-    "vetshadow"
-  ],
-  "Cyclo": 15
+    "vetshadow",
+    "gocyclo"
+  ]
 }

--- a/integration/general/result.json
+++ b/integration/general/result.json
@@ -56,13 +56,13 @@
   {
     "type": "ERROR",
     "message": "route target is not specified, each route must contain either a gateway_id, egress_only_gateway_id a nat_gateway_id, an instance_id or a vpc_peering_connection_id or a network_interface_id.",
-    "line": 22,
+    "line": 28,
     "file": "template.tf"
   },
   {
     "type": "ERROR",
     "message": "more than 1 target specified, only 1 routing target can be specified.",
-    "line": 27,
+    "line": 33,
     "file": "template.tf"
   },
   {
@@ -86,13 +86,13 @@
   {
     "type": "WARNING",
     "message": "Module source \"github.com/wata727/example-module\" is not pinned",
-    "line": 49,
+    "line": 55,
     "file": "template.tf"
   },
   {
     "type": "ERROR",
     "message": "\"percent\" is invalid unit.",
-    "line": 43,
+    "line": 49,
     "file": "template.tf"
   }
 ]

--- a/integration/general/template.tf
+++ b/integration/general/template.tf
@@ -19,6 +19,12 @@ variable "redis_previous_type" {
   default = "cache.t2.micro"
 }
 
+// override by `template_override.tf`
+resource "aws_instance" "web" {
+  ami           = "ami-12345678"
+  instance_type = "t1.2xlarge"
+}
+
 resource "aws_route" "not_specified" {
   route_table_id         = "rtb-1234abcd" // aws_route_not_specified_target
   destination_cidr_block = "10.0.1.0/22"

--- a/integration/general/template_override.tf
+++ b/integration/general/template_override.tf
@@ -1,0 +1,5 @@
+resource "aws_instance" "web" {
+  ami                  = "ami-12345678"
+  instance_type        = "t2.2xlarge"
+  iam_instance_profile = "web-server"
+}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -96,6 +96,7 @@ func TestLoadJSON(t *testing.T) {
 func TestLoadTemplate(t *testing.T) {
 	type Input struct {
 		Templates map[string]*ast.File
+		Files     map[string][]byte
 		File      string
 	}
 
@@ -108,6 +109,9 @@ func TestLoadTemplate(t *testing.T) {
 			Name: "add file list",
 			Input: Input{
 				Templates: map[string]*ast.File{
+					"example.tf": {},
+				},
+				Files: map[string][]byte{
 					"example.tf": {},
 				},
 				File: "empty.tf",
@@ -128,6 +132,7 @@ func TestLoadTemplate(t *testing.T) {
 		load := &Loader{
 			Logger:    logger.Init(false),
 			Templates: tc.Input.Templates,
+			Files:     tc.Input.Files,
 		}
 
 		load.LoadTemplate(tc.Input.File)
@@ -435,6 +440,10 @@ func TestDump(t *testing.T) {
 		"main.tf":   {},
 		"output.tf": {},
 	}
+	files := map[string][]byte{
+		"main.tf":   {},
+		"output.tf": {},
+	}
 	state := &state.TFState{
 		Modules: []*state.Module{
 			{
@@ -465,12 +474,16 @@ func TestDump(t *testing.T) {
 		},
 	}
 	load.Templates = templates
+	load.Files = files
 	load.State = state
 	load.TFVars = tfvars
 
-	dumpTemplates, dumpState, dumpTFvars := load.Dump()
+	dumpTemplates, dumpFiles, dumpState, dumpTFvars := load.Dump()
 	if !reflect.DeepEqual(dumpTemplates, templates) {
 		t.Fatalf("\nBad: %s\nExpected: %s\n\n", pp.Sprint(dumpTemplates), pp.Sprint(templates))
+	}
+	if !reflect.DeepEqual(dumpFiles, files) {
+		t.Fatalf("\nBad: %s\nExpected: %s\n\n", pp.Sprint(dumpFiles), pp.Sprint(files))
 	}
 	if !reflect.DeepEqual(dumpState, state) {
 		t.Fatalf("\nBad: %s\nExpected: %s\n\n", pp.Sprint(dumpState), pp.Sprint(state))

--- a/mock/loadermock.go
+++ b/mock/loadermock.go
@@ -60,12 +60,13 @@ func (_mr *_MockLoaderIFRecorder) LoadAllTemplate(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadAllTemplate", arg0)
 }
 
-func (_m *MockLoaderIF) Dump() (map[string]*ast.File, *state.TFState, []*ast.File) {
+func (_m *MockLoaderIF) Dump() (map[string]*ast.File, map[string][]byte, *state.TFState, []*ast.File) {
 	ret := _m.ctrl.Call(_m, "Dump")
 	ret0, _ := ret[0].(map[string]*ast.File)
-	ret1, _ := ret[1].(*state.TFState)
-	ret2, _ := ret[2].([]*ast.File)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(map[string][]byte)
+	ret2, _ := ret[2].(*state.TFState)
+	ret3, _ := ret[3].([]*ast.File)
+	return ret0, ret1, ret2, ret3
 }
 
 func (_mr *_MockLoaderIFRecorder) Dump() *gomock.Call {

--- a/schema/resource.go
+++ b/schema/resource.go
@@ -1,0 +1,88 @@
+package schema
+
+import "github.com/hashicorp/hcl/hcl/token"
+
+type Resource struct {
+	File  string
+	Type  string
+	Id    string
+	Pos   token.Pos
+	Attrs map[string]*Attribute
+}
+
+type Attribute struct {
+	Poses []token.Pos
+	Vals  []interface{}
+}
+
+func (r *Resource) GetToken(name string) (token.Token, bool) {
+	if r.Attrs[name] != nil {
+		token, ok := r.Attrs[name].Vals[0].(token.Token)
+		return token, ok
+	}
+	return token.Token{}, false
+}
+
+func (r *Resource) GetListToken(name string) ([]token.Token, bool) {
+	if r.Attrs[name] != nil {
+		val, ok := r.Attrs[name].Vals[0].([]interface{})
+		if !ok {
+			return []token.Token{}, false
+		}
+
+		tokens := []token.Token{}
+		for _, v := range val {
+			t, ok := v.(token.Token)
+			if !ok {
+				return []token.Token{}, false
+			}
+			tokens = append(tokens, t)
+		}
+		return tokens, true
+	}
+	return []token.Token{}, false
+}
+
+func (r *Resource) GetMapToken(name string) (map[string]token.Token, bool) {
+	var tokens map[string]token.Token = map[string]token.Token{}
+	if r.Attrs[name] != nil {
+		cval, ok := r.Attrs[name].Vals[0].(map[string]interface{})
+		if !ok {
+			return map[string]token.Token{}, false
+		}
+
+		for k, v := range cval {
+			cv, ok := v.(token.Token)
+			if !ok {
+				return map[string]token.Token{}, false
+			}
+			tokens[k] = cv
+		}
+		return tokens, true
+	}
+	return map[string]token.Token{}, false
+}
+
+func (r *Resource) GetAllMapTokens(name string) ([]map[string]token.Token, bool) {
+	var tokens []map[string]token.Token = []map[string]token.Token{}
+	if r.Attrs[name] != nil {
+		for _, val := range r.Attrs[name].Vals {
+			cval, ok := val.(map[string]interface{})
+			if !ok {
+				return []map[string]token.Token{}, false
+			}
+
+			var tokenMap map[string]token.Token = map[string]token.Token{}
+			for k, v := range cval {
+				cv, ok := v.(token.Token)
+				if !ok {
+					return []map[string]token.Token{}, false
+				}
+				tokenMap[k] = cv
+			}
+			tokens = append(tokens, tokenMap)
+		}
+		return tokens, true
+	}
+	return []map[string]token.Token{}, false
+}

--- a/schema/resource_test.go
+++ b/schema/resource_test.go
@@ -1,0 +1,421 @@
+package schema
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/hcl/hcl/token"
+	"github.com/k0kubun/pp"
+)
+
+var literalToken = []interface{}{
+	token.Token{
+		Type: 9,
+		Pos: token.Pos{
+			Filename: "test.tf",
+			Offset:   51,
+			Line:     3,
+			Column:   19,
+		},
+		Text: "\"literal value\"",
+		JSON: false,
+	},
+}
+
+var listToken = []interface{}{
+	[]interface{}{
+		token.Token{
+			Type: 9,
+			Pos: token.Pos{
+				Filename: "test.tf",
+				Offset:   208,
+				Line:     12,
+				Column:   22,
+			},
+			Text: "\"list1\"",
+			JSON: false,
+		},
+		token.Token{
+			Type: 9,
+			Pos: token.Pos{
+				Filename: "test.tf",
+				Offset:   216,
+				Line:     12,
+				Column:   30,
+			},
+			Text: "\"list2\"",
+			JSON: false,
+		},
+	},
+}
+
+var mapToken = []interface{}{
+	map[string]interface{}{
+		"Key": token.Token{
+			Type: 9,
+			Pos: token.Pos{
+				Filename: "test.tf",
+				Offset:   134,
+				Line:     7,
+				Column:   12,
+			},
+			Text: "\"Value\"",
+			JSON: false,
+		},
+	},
+}
+
+var multiMapToken = []interface{}{
+	map[string]interface{}{
+		"Key1": token.Token{
+			Type: 9,
+			Pos: token.Pos{
+				Filename: "test.tf",
+				Offset:   134,
+				Line:     7,
+				Column:   12,
+			},
+			Text: "\"Value1\"",
+			JSON: false,
+		},
+	},
+	map[string]interface{}{
+		"Key2": token.Token{
+			Type: 9,
+			Pos: token.Pos{
+				Filename: "test2.tf",
+				Offset:   134,
+				Line:     7,
+				Column:   12,
+			},
+			Text: "\"Value2\"",
+			JSON: false,
+		},
+	}}
+
+var resource = &Resource{
+	Attrs: map[string]*Attribute{
+		"literal": {
+			Vals: literalToken,
+		},
+		"list": {
+			Vals: listToken,
+		},
+		"map": {
+			Vals: mapToken,
+		},
+		"multiMap": {
+			Vals: multiMapToken,
+		},
+	},
+}
+
+func TestGetToken(t *testing.T) {
+	type Result struct {
+		Token token.Token
+		Ok    bool
+	}
+
+	cases := []struct {
+		Name   string
+		Input  string
+		Result Result
+	}{
+		{
+			Name:  "Get literal token",
+			Input: "literal",
+			Result: Result{
+				Token: token.Token{
+					Type: 9,
+					Pos: token.Pos{
+						Filename: "test.tf",
+						Offset:   51,
+						Line:     3,
+						Column:   19,
+					},
+					Text: "\"literal value\"",
+					JSON: false,
+				},
+				Ok: true,
+			},
+		},
+		{
+			Name:  "Get another token",
+			Input: "list",
+			Result: Result{
+				Token: token.Token{},
+				Ok:    false,
+			},
+		},
+		{
+			Name:  "Get token by not exists key",
+			Input: "unknown",
+			Result: Result{
+				Token: token.Token{},
+				Ok:    false,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		token, ok := resource.GetToken(tc.Input)
+		if !reflect.DeepEqual(token, tc.Result.Token) {
+			t.Fatalf("\nBad: %s\nExpected: %s\n\ntestcase: %s", pp.Sprint(token), pp.Sprint(tc.Result.Token), tc.Name)
+		}
+
+		if ok != tc.Result.Ok {
+			t.Fatalf("\nBad: %s\nExpected: %s\n\ntestcase: %s", pp.Sprint(ok), pp.Sprint(tc.Result.Ok), tc.Name)
+		}
+	}
+}
+
+func TestGetListToken(t *testing.T) {
+	type Result struct {
+		Token []token.Token
+		Ok    bool
+	}
+
+	cases := []struct {
+		Name   string
+		Input  string
+		Result Result
+	}{
+		{
+			Name:  "Get list token",
+			Input: "list",
+			Result: Result{
+				Token: []token.Token{
+					{
+						Type: 9,
+						Pos: token.Pos{
+							Filename: "test.tf",
+							Offset:   208,
+							Line:     12,
+							Column:   22,
+						},
+						Text: "\"list1\"",
+						JSON: false,
+					},
+					{
+						Type: 9,
+						Pos: token.Pos{
+							Filename: "test.tf",
+							Offset:   216,
+							Line:     12,
+							Column:   30,
+						},
+						Text: "\"list2\"",
+						JSON: false,
+					},
+				},
+				Ok: true,
+			},
+		},
+		{
+			Name:  "Get another token",
+			Input: "literal",
+			Result: Result{
+				Token: []token.Token{},
+				Ok:    false,
+			},
+		},
+		{
+			Name:  "Get token by not exists key",
+			Input: "unknown",
+			Result: Result{
+				Token: []token.Token{},
+				Ok:    false,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		token, ok := resource.GetListToken(tc.Input)
+		if !reflect.DeepEqual(token, tc.Result.Token) {
+			t.Fatalf("\nBad: %s\nExpected: %s\n\ntestcase: %s", pp.Sprint(token), pp.Sprint(tc.Result.Token), tc.Name)
+		}
+
+		if ok != tc.Result.Ok {
+			t.Fatalf("\nBad: %s\nExpected: %s\n\ntestcase: %s", pp.Sprint(ok), pp.Sprint(tc.Result.Ok), tc.Name)
+		}
+	}
+}
+
+func TestGetMapToken(t *testing.T) {
+	type Result struct {
+		Token map[string]token.Token
+		Ok    bool
+	}
+
+	cases := []struct {
+		Name   string
+		Input  string
+		Result Result
+	}{
+		{
+			Name:  "Get map token",
+			Input: "map",
+			Result: Result{
+				Token: map[string]token.Token{
+					"Key": {
+						Type: 9,
+						Pos: token.Pos{
+							Filename: "test.tf",
+							Offset:   134,
+							Line:     7,
+							Column:   12,
+						},
+						Text: "\"Value\"",
+						JSON: false,
+					},
+				},
+				Ok: true,
+			},
+		},
+		{
+			Name:  "Get multi map token",
+			Input: "multiMap",
+			Result: Result{
+				Token: map[string]token.Token{
+					"Key1": {
+						Type: 9,
+						Pos: token.Pos{
+							Filename: "test.tf",
+							Offset:   134,
+							Line:     7,
+							Column:   12,
+						},
+						Text: "\"Value1\"",
+						JSON: false,
+					},
+				},
+				Ok: true,
+			},
+		},
+		{
+			Name:  "Get another token",
+			Input: "list",
+			Result: Result{
+				Token: map[string]token.Token{},
+				Ok:    false,
+			},
+		},
+		{
+			Name:  "Get token by not exists key",
+			Input: "unknown",
+			Result: Result{
+				Token: map[string]token.Token{},
+				Ok:    false,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		token, ok := resource.GetMapToken(tc.Input)
+		if !reflect.DeepEqual(token, tc.Result.Token) {
+			t.Fatalf("\nBad: %s\nExpected: %s\n\ntestcase: %s", pp.Sprint(token), pp.Sprint(tc.Result.Token), tc.Name)
+		}
+
+		if ok != tc.Result.Ok {
+			t.Fatalf("\nBad: %s\nExpected: %s\n\ntestcase: %s", pp.Sprint(ok), pp.Sprint(tc.Result.Ok), tc.Name)
+		}
+	}
+}
+
+func TestGetAllMapTokens(t *testing.T) {
+	type Result struct {
+		Token []map[string]token.Token
+		Ok    bool
+	}
+
+	cases := []struct {
+		Name   string
+		Input  string
+		Result Result
+	}{
+		{
+			Name:  "Get map token",
+			Input: "map",
+			Result: Result{
+				Token: []map[string]token.Token{
+					{
+						"Key": {
+							Type: 9,
+							Pos: token.Pos{
+								Filename: "test.tf",
+								Offset:   134,
+								Line:     7,
+								Column:   12,
+							},
+							Text: "\"Value\"",
+							JSON: false,
+						},
+					},
+				},
+				Ok: true,
+			},
+		},
+		{
+			Name:  "Get multi map token",
+			Input: "multiMap",
+			Result: Result{
+				Token: []map[string]token.Token{
+					{
+						"Key1": {
+							Type: 9,
+							Pos: token.Pos{
+								Filename: "test.tf",
+								Offset:   134,
+								Line:     7,
+								Column:   12,
+							},
+							Text: "\"Value1\"",
+							JSON: false,
+						},
+					},
+					{
+						"Key2": token.Token{
+							Type: 9,
+							Pos: token.Pos{
+								Filename: "test2.tf",
+								Offset:   134,
+								Line:     7,
+								Column:   12,
+							},
+							Text: "\"Value2\"",
+							JSON: false,
+						},
+					},
+				},
+				Ok: true,
+			},
+		},
+		{
+			Name:  "Get another token",
+			Input: "list",
+			Result: Result{
+				Token: []map[string]token.Token{},
+				Ok:    false,
+			},
+		},
+		{
+			Name:  "Get token by not exists key",
+			Input: "unknown",
+			Result: Result{
+				Token: []map[string]token.Token{},
+				Ok:    false,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		token, ok := resource.GetAllMapTokens(tc.Input)
+		if !reflect.DeepEqual(token, tc.Result.Token) {
+			t.Fatalf("\nBad: %s\nExpected: %s\n\ntestcase: %s", pp.Sprint(token), pp.Sprint(tc.Result.Token), tc.Name)
+		}
+
+		if ok != tc.Result.Ok {
+			t.Fatalf("\nBad: %s\nExpected: %s\n\ntestcase: %s", pp.Sprint(ok), pp.Sprint(tc.Result.Ok), tc.Name)
+		}
+	}
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1,0 +1,186 @@
+package schema
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/hcl"
+	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/hashicorp/hcl/hcl/parser"
+	"github.com/hashicorp/hcl/hcl/token"
+)
+
+type Template struct {
+	File      string
+	Resources []*Resource
+}
+
+func Make(files map[string][]byte) ([]*Template, error) {
+	var templates []*Template
+	var err error
+	plains := map[string][]byte{}
+	overrideFiles := []string{}
+	overrides := map[string][]byte{}
+
+	for file := range files {
+		if file == "override.tf" || strings.HasSuffix(file, "_override.tf") {
+			overrideFiles = append(overrideFiles, file)
+		} else {
+			plains[file] = files[file]
+		}
+	}
+	// Override files are loaded last in alphabetical order.
+	sort.Strings(overrideFiles)
+	for _, file := range overrideFiles {
+		overrides[file] = files[file]
+	}
+
+	if templates, err = appendTemplates(templates, plains, false); err != nil {
+		return nil, err
+	}
+	if templates, err = appendTemplates(templates, overrides, true); err != nil {
+		return nil, err
+	}
+
+	return templates, nil
+}
+
+func (t *Template) Find(query ...string) []*Resource {
+	resources := []*Resource{}
+	var provider, providerType, id string
+	for i, attr := range query {
+		switch i {
+		case 0:
+			provider = attr
+		case 1:
+			providerType = attr
+		case 2:
+			id = attr
+		default:
+			// noop
+		}
+	}
+
+	switch provider {
+	case "resource":
+		if providerType != "" {
+			for _, resource := range t.Resources {
+				if id != "" {
+					if resource.Type == providerType && resource.Id == id {
+						resources = append(resources, resource)
+					}
+				} else {
+					if resource.Type == providerType {
+						resources = append(resources, resource)
+					}
+				}
+			}
+		} else {
+			resources = t.Resources
+		}
+		return resources
+	default:
+		return resources
+	}
+}
+
+func appendTemplates(templates []*Template, files map[string][]byte, override bool) ([]*Template, error) {
+	for file, body := range files {
+		template := &Template{
+			File:      file,
+			Resources: []*Resource{},
+		}
+		var ret map[string]map[string]interface{}
+		root, err := parser.Parse(body)
+		if err != nil {
+			return nil, err
+		}
+		if err := hcl.DecodeObject(&ret, root); err != nil {
+			return nil, err
+		}
+
+		for resourceType, typeResources := range ret["resource"] {
+			for _, typeResource := range typeResources.([]map[string]interface{}) {
+				for key, attrs := range typeResource {
+					var newResource bool = true
+					var resourceItem *ast.ObjectItem = root.Node.(*ast.ObjectList).Filter("resource", resourceType, key).Items[0]
+					var resourcePos token.Pos = resourceItem.Val.Pos()
+					resourcePos.Filename = file
+					resource := &Resource{
+						File:  file,
+						Type:  resourceType,
+						Id:    key,
+						Pos:   resourcePos,
+						Attrs: map[string]*Attribute{},
+					}
+
+					if override {
+						for _, temp := range templates {
+							if res := temp.Find("resource", resourceType, key); len(res) != 0 {
+								resource = res[0]
+								newResource = false
+								break
+							}
+						}
+					}
+
+					for _, attr := range attrs.([]map[string]interface{}) {
+						for k := range attr {
+							for _, attrToken := range resourceItem.Val.(*ast.ObjectType).List.Filter(k).Items {
+								if resource.Attrs[k] == nil || override {
+									resource.Attrs[k] = &Attribute{}
+								}
+								// The case of multiple specifiable keys such as `ebs_block_device`.
+								resource.Attrs[k].Vals = append(resource.Attrs[k].Vals, getToken(file, attrToken.Val))
+								pos := attrToken.Val.Pos()
+								pos.Filename = file
+								resource.Attrs[k].Poses = append(resource.Attrs[k].Poses, pos)
+							}
+						}
+					}
+
+					if newResource {
+						template.Resources = append(template.Resources, resource)
+					}
+				}
+			}
+		}
+
+		if !override {
+			templates = append(templates, template)
+		}
+	}
+
+	return templates, nil
+}
+
+func getToken(file string, node interface{}) interface{} {
+	// attr = "literal"
+	if v, ok := node.(*ast.LiteralType); ok {
+		v.Token.Pos.Filename = file
+		// token.Token{}
+		return v.Token
+	}
+	// attr = ["elem1", "elem2"]
+	if v, ok := node.(*ast.ListType); ok {
+		tokens := []interface{}{}
+		for _, childNode := range v.List {
+			tokens = append(tokens, getToken(file, childNode))
+		}
+		// []token.Token{}
+		return tokens
+	}
+	// attr = {
+	//   "key" = "value"
+	// }
+	if v, ok := node.(*ast.ObjectType); ok {
+		tokenMap := map[string]interface{}{}
+		for _, item := range v.List.Items {
+			tokenMap[item.Keys[0].Token.Text] = getToken(file, item.Val)
+		}
+		// map[string]token.Token{}
+		return tokenMap
+	}
+	// Unexpected node pattern
+	return token.Token{}
+}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -1,0 +1,364 @@
+package schema
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/hashicorp/hcl/hcl/token"
+	"github.com/k0kubun/pp"
+)
+
+func TestMake(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Input  map[string]string
+		Result []*Template
+	}{
+		{
+			Name: "make templates",
+			Input: map[string]string{
+				"test.tf": `
+resource "aws_instance" "web" {
+  ami           = "ami-b73b63a0"
+  instance_type = "t1.2xlarge" # invalid type!
+
+  tags {
+    Name = "HelloWorld"
+  }
+}
+
+resource "aws_instance" "web2" {
+  security_groups = ["sg-1", "sg-2"]
+}
+
+resource "aws_instance2" "web" {
+  root_block_device = {
+    volume_size = "24"
+  }
+}
+`,
+			},
+			Result: []*Template{
+				{
+					File: "test.tf",
+					Resources: []*Resource{
+						{
+							File: "test.tf",
+							Type: "aws_instance2",
+							Id:   "web",
+							Pos: token.Pos{
+								Filename: "test.tf",
+								Offset:   258,
+								Line:     15,
+								Column:   32,
+							},
+							Attrs: map[string]*Attribute{
+								"root_block_device": {
+									Poses: []token.Pos{
+										{
+											Filename: "test.tf",
+											Offset:   282,
+											Line:     16,
+											Column:   23,
+										},
+									},
+									Vals: []interface{}{
+										map[string]interface{}{
+											"volume_size": token.Token{
+												Type: 9,
+												Pos: token.Pos{
+													Filename: "test.tf",
+													Offset:   302,
+													Line:     17,
+													Column:   19,
+												},
+												Text: "\"24\"",
+												JSON: false,
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							File: "test.tf",
+							Type: "aws_instance",
+							Id:   "web",
+							Pos: token.Pos{
+								Filename: "test.tf",
+								Offset:   31,
+								Line:     2,
+								Column:   31,
+							},
+							Attrs: map[string]*Attribute{
+								"ami": {
+									Poses: []token.Pos{
+										{
+											Filename: "test.tf",
+											Offset:   51,
+											Line:     3,
+											Column:   19,
+										},
+									},
+									Vals: []interface{}{
+										token.Token{
+											Type: 9,
+											Pos: token.Pos{
+												Filename: "test.tf",
+												Offset:   51,
+												Line:     3,
+												Column:   19,
+											},
+											Text: "\"ami-b73b63a0\"",
+											JSON: false,
+										},
+									},
+								},
+								"instance_type": {
+									Poses: []token.Pos{
+										{
+											Filename: "test.tf",
+											Offset:   84,
+											Line:     4,
+											Column:   19,
+										},
+									},
+									Vals: []interface{}{
+										token.Token{
+											Type: 9,
+											Pos: token.Pos{
+												Filename: "test.tf",
+												Offset:   84,
+												Line:     4,
+												Column:   19,
+											},
+											Text: "\"t1.2xlarge\"",
+											JSON: false,
+										},
+									},
+								},
+								"tags": {
+									Poses: []token.Pos{
+										{
+											Filename: "test.tf",
+											Offset:   121,
+											Line:     6,
+											Column:   8,
+										},
+									},
+									Vals: []interface{}{
+										map[string]interface{}{
+											"Name": token.Token{
+												Type: 9,
+												Pos: token.Pos{
+													Filename: "test.tf",
+													Offset:   134,
+													Line:     7,
+													Column:   12,
+												},
+												Text: "\"HelloWorld\"",
+												JSON: false,
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							File: "test.tf",
+							Type: "aws_instance",
+							Id:   "web2",
+							Pos: token.Pos{
+								Filename: "test.tf",
+								Offset:   185,
+								Line:     11,
+								Column:   32,
+							},
+							Attrs: map[string]*Attribute{
+								"security_groups": {
+									Poses: []token.Pos{
+										{
+											Filename: "test.tf",
+											Offset:   207,
+											Line:     12,
+											Column:   21,
+										},
+									},
+									Vals: []interface{}{
+										[]interface{}{
+											token.Token{
+												Type: 9,
+												Pos: token.Pos{
+													Filename: "test.tf",
+													Offset:   208,
+													Line:     12,
+													Column:   22,
+												},
+												Text: "\"sg-1\"",
+												JSON: false,
+											},
+											token.Token{
+												Type: 9,
+												Pos: token.Pos{
+													Filename: "test.tf",
+													Offset:   216,
+													Line:     12,
+													Column:   30,
+												},
+												Text: "\"sg-2\"",
+												JSON: false,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "override template",
+			Input: map[string]string{
+				"test.tf": `
+resource "aws_instance" "web" {
+  ami           = "ami-b73b63a0"
+  instance_type = "t1.2xlarge" # invalid type!
+
+  tags {
+    Name = "HelloWorld"
+  }
+}
+`,
+				"test_override.tf": `
+resource "aws_instance" "web" {
+  ami           = "ami-override"
+  instance_type = "t2.nano"
+
+  tags {
+    Version = "0.1"
+  }
+}
+`,
+				"override.tf": `
+resource "aws_instance" "web" {
+  instance_type = "t2.micro"
+}
+`,
+			},
+			Result: []*Template{
+				{
+					File: "test.tf",
+					Resources: []*Resource{
+						{
+							File: "test.tf",
+							Type: "aws_instance",
+							Id:   "web",
+							Pos: token.Pos{
+								Filename: "test.tf",
+								Offset:   31,
+								Line:     2,
+								Column:   31,
+							},
+							Attrs: map[string]*Attribute{
+								"ami": {
+									Poses: []token.Pos{
+										{
+											Filename: "test_override.tf",
+											Offset:   51,
+											Line:     3,
+											Column:   19,
+										},
+									},
+									Vals: []interface{}{
+										token.Token{
+											Type: 9,
+											Pos: token.Pos{
+												Filename: "test_override.tf",
+												Offset:   51,
+												Line:     3,
+												Column:   19,
+											},
+											Text: "\"ami-override\"",
+											JSON: false,
+										},
+									},
+								},
+								"instance_type": {
+									Poses: []token.Pos{
+										{
+											Filename: "test_override.tf",
+											Offset:   84,
+											Line:     4,
+											Column:   19,
+										},
+									},
+									Vals: []interface{}{
+										token.Token{
+											Type: 9,
+											Pos: token.Pos{
+												Filename: "test_override.tf",
+												Offset:   84,
+												Line:     4,
+												Column:   19,
+											},
+											Text: "\"t2.nano\"",
+											JSON: false,
+										},
+									},
+								},
+								"tags": {
+									Poses: []token.Pos{
+										{
+											Filename: "test_override.tf",
+											Offset:   102,
+											Line:     6,
+											Column:   8,
+										},
+									},
+									Vals: []interface{}{
+										map[string]interface{}{
+											"Version": token.Token{
+												Type: 9,
+												Pos: token.Pos{
+													Filename: "test_override.tf",
+													Offset:   118,
+													Line:     7,
+													Column:   15,
+												},
+												Text: "\"0.1\"",
+												JSON: false,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		files := map[string][]byte{}
+		for filename, body := range tc.Input {
+			files[filename] = []byte(body)
+		}
+		templates, err := Make(files)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, template := range templates {
+			sort.Slice(template.Resources, func(i, j int) bool {
+				return template.Resources[i].Type+template.Resources[i].Id < template.Resources[j].Type+template.Resources[j].Id
+			})
+		}
+
+		if !reflect.DeepEqual(templates, tc.Result) {
+			t.Fatalf("\nBad: %s\nExpected: %s\n\ntestcase: %s", pp.Sprint(templates), pp.Sprint(tc.Result), tc.Name)
+		}
+	}
+}


### PR DESCRIPTION
Fix #103 

Currently, TFLint takes a direct reference to the interface provided by [hashicorp/hcl](https://github.com/hashicorp/hcl). But, In this approach, handling of override is very difficult.

As a countermeasure for this problem, introduce `schema` package. In this approach, all access to HCL is through this package. So, override implementation is in this package.