### PR TITLE
Fallback to config under the home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,12 @@ Help Options:
 ```
 
 ## Configuration
-By default, TFLint loads `.tflint.hcl` under the current directory. The configuration file is described in [HCL](https://github.com/hashicorp/hcl), and options available on the command line can be described in advance. Following example:
+By default, TFLint loads `.tflint.hcl` according to the following priority:
+
+- Current directory (`./.tflint.hcl`)
+- Home directory (`~/.tflint.hcl`)
+
+The configuration file is described in [HCL](https://github.com/hashicorp/hcl), and options available on the command line can be described in advance. Following example:
 
 ```hcl
 config {

--- a/cli.go
+++ b/cli.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	flags "github.com/jessevdk/go-flags"
+	homedir "github.com/mitchellh/go-homedir"
 
 	"github.com/wata727/tflint/config"
 	"github.com/wata727/tflint/detector"
@@ -147,7 +148,11 @@ func (cli *CLI) setupConfig(opts CLIOptions) (*config.Config, error) {
 	if opts.Debug {
 		c.Debug = true
 	}
-	if err := c.LoadConfig(opts.Config); err != nil {
+	fallbackConfig, err := homedir.Expand("~/.tflint.hcl")
+	if err != nil {
+		return nil, err
+	}
+	if err := c.LoadConfig(opts.Config, fallbackConfig); err != nil {
 		return nil, err
 	}
 	if opts.Deep || c.DeepCheck {


### PR DESCRIPTION
Fixes #173 

After these changes, TFLint loads `.tflint.hcl` under the home directory when a configuration file is missing.