### PR TITLE
Accept glob and multiple input

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -96,13 +96,20 @@ func (cli *CLI) Run(args []string) int {
 	cli.loader.LoadState()
 	cli.loader.LoadTFVars(c.Varfile)
 	if len(args) > 1 {
-		err = cli.loader.LoadTemplate(args[1])
+		for i, file := range args {
+			if i == 0 {
+				continue
+			}
+			if err = cli.loader.LoadTemplate(file); err != nil {
+				fmt.Fprintln(cli.errStream, err)
+				return ExitCodeError
+			}
+		}
 	} else {
-		err = cli.loader.LoadAllTemplate(".")
-	}
-	if err != nil {
-		fmt.Fprintln(cli.errStream, err)
-		return ExitCodeError
+		if err = cli.loader.LoadAllTemplate("."); err != nil {
+			fmt.Fprintln(cli.errStream, err)
+			return ExitCodeError
+		}
 	}
 
 	// If disabled test mode, generates real detector

--- a/cli_test.go
+++ b/cli_test.go
@@ -185,6 +185,24 @@ func TestCLIRun(t *testing.T) {
 			},
 		},
 		{
+			Name:    "load multiple file",
+			Command: "./tflint template1.tf template2.tf",
+			LoaderGenerator: func(ctrl *gomock.Controller) loader.LoaderIF {
+				loader := mock.NewMockLoaderIF(ctrl)
+				loader.EXPECT().LoadState()
+				loader.EXPECT().LoadTFVars([]string{"terraform.tfvars"})
+				loader.EXPECT().LoadTemplate("template1.tf").Return(nil)
+				loader.EXPECT().LoadTemplate("template2.tf").Return(nil)
+				return loader
+			},
+			DetectorGenerator: detectorNoErrorNoIssuesBehavior,
+			PrinterGenerator:  printerNoIssuesDefaultBehaviour,
+			Result: Result{
+				Status:     ExitCodeOK,
+				CLIOptions: defaultCLIOptions,
+			},
+		},
+		{
 			Name:    "load single file when occurred loading error",
 			Command: "./tflint test_template.tf",
 			LoaderGenerator: func(ctrl *gomock.Controller) loader.LoaderIF {


### PR DESCRIPTION
Fixes #169 

These changes allow using glob pattern and multiple files as arguments. For example:

```
$ tflint dev/*.tf
```

```
$ tflint dev/template.tf dev/variable.tf
```