### PR TITLE
Fix panic for integer variables interpolation

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -74,6 +74,16 @@ variable "name" {
 			Result: "test",
 		},
 		{
+			Name: "completed integer variable",
+			Input: `
+variable "name" {
+    type = "string"
+    default = 1
+}`,
+			Src:    "${var.name}",
+			Result: "1",
+		},
+		{
 			Name: "completed list variable",
 			Input: `
 variable "name" {
@@ -104,6 +114,15 @@ variable "name" {
 }`,
 			Src:    "${var.name}",
 			Result: "test",
+		},
+		{
+			Name: "integer variable in missing type",
+			Input: `
+variable "name" {
+    default = 1
+}`,
+			Src:    "${var.name}",
+			Result: "1",
 		},
 		{
 			Name: "list variable in missing key",

--- a/evaluator/variable.go
+++ b/evaluator/variable.go
@@ -3,6 +3,8 @@ package evaluator
 import (
 	"reflect"
 
+	"fmt"
+
 	"github.com/hashicorp/hcl"
 	hclast "github.com/hashicorp/hcl/hcl/ast"
 	hilast "github.com/hashicorp/hil/ast"
@@ -99,7 +101,7 @@ func parseVariable(val interface{}, varType string) hilast.Variable {
 	case HCL_STRING_VARTYPE:
 		hilVar = hilast.Variable{
 			Type:  hilast.TypeString,
-			Value: val,
+			Value: fmt.Sprint(val),
 		}
 	case HCL_MAP_VARTYPE:
 		// When HCL map var convert(parse) to Go var,

--- a/evaluator/variable_test.go
+++ b/evaluator/variable_test.go
@@ -539,11 +539,11 @@ func TestParseVariable(t *testing.T) {
 						Value: map[string]hilast.Variable{
 							"test3": {
 								Type:  hilast.TypeString,
-								Value: 1,
+								Value: "1",
 							},
 							"test4": {
 								Type:  hilast.TypeString,
-								Value: 10,
+								Value: "10",
 							},
 						},
 					},


### PR DESCRIPTION
Fix #129 

NOTE: I feel a sense of incompatibility to forcibly convert an integer value to a string value. However, Terraform does not have an attribute that must be an integer type.