### PR TITLE
Detect pinned sources using regular expressions

### DIFF
--- a/detector/terraform_module_pinned_source.go
+++ b/detector/terraform_module_pinned_source.go
@@ -2,6 +2,7 @@ package detector
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/wata727/tflint/issue"
@@ -25,11 +26,15 @@ func (d *Detector) CreateTerraformModulePinnedSourceDetector() *TerraformModuleP
 func (d *TerraformModulePinnedSourceDetector) Detect(module *schema.Module, issues *[]*issue.Issue) {
 	lower := strings.ToLower(module.ModuleSource)
 
-	if strings.Contains(lower, "git") || strings.Contains(lower, "bitbucket") {
+	reGithub := regexp.MustCompile("(^github.com/(.+)/(.+)$)|(^git@github.com:(.+)/(.+)$)")
+	reBitbucket := regexp.MustCompile("^bitbucket.org/(.+)/(.+)$")
+	reGenericGit := regexp.MustCompile("(git://(.+)/(.+))|(git::https://(.+)/(.+))|(git::ssh://((.+)@)??(.+)/(.+)/(.+))")
+
+	if reGithub.MatchString(lower) || reBitbucket.MatchString(lower) || reGenericGit.MatchString(lower) {
 		if issue := d.detectGitSource(module); issue != nil {
 			*issues = append(*issues, issue)
 		}
-	} else if strings.HasPrefix(lower, "hg:") {
+	} else if strings.HasPrefix(lower, "hg::") {
 		if issue := d.detectMercurialSource(module); issue != nil {
 			*issues = append(*issues, issue)
 		}

--- a/detector/terraform_module_pinned_source_test.go
+++ b/detector/terraform_module_pinned_source_test.go
@@ -143,6 +143,96 @@ module "pinned git" {
 			Issues: []*issue.Issue{},
 		},
 		{
+			Name: "generic git (git::https) module reference is not pinned",
+			Src: `
+module "unpinned generic git https" {
+  source = "git::https://hashicorp.com/consul.git"
+}
+`,
+			Issues: []*issue.Issue{
+				{
+					Detector: "terraform_module_pinned_source",
+					Type:     "WARNING",
+					Message:  "Module source \"git::https://hashicorp.com/consul.git\" is not pinned",
+					Line:     3,
+					File:     "test.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/terraform_module_pinned_source.md",
+				},
+			},
+		},
+		{
+			Name: "generic git (git::ssh) module reference is not pinned",
+			Src: `
+module "unpinned generic git ssh" {
+  source = "git::ssh://git@github.com/owner/repo.git"
+}
+`,
+			Issues: []*issue.Issue{
+				{
+					Detector: "terraform_module_pinned_source",
+					Type:     "WARNING",
+					Message:  "Module source \"git::ssh://git@github.com/owner/repo.git\" is not pinned",
+					Line:     3,
+					File:     "test.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/terraform_module_pinned_source.md",
+				},
+			},
+		},
+		{
+			Name: "generic git (git::https) module reference is default",
+			Src: `
+module "default generic git https" {
+  source = "git::https://hashicorp.com/consul.git?ref=master"
+}
+`,
+			Issues: []*issue.Issue{
+				{
+					Detector: "terraform_module_pinned_source",
+					Type:     "WARNING",
+					Message:  "Module source \"git::https://hashicorp.com/consul.git?ref=master\" uses default ref \"master\"",
+					Line:     3,
+					File:     "test.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/terraform_module_pinned_source.md",
+				},
+			},
+		},
+		{
+			Name: "generic git (git::ssh) module reference is default",
+			Src: `
+module "default generic git ssh" {
+  source = "git::ssh://git@github.com/owner/repo.git?ref=master"
+}
+`,
+			Issues: []*issue.Issue{
+				{
+					Detector: "terraform_module_pinned_source",
+					Type:     "WARNING",
+					Message:  "Module source \"git::ssh://git@github.com/owner/repo.git?ref=master\" uses default ref \"master\"",
+					Line:     3,
+					File:     "test.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/terraform_module_pinned_source.md",
+				},
+			},
+		},
+		{
+			Name: "generic git (git::https) module reference is pinned",
+			Src: `
+module "pinned generic git https" {
+  source = "git::https://hashicorp.com/consul.git?ref=pinned"
+}
+`,
+			Issues: []*issue.Issue{},
+		},
+		{
+			Name: "generic git (git::ssh) module reference is pinned",
+			Src: `
+module "pinned generic git ssh" {
+  source = "git::ssh://git@github.com/owner/repo.git?ref=pinned"
+}
+`,
+			Issues: []*issue.Issue{},
+		},
+		{
 			Name: "mercurial module is not pinned",
 			Src: `
 module "default mercurial" {


### PR DESCRIPTION
Resolves #193 

- Substitutes `strings.Contains` for `regexp.MatchString`
- Uses `regexp.MustCompile` as regexp is checked during tests
- Adds tests for generic git repositories with HTTPS and SSH formats