### PR TITLE
Use `strings.Trim` instead of `strings.Replace`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: go
 
 sudo: false
 
-go:
-  - 1.9
-  - tip
+go: 1.9
 
 script:
   - 'make build'

--- a/evaluator/module.go
+++ b/evaluator/module.go
@@ -22,7 +22,7 @@ func (e *Evaluator) initModule(module *schema.Module, c *config.Config) error {
 		if k != "source" {
 			if varToken, ok := module.GetToken(k); ok {
 				varName := "var." + k
-				ev, err := e.evalModuleAttr(k, strings.Replace(varToken.Text, "\"", "", -1))
+				ev, err := e.evalModuleAttr(k, strings.Trim(varToken.Text, "\""))
 				if err != nil {
 					return errors.New(fmt.Sprintf("Evaluation error: %s in %s:%d", err, varToken.Pos.Filename, varToken.Pos.Line))
 				}

--- a/evaluator/module_test.go
+++ b/evaluator/module_test.go
@@ -103,6 +103,41 @@ module "ec2_instance" {
 			Error: false,
 		},
 		{
+			Name: "init module with list in map",
+			Input: `
+variable "amis" {
+    default = {
+        test1 = ["ami-12345", "ami-54321"]
+        test2 = ["ami-123ab", "ami-abc12"]
+    }
+}
+
+module "ec2_instance" {
+    source = "./tf_aws_ec2_instance"
+    ami = "${var.amis["test1"]}"
+}`,
+			Result: hil.EvalConfig{
+				GlobalScope: &hilast.BasicScope{
+					VarMap: map[string]hilast.Variable{
+						"var.ami": {
+							Type: hilast.TypeList,
+							Value: []hilast.Variable{
+								{
+									Type:  hilast.TypeString,
+									Value: "ami-12345",
+								},
+								{
+									Type:  hilast.TypeString,
+									Value: "ami-54321",
+								},
+							},
+						},
+					},
+				},
+			},
+			Error: false,
+		},
+		{
 			Name: "init module with map variable",
 			Input: `
 variable "ami_info" {


### PR DESCRIPTION
Fixes https://github.com/wata727/tflint/issues/157

## Problem

If there is access to a map element using a key as module attributes, an evaluation error occurred. 

The string obtained from the token contains unnecessary double quotes. Therefore, it deletes this, but until now it deletes even the necessary double quotes.

```
"\"${var.ami_info}\"" => "${var.ami_info}"
```

```
"\"${var.amis[\"test1\"]}\" => "${var.amis[test1]}" # Oops!
```

## Solution

Remove all leading and trailing double quotes. In other words, use `strings.Trim` instead of `strings.Replace`.
