### PR TITLE
Fix interpolation checking

### DIFF
--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -37,7 +37,7 @@ func TestIsEvaluable(t *testing.T) {
 			Result: false,
 		},
 		{
-			Name:   "function syntax",
+			Name:   "unsupported function syntax",
 			Input:  "${lookup(var.roles, count.index)}",
 			Result: false,
 		},
@@ -45,6 +45,16 @@ func TestIsEvaluable(t *testing.T) {
 			Name:   "terraform metadata syntax",
 			Input:  "${terraform.env}",
 			Result: true,
+		},
+		{
+			Name:   "complex syntax including var syntax",
+			Input:  "Hello ${var.world}",
+			Result: true,
+		},
+		{
+			Name:   "complex syntax including unsupported function",
+			Input:  "${var.text} ${lookup(var.roles, count.index)}",
+			Result: false,
 		},
 	}
 

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -155,6 +155,16 @@ variable "name" {
 			Src:    "${var.name[\"key\"]}",
 			Result: "test1",
 		},
+		{
+			Name: "conditional",
+			Input: `
+variable "name" {
+    type = "string"
+    default = "prod"
+}`,
+			Src:    "${var.name == \"prod\" ? \"production\" : \"development\"}",
+			Result: "production",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fixes https://github.com/wata727/tflint/issues/170
Fixes https://github.com/wata727/tflint/issues/187

Modify the validation logic of expressions that TFLint can evaluate. Until now, it had been judge the expression is evaluable if contains `var` or `terraform` syntax. (Even if it contains an unevaluable function such as `replace`)

These changes makes it strictly perform this check to avoid errors. I considered incorporating [Terraform's build-in functions](https://github.com/hashicorp/terraform/blob/0cc9e050ecd4a46ba6448758c2edc0b29bef5695/config/interpolate_funcs.go#L62), but [the vendoring type problem](https://forum.golangbridge.org/t/version-mismatch-between-vendored-version-of-dependency-and-normal-version/4073) disturbs me... Built-in functions will become available after refactoring assuming HCL2.
