### PR TITLE
Add ca-certificates to Docker image for TLS requests to AWS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM alpine:3.5
 
 MAINTAINER wata727
 
+RUN apk add --no-cache ca-certificates
+
 COPY dist/linux_amd64/tflint /usr/local/bin
 
 ENTRYPOINT ["tflint"]


### PR DESCRIPTION
As per https://github.com/wata727/tflint/issues/154