### PR TITLE
Add new TerraformResourceExplicitProviderDetector

### DIFF
--- a/detector/detector.go
+++ b/detector/detector.go
@@ -83,6 +83,7 @@ var detectorFactories = []string{
 	"CreateAwsCloudWatchMetricAlarmInvalidUnitDetector",
 	"CreateAwsECSClusterDuplicateNameDetector",
 	"CreateTerraformModulePinnedSourceDetector",
+	"CreateTerraformResourceExplicitProviderDetector",
 }
 
 func NewDetector(templates map[string]*ast.File, schema []*schema.Template, state *state.TFState, tfvars []*ast.File, c *config.Config) (*Detector, error) {

--- a/detector/terraform_resource_explicit_provider.go
+++ b/detector/terraform_resource_explicit_provider.go
@@ -1,0 +1,39 @@
+package detector
+
+import (
+	"fmt"
+
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/schema"
+)
+
+type TerraformResourceExplicitProviderDetector struct {
+	*Detector
+}
+
+func (d *Detector) CreateTerraformResourceExplicitProviderDetector() *TerraformResourceExplicitProviderDetector {
+	nd := &TerraformResourceExplicitProviderDetector{Detector: d}
+	nd.Name = "terraform_resource_explicit_provider"
+	nd.IssueType = issue.WARNING
+	nd.TargetType = "resource"
+	nd.Target = ""
+	nd.DeepCheck = false
+	nd.Link = "https://github.com/wata727/tflint/blob/master/docs/terraform_resource_explicit_provider.md"
+	nd.Enabled = false
+	return nd
+}
+
+func (d *TerraformResourceExplicitProviderDetector) Detect(resource *schema.Resource, issues *[]*issue.Issue) {
+	_, ok := resource.GetToken("provider")
+	if !ok {
+		issue := &issue.Issue{
+			Detector: d.Name,
+			Type:     d.IssueType,
+			Message:  fmt.Sprintf("Resource \"%s\" provider is implicit", resource.Id),
+			Line:     resource.Pos.Line,
+			File:     resource.Pos.Filename,
+			Link:     d.Link,
+		}
+		*issues = append(*issues, issue)
+	}
+}

--- a/detector/terraform_resource_explicit_provider_test.go
+++ b/detector/terraform_resource_explicit_provider_test.go
@@ -1,0 +1,75 @@
+package detector
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/k0kubun/pp"
+	"github.com/wata727/tflint/config"
+	"github.com/wata727/tflint/issue"
+)
+
+func TestDetectTerraformResourceExplicitProvider(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Src    string
+		Issues []*issue.Issue
+	}{
+		{
+			Name: "implicit provider",
+			Src: `
+resource "aws_instance" "web" {
+  ami           = "ami-b73b63a0"
+  instance_type = "t2.micro"
+
+  tags {
+    Name = "HelloWorld"
+  }
+}`,
+			Issues: []*issue.Issue{
+				{
+					Detector: "terraform_resource_explicit_provider",
+					Type:     "WARNING",
+					Message:  "Resource \"web\" provider is implicit",
+					Line:     2,
+					File:     "test.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/terraform_resource_explicit_provider.md",
+				},
+			},
+		},
+		{
+			Name: "explicit provider",
+			Src: `
+resource "aws_instance" "web" {
+  provider = "aws.west"
+
+  ami           = "ami-b73b63a0"
+  instance_type = "t2.micro"
+
+  tags {
+    Name = "HelloWorld"
+  }
+}`,
+			Issues: []*issue.Issue{},
+		},
+	}
+
+	for _, tc := range cases {
+		var issues = []*issue.Issue{}
+		err := TestDetectByCreatorName(
+			"CreateTerraformResourceExplicitProviderDetector",
+			tc.Src,
+			"",
+			config.Init(),
+			config.Init().NewAwsClient(),
+			&issues,
+		)
+		if err != nil {
+			t.Fatalf("\nERROR: %s", err)
+		}
+
+		if !reflect.DeepEqual(issues, tc.Issues) {
+			t.Fatalf("\nBad: %s\nExpected: %s\n\ntestcase: %s", pp.Sprint(issues), pp.Sprint(tc.Issues), tc.Name)
+		}
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,12 @@ Issues are classified into the following three types.
 - **Terraform**
     - [terraform_module_pinned_source](terraform_module_pinned_source.md)
 
+### Default Disabled Issue
+These rules are not always useful, so they are disabled by default. If you want to check the following, enabled the rule in configuration file.
+
+- **Terraform**
+    - [terraform_resource_explicit_provider](terraform_resource_explicit_provider.md)
+
 ### Invalid Reference Issue
 Report these issues if you have specified invalid resource ID, name, etc. All issues are reported as ERROR. These issues are reported when enabled deep check. In many cases, an incorrect value is specified, so please fix it.
 

--- a/docs/terraform_resource_explicit_provider.md
+++ b/docs/terraform_resource_explicit_provider.md
@@ -1,0 +1,56 @@
+# Terraform Resource Explicit Provider
+This issue is reported if you don't set `provider` in resources explicitly. This rule is disabled by default.
+
+## Example
+```hcl
+provider "aws" {
+  alias  = "west"
+  region = "us-west-1"
+}
+
+resource "aws_instance" "web" {
+  ami           = "ami-b73b63a0"
+  instance_type = "t2.micro"
+
+  tags {
+    Name = "HelloWorld"
+  }
+}
+```
+
+The following is execution result of TFLint:
+
+```
+$ tflint
+template.tf
+        WARNING:1 Resource "web" provider is implicit (terraform_resource_explicit_provider)
+
+Result: 1 issues  (0 errors , 1 warnings , 0 notices)
+```
+
+## Why
+
+Resources are normally associated with the default provider configuration inferred from the resource type name.
+However, If you use multiple providers, you must explicitly specify the provider on each resource if you do not prepare defaults.
+
+## How To Fix
+
+Specify `provider` in the resource explicitly.
+
+```hcl
+provider "aws" {
+  alias  = "west"
+  region = "us-west-1"
+}
+
+resource "aws_instance" "web" {
+  provider = "aws.west"
+
+  ami           = "ami-b73b63a0"
+  instance_type = "t2.micro"
+
+  tags {
+    Name = "HelloWorld"
+  }
+}
+```


### PR DESCRIPTION
Fixes #178 

This rule enforces describing `provider` in all resources. If using multiple providers (without default provider), each resource block requires `provider` explicitly.

However, this rule is noisy for users who use default provider. For that reason, this rule is disabled by default. If you want to check about this, enabled this rule in configuration like the following:

```hcl
rule "terraform_resource_explicit_provider" {
    enabled = true
}
```

cc @sean-abbott