### PR TITLE
Report `aws_instance_not_specified_iam_profile` only when `terraform_version` is less than 0.8.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Try running TFLint under the directory where Terraform is executed. It detect if
 ```
 $ tflint
 template.tf
-        NOTICE:1 "iam_instance_profile" is not specified. If you want to change it, you need to recreate instance. (Only less than Terraform 0.8.8)
+        NOTICE:1 "iam_instance_profile" is not specified. If you want to change it, you need to recreate the instance.
         ERROR:3 "t1.2xlarge" is invalid instance type.
 
 Result: 2 issues  (1 errors , 0 warnings , 1 notices)

--- a/docs/aws_instance_not_specified_iam_profile.md
+++ b/docs/aws_instance_not_specified_iam_profile.md
@@ -18,7 +18,7 @@ The following is the execution result of TFLint:
 ```
 $ tflint
 template.tf
-        NOTICE:1 "iam_instance_profile" is not specified. If you want to change it, you need to recreate instance. (Only less than Terraform 0.8.8)
+        NOTICE:1 "iam_instance_profile" is not specified. If you want to change it, you need to recreate the instance.
 
 Result: 1 issues  (0 errors , 0 warnings , 1 notices)
 ```
@@ -28,7 +28,7 @@ You can select only one IAM profile at instance setup. However, if you do not se
 
 Even if you think that you do not need an IAM profile, we recommend that you specify a dummy. Then you can change the privilege when you need it, so you can escape the recreate of the instance.
 
-NOTE: There is good news that Terraform 0.8.8 and later can change it later. However, it is better to give proper authority from the beginning. If you change it later, there is a possibility that your application may have unexpected effects.
+NOTE: There is good news that Terraform 0.8.8 and later can change it later. If `terraform_version` is greater than `0.8.8`, This issue is not reported.
 
 ## How To Fix
 Please add `iam_instance_profile` attribute.

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a877232f32e3186a58aecd016a18032815be2ee1f3dc52a7240367b46ddc76ca
-updated: 2017-04-15T17:08:16.557042621+09:00
+hash: 7dcc19395a7ae20cd2d8d2bf57ec53525774185572a387ba791f3b4349aff73b
+updated: 2017-07-09T14:47:09.476933057+09:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 7be45195c3af1b54a609812f90c05a7e492e2491
@@ -47,6 +47,8 @@ imports:
   version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
   subpackages:
   - gomock
+- name: github.com/hashicorp/go-version
+  version: 03c5bf6be031b6dd45afec16b1cf94fc8938bc77
 - name: github.com/hashicorp/hcl
   version: 630949a3c5fa3c613328e1b8256052cbc2327c9b
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -30,3 +30,4 @@ import:
 - package: github.com/mitchellh/go-homedir
 - package: github.com/jessevdk/go-flags
   version: ^1.2.0
+- package: github.com/hashicorp/go-version

--- a/integration/general/result.json
+++ b/integration/general/result.json
@@ -26,7 +26,7 @@
   {
     "detector": "aws_instance_not_specified_iam_profile",
     "type": "NOTICE",
-    "message": "\"iam_instance_profile\" is not specified. If you want to change it, you need to recreate instance. (Only less than Terraform 0.8.8)",
+    "message": "\"iam_instance_profile\" is not specified. If you want to change it, you need to recreate the instance.",
     "line": 5,
     "file": "github.com/wata727/example-module/aws_instance.tf",
     "link": "https://github.com/wata727/tflint/blob/master/docs/aws_instance_not_specified_iam_profile.md"


### PR DESCRIPTION
The target of `aws_instance_not_specified_iam_profile` detector is when using Terraform less than 0.8.8. ref: https://github.com/wata727/tflint/pull/81

By using the newly introduced `terraform_version`, TFLint will not report this issue unless conditions are satisfied. If it is not set, It is reported as before.