### PR TITLE
Use standard logger instead of custom logger

### DIFF
--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -1,16 +1,11 @@
 package tflint
 
 import (
-	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/hashicorp/hcl2/hcl"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -748,44 +743,4 @@ resource "null_resource" "test" {
 			}
 		}
 	}
-}
-
-func loadConfigHelper(dir string) (*configs.Config, error) {
-	loader, err := configload.NewLoader(&configload.Config{})
-	if err != nil {
-		return nil, err
-	}
-
-	mod, diags := loader.Parser().LoadConfigDir(dir)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-	cfg, diags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	return cfg, nil
-}
-
-func extractAttributeHelper(key string, cfg *configs.Config) (*hcl.Attribute, error) {
-	resource := cfg.Module.ManagedResources["null_resource.test"]
-	if resource == nil {
-		return nil, errors.New("Expected resource is not found")
-	}
-	body, _, diags := resource.Config.PartialContent(&hcl.BodySchema{
-		Attributes: []hcl.AttributeSchema{
-			{
-				Name: key,
-			},
-		},
-	})
-	if diags.HasErrors() {
-		return nil, diags
-	}
-	attribute := body.Attributes[key]
-	if attribute == nil {
-		return nil, fmt.Errorf("Expected attribute is not found: %s", key)
-	}
-	return attribute, nil
 }

--- a/tflint/terraform.go
+++ b/tflint/terraform.go
@@ -3,6 +3,7 @@ package tflint
 import (
 	"bytes"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,7 +14,9 @@ import (
 
 func getTFDataDir() string {
 	dir := os.Getenv("TF_DATA_DIR")
-	if dir == "" {
+	if dir != "" {
+		log.Printf("[INFO] TF_DATA_DIR environment variable found: %s", dir)
+	} else {
 		dir = ".terraform"
 	}
 
@@ -30,12 +33,15 @@ func getTFModuleManifestPath() string {
 
 func getTFWorkspace() string {
 	if envVar := os.Getenv("TF_WORKSPACE"); envVar != "" {
+		log.Printf("[INFO] TF_WORKSPACE environment variable found: %s", envVar)
 		return envVar
 	}
 
 	envData, _ := ioutil.ReadFile(filepath.Join(getTFDataDir(), "environment"))
 	current := string(bytes.TrimSpace(envData))
-	if current == "" {
+	if current != "" {
+		log.Printf("[INFO] environment file found: %s", current)
+	} else {
 		current = "default"
 	}
 
@@ -50,6 +56,7 @@ func getTFEnvVariables() terraform.InputValues {
 		envVal := e[idx+1:]
 
 		if strings.HasPrefix(envKey, "TF_VAR_") {
+			log.Printf("[INFO] TF_VAR_* environment variable found: key=%s, value=%s", envKey, envVal)
 			varName := strings.Replace(envKey, "TF_VAR_", "", 1)
 
 			envVariables[varName] = &terraform.InputValue{

--- a/tflint/tflint_test.go
+++ b/tflint/tflint_test.go
@@ -1,0 +1,59 @@
+package tflint
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+)
+
+func TestMain(m *testing.M) {
+	log.SetOutput(ioutil.Discard)
+	os.Exit(m.Run())
+}
+
+func loadConfigHelper(dir string) (*configs.Config, error) {
+	loader, err := configload.NewLoader(&configload.Config{})
+	if err != nil {
+		return nil, err
+	}
+
+	mod, diags := loader.Parser().LoadConfigDir(dir)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	cfg, diags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	return cfg, nil
+}
+
+func extractAttributeHelper(key string, cfg *configs.Config) (*hcl.Attribute, error) {
+	resource := cfg.Module.ManagedResources["null_resource.test"]
+	if resource == nil {
+		return nil, errors.New("Expected resource is not found")
+	}
+	body, _, diags := resource.Config.PartialContent(&hcl.BodySchema{
+		Attributes: []hcl.AttributeSchema{
+			{
+				Name: key,
+			},
+		},
+	})
+	if diags.HasErrors() {
+		return nil, diags
+	}
+	attribute := body.Attributes[key]
+	if attribute == nil {
+		return nil, fmt.Errorf("Expected attribute is not found: %s", key)
+	}
+	return attribute, nil
+}


### PR DESCRIPTION
As a part of refactoring, use standard logger instead of custom (existing) logger. Ultimately, existing loggers will be removed.

The caller's output can be substituted with `log.SetFlag(log.stdFlags | log.Longfile)`. Also, by introducing [`hashicorp/logutils`](https://github.com/hashicorp/logutils), we can control the log level. This package is used by callers of Runner and Loader (perhaps it will be the main package).

Along with that, the `--debug` option will be removed, and the user will specify the log level via environment variables and so on.