### PR TITLE
Ignore module initialization when settings `ignore_module`

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -36,6 +36,10 @@ func NewEvaluator(templates map[string]*hclast.File, schema []*schema.Template, 
 
 	for _, template := range schema {
 		for _, module := range template.Modules {
+			if c.IgnoreModule[module.ModuleSource] {
+				continue
+			}
+
 			if err := evaluator.initModule(module, c); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Ref: https://github.com/wata727/tflint/pull/161

There was no way to solve it when module detection failed due to TFLint problem. This p-r also applies `ignore_module` to module initialization.

## Before
```
$ tflint --ignore-module=hashicorp/consule/aws
ERROR: module `hashicorp/consul/aws` not found. Did you run `terraform get`?
```

## After
```
$ tflint --ignore-module=hashicorp/consule/aws
Awesome! Your code is following the best practices :)
```