### PR TITLE
Handle resources and modules with Terraform's configs package

### DIFF
--- a/client/aws.go
+++ b/client/aws.go
@@ -1,0 +1,85 @@
+package client
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/aws/aws-sdk-go/service/elasticache/elasticacheiface"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elb/elbiface"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/wata727/tflint/config"
+)
+
+// AwsClient is a wrapper of the AWS SDK client
+// It has interfaces for each services to make testing easier
+type AwsClient struct {
+	IAM         iamiface.IAMAPI
+	EC2         ec2iface.EC2API
+	RDS         rdsiface.RDSAPI
+	ElastiCache elasticacheiface.ElastiCacheAPI
+	ELB         elbiface.ELBAPI
+	ELBV2       elbv2iface.ELBV2API
+	ECS         ecsiface.ECSAPI
+}
+
+// NewAwsClient returns new AwsClient with configured session
+func NewAwsClient(cfg *config.Config) *AwsClient {
+	s := newAwsSession(cfg)
+
+	return &AwsClient{
+		IAM:         iam.New(s),
+		EC2:         ec2.New(s),
+		RDS:         rds.New(s),
+		ElastiCache: elasticache.New(s),
+		ELB:         elb.New(s),
+		ELBV2:       elbv2.New(s),
+		ECS:         ecs.New(s),
+	}
+}
+
+// newAwsSession returns a session necessary for initialization of the AWS SDK
+func newAwsSession(cfg *config.Config) *session.Session {
+	s := session.New()
+
+	if cfg.HasAwsRegion() {
+		log.Printf("[INFO] Set AWS region: %s", cfg.AwsCredentials["region"])
+		s = session.New(&aws.Config{
+			Region: aws.String(cfg.AwsCredentials["region"]),
+		})
+	}
+	if cfg.HasAwsSharedCredentials() {
+		log.Printf("[INFO] Set AWS shared credentials")
+		path, err := homedir.Expand("~/.aws/credentials")
+		if err != nil {
+			// Maybe this is bug
+			panic(err)
+		}
+		s = session.New(&aws.Config{
+			Credentials: credentials.NewSharedCredentials(path, cfg.AwsCredentials["profile"]),
+			Region:      aws.String(cfg.AwsCredentials["region"]),
+		})
+	}
+	if cfg.HasAwsStaticCredentials() {
+		log.Printf("[INFO] Set AWS static credentials")
+		s = session.New(&aws.Config{
+			Credentials: credentials.NewStaticCredentials(cfg.AwsCredentials["access_key"], cfg.AwsCredentials["secret_key"], ""),
+			Region:      aws.String(cfg.AwsCredentials["region"]),
+		})
+	}
+
+	return s
+}

--- a/client/aws_test.go
+++ b/client/aws_test.go
@@ -1,0 +1,63 @@
+package client
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/wata727/tflint/config"
+)
+
+func Test_newAwsSession(t *testing.T) {
+	type Result struct {
+		Credentials *credentials.Credentials
+		Region      *string
+	}
+	path, _ := homedir.Expand("~/.aws/credentials")
+
+	cases := []struct {
+		Name     string
+		Config   *config.Config
+		Expected Result
+	}{
+		{
+			Name: "static credentials",
+			Config: &config.Config{
+				AwsCredentials: map[string]string{
+					"access_key": "AWS_ACCESS_KEY",
+					"secret_key": "AWS_SECRET_KEY",
+					"region":     "us-east-1",
+				},
+			},
+			Expected: Result{
+				Credentials: credentials.NewStaticCredentials("AWS_ACCESS_KEY", "AWS_SECRET_KEY", ""),
+				Region:      aws.String("us-east-1"),
+			},
+		},
+		{
+			Name: "shared credentials",
+			Config: &config.Config{
+				AwsCredentials: map[string]string{
+					"profile": "account1",
+					"region":  "us-east-1",
+				},
+			},
+			Expected: Result{
+				Credentials: credentials.NewSharedCredentials(path, "account1"),
+				Region:      aws.String("us-east-1"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		s := newAwsSession(tc.Config)
+		if !reflect.DeepEqual(tc.Expected.Credentials, s.Config.Credentials) {
+			t.Fatalf("Failed `%s` test: expected credentials are `%#v`, but get `%#v`", tc.Name, tc.Expected.Credentials, s.Config.Credentials)
+		}
+		if !reflect.DeepEqual(tc.Expected.Region, s.Config.Region) {
+			t.Fatalf("Failed `%s` test: expected region are `%#v`, but get `%#v`", tc.Name, tc.Expected.Region, s.Config.Region)
+		}
+	}
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,13 @@
+package client
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	log.SetOutput(ioutil.Discard)
+	os.Exit(m.Run())
+}

--- a/rules/awsrules/aws_instance_invalid_ami.go
+++ b/rules/awsrules/aws_instance_invalid_ami.go
@@ -1,0 +1,100 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsInstanceInvalidAMIRule checks whether "aws_instance" has invalid AMI ID
+type AwsInstanceInvalidAMIRule struct {
+	resourceType  string
+	attributeName string
+	amiIDs        map[string]bool
+}
+
+// NewAwsInstanceInvalidAMIRule returns new rule with default attributes
+func NewAwsInstanceInvalidAMIRule() *AwsInstanceInvalidAMIRule {
+	return &AwsInstanceInvalidAMIRule{
+		resourceType:  "aws_instance",
+		attributeName: "ami",
+		amiIDs:        map[string]bool{},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsInstanceInvalidAMIRule) Name() string {
+	return "aws_instance_invalid_ami"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsInstanceInvalidAMIRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether "aws_instance" has invalid AMI ID
+func (r *AwsInstanceInvalidAMIRule) Check(runner *tflint.Runner) error {
+	resources := runner.LookupResourcesByType(r.resourceType)
+	if len(resources) == 0 {
+		return nil
+	}
+
+	resp, err := runner.AwsClient.EC2.DescribeImages(&ec2.DescribeImagesInput{})
+	if err != nil {
+		err := &tflint.Error{
+			Code:    tflint.ExternalAPIError,
+			Level:   tflint.ErrorLevel,
+			Message: "An error occurred while describing images",
+			Cause:   err,
+		}
+		log.Printf("[ERROR] %s", err)
+		return err
+	}
+	for _, image := range resp.Images {
+		r.amiIDs[*image.ImageId] = true
+	}
+
+	for _, resource := range resources {
+		body, _, diags := resource.Config.PartialContent(&hcl.BodySchema{
+			Attributes: []hcl.AttributeSchema{
+				{
+					Name: r.attributeName,
+				},
+			},
+		})
+		if diags.HasErrors() {
+			panic(diags)
+		}
+
+		if attribute, ok := body.Attributes[r.attributeName]; ok {
+			var ami string
+			err := runner.EvaluateExpr(attribute.Expr, &ami)
+			if appErr, ok := err.(*tflint.Error); ok {
+				switch appErr.Level {
+				case tflint.WarningLevel:
+					continue
+				case tflint.ErrorLevel:
+					return appErr
+				default:
+					panic(appErr)
+				}
+			}
+
+			if !r.amiIDs[ami] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid AMI ID.", ami),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+				})
+			}
+		}
+	}
+
+	return nil
+}

--- a/rules/awsrules/aws_instance_invalid_ami_test.go
+++ b/rules/awsrules/aws_instance_invalid_ami_test.go
@@ -1,0 +1,183 @@
+package awsrules
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/config"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsInstanceInvalidAMI(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*ec2.Image
+		Expected issue.Issues
+	}{
+		{
+			Name: "basic",
+			Content: `
+resource "aws_instance" "invalid" {
+  ami = "ami-1234abcd"
+}
+
+resource "aws_instance" "valid" {
+  ami = "ami-9ad76sd1"
+}`,
+			Response: []*ec2.Image{
+				{
+					ImageId: aws.String("ami-0c11b26d"),
+				},
+				{
+					ImageId: aws.String("ami-9ad76sd1"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_instance_invalid_ami",
+					Type:     issue.ERROR,
+					Message:  "\"ami-1234abcd\" is invalid AMI ID.",
+					Line:     3,
+					File:     "instances.tf",
+				},
+			},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsInstanceInvalidAMI")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	loader, err := configload.NewLoader(&configload.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		err := ioutil.WriteFile(dir+"/instances.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(config.Init(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsInstanceInvalidAMIRule()
+
+		ec2mock := mock.NewMockEC2API(ctrl)
+		ec2mock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{}).Return(&ec2.DescribeImagesOutput{
+			Images: tc.Response,
+		}, nil)
+		runner.AwsClient.EC2 = ec2mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}
+
+func Test_AwsInstanceInvalidAMI_error(t *testing.T) {
+	cases := []struct {
+		Name       string
+		Content    string
+		Response   error
+		ErrorCode  int
+		ErrorLevel int
+		ErrorText  string
+	}{
+		{
+			Name: "AWS API error",
+			Content: `
+resource "aws_instance" "valid" {
+  ami = "ami-9ad76sd1"
+}`,
+			Response:   errors.New("MissingRegion: could not find region configuration"),
+			ErrorCode:  tflint.ExternalAPIError,
+			ErrorLevel: tflint.ErrorLevel,
+			ErrorText:  "An error occurred while describing images; MissingRegion: could not find region configuration",
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsInstanceInvalidAMI_error")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	loader, err := configload.NewLoader(&configload.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		err := ioutil.WriteFile(dir+"/instances.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(config.Init(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsInstanceInvalidAMIRule()
+
+		ec2mock := mock.NewMockEC2API(ctrl)
+		ec2mock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{}).Return(nil, tc.Response)
+		runner.AwsClient.EC2 = ec2mock
+
+		err = rule.Check(runner)
+		if appErr, ok := err.(*tflint.Error); ok {
+			if appErr == nil {
+				t.Fatalf("Failed `%s` test: expected err is `%s`, but nothing occurred", tc.Name, tc.ErrorText)
+			}
+			if appErr.Code != tc.ErrorCode {
+				t.Fatalf("Failed `%s` test: expected error code is `%d`, but get `%d`", tc.Name, tc.ErrorCode, appErr.Code)
+			}
+			if appErr.Level != tc.ErrorLevel {
+				t.Fatalf("Failed `%s` test: expected error level is `%d`, but get `%d`", tc.Name, tc.ErrorLevel, appErr.Level)
+			}
+			if appErr.Error() != tc.ErrorText {
+				t.Fatalf("Failed `%s` test: expected error is `%s`, but get `%s`", tc.Name, tc.ErrorText, appErr.Error())
+			}
+		} else {
+			t.Fatalf("Failed `%s` test: unexpected error occurred: %s", tc.Name, err)
+		}
+	}
+}

--- a/rules/awsrules/aws_instance_invalid_type_test.go
+++ b/rules/awsrules/aws_instance_invalid_type_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/configs/configload"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/config"
 	"github.com/wata727/tflint/issue"
 	"github.com/wata727/tflint/tflint"
 )
@@ -72,13 +73,10 @@ resource "aws_instance" "missing_key" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(cfg, map[string]*terraform.InputValue{})
-		rule := &AwsInstanceInvalidTypeRule{}
-		if err = rule.PreProcess(); err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.NewRunner(config.Init(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsInstanceInvalidTypeRule()
 		if err = rule.Check(runner); err != nil {
-			t.Fatal(err)
+			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
 		if !cmp.Equal(tc.Expected, runner.Issues) {

--- a/rules/awsrules/awsrules_test.go
+++ b/rules/awsrules/awsrules_test.go
@@ -1,0 +1,13 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	log.SetOutput(ioutil.Discard)
+	os.Exit(m.Run())
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -1,0 +1,48 @@
+package rules
+
+import (
+	"github.com/wata727/tflint/config"
+	"github.com/wata727/tflint/rules/awsrules"
+	"github.com/wata727/tflint/tflint"
+)
+
+// Rule is an implementation that receives a Runner and inspects for resources and modules.
+type Rule interface {
+	Name() string
+	Enabled() bool
+	Check(runner *tflint.Runner) error
+}
+
+var defaultRules = []Rule{
+	awsrules.NewAwsInstanceInvalidTypeRule(),
+}
+
+var deepCheckRules = []Rule{
+	awsrules.NewAwsInstanceInvalidAMIRule(),
+}
+
+// NewRules returns rules according to configuration
+func NewRules(c *config.Config) []Rule {
+	ret := []Rule{}
+	allRules := []Rule{}
+
+	if c.DeepCheck {
+		allRules = append(defaultRules, deepCheckRules...)
+	} else {
+		allRules = defaultRules
+	}
+
+	for _, rule := range allRules {
+		if r := c.Rules[rule.Name()]; r != nil {
+			if r.Enabled {
+				ret = append(ret, rule)
+			}
+		} else {
+			if !c.IgnoreRule[rule.Name()] && rule.Enabled() {
+				ret = append(ret, rule)
+			}
+		}
+	}
+
+	return ret
+}

--- a/rules/provider_test.go
+++ b/rules/provider_test.go
@@ -1,0 +1,86 @@
+package rules
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/wata727/tflint/config"
+	"github.com/wata727/tflint/rules/awsrules"
+)
+
+func Test_NewRules(t *testing.T) {
+	// Mock rules in test
+	defaultRules = []Rule{
+		awsrules.NewAwsInstanceInvalidTypeRule(),
+	}
+	deepCheckRules = []Rule{
+		awsrules.NewAwsInstanceInvalidAMIRule(),
+	}
+
+	cases := []struct {
+		Name     string
+		Config   *config.Config
+		Expected []Rule
+	}{
+		{
+			Name:   "default",
+			Config: config.Init(),
+			Expected: []Rule{
+				awsrules.NewAwsInstanceInvalidTypeRule(),
+			},
+		},
+		{
+			Name: "enabled deep check",
+			Config: &config.Config{
+				DeepCheck: true,
+			},
+			Expected: []Rule{
+				awsrules.NewAwsInstanceInvalidTypeRule(),
+				awsrules.NewAwsInstanceInvalidAMIRule(),
+			},
+		},
+		{
+			Name: "ignore_rule",
+			Config: &config.Config{
+				IgnoreRule: map[string]bool{
+					"aws_instance_invalid_type": true,
+				},
+			},
+			Expected: []Rule{},
+		},
+		{
+			Name: "enabled = false",
+			Config: &config.Config{
+				Rules: map[string]*config.Rule{
+					"aws_instance_invalid_type": {
+						Enabled: false,
+					},
+				},
+			},
+			Expected: []Rule{},
+		},
+		{
+			Name: "`enabled = true` and `ignore_rule`",
+			Config: &config.Config{
+				IgnoreRule: map[string]bool{
+					"aws_instance_invalid_type": true,
+				},
+				Rules: map[string]*config.Rule{
+					"aws_instance_invalid_type": {
+						Enabled: true,
+					},
+				},
+			},
+			Expected: []Rule{
+				awsrules.NewAwsInstanceInvalidTypeRule(),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		ret := NewRules(tc.Config)
+		if !reflect.DeepEqual(tc.Expected, ret) {
+			t.Fatalf("Failed `%s` test: expected rules are `%#v`, but get `%#v`", tc.Name, tc.Expected, ret)
+		}
+	}
+}

--- a/tflint/errors.go
+++ b/tflint/errors.go
@@ -13,6 +13,8 @@ const (
 	TypeMismatchError
 	// UnevaluableError is an error when a received expression has unevaluable references.
 	UnevaluableError
+	// UnexpectedAttributeError is an error when handle unexpected attributes (e.g. block)
+	UnexpectedAttributeError
 
 	// FatalLevel is a recorverable error, it cause panic
 	FatalLevel int = 0

--- a/tflint/errors.go
+++ b/tflint/errors.go
@@ -15,6 +15,8 @@ const (
 	UnevaluableError
 	// UnexpectedAttributeError is an error when handle unexpected attributes (e.g. block)
 	UnexpectedAttributeError
+	// ExternalAPIError is an error when calling the external API (e.g. AWS SDK)
+	ExternalAPIError
 
 	// FatalLevel is a recorverable error, it cause panic
 	FatalLevel int = 0

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -3,10 +3,15 @@ package tflint
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/k0kubun/pp"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -742,5 +747,297 @@ resource "null_resource" "test" {
 				t.Fatal(err)
 			}
 		}
+	}
+}
+
+func Test_NewModuleRunners_noModules(t *testing.T) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "no_modules"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loader, err := NewLoader()
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+	cfg, err := loader.LoadConfig()
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+
+	runner := NewRunner(cfg, map[string]*terraform.InputValue{})
+	runners, err := NewModuleRunners(runner)
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+
+	if len(runners) > 0 {
+		t.Fatal("`NewModuleRunners` must not return runners when there is no module")
+	}
+}
+
+func Test_NewModuleRunners_nestedModules(t *testing.T) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "nested_modules"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loader, err := NewLoader()
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+	cfg, err := loader.LoadConfig()
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+
+	runner := NewRunner(cfg, map[string]*terraform.InputValue{})
+	runners, err := NewModuleRunners(runner)
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+
+	if len(runners) != 2 {
+		t.Fatal("This function must return 2 runners because the config has 2 modules")
+	}
+
+	child := runners[0].TFConfig
+	if child.Path.String() != "root" {
+		t.Fatalf("Expected child config path name is `root`, but get `%s`", child.Path.String())
+	}
+
+	expected := map[string]*configs.Variable{
+		"override": {
+			Name:        "override",
+			Default:     cty.StringVal("foo"),
+			Type:        cty.DynamicPseudoType,
+			ParsingMode: configs.VariableParseLiteral,
+			DeclRange: hcl.Range{
+				Filename: filepath.Join(".terraform", "modules", "07be448a6067a2bba065bff4beea229d", "module.tf"),
+				Start: hcl.Pos{
+					Line:   1,
+					Column: 1,
+					Byte:   0,
+				},
+				End: hcl.Pos{
+					Line:   1,
+					Column: 20,
+					Byte:   19,
+				},
+			},
+		},
+		"no_default": {
+			Name:        "no_default",
+			Default:     cty.StringVal("bar"),
+			Type:        cty.DynamicPseudoType,
+			ParsingMode: configs.VariableParseLiteral,
+			DeclRange: hcl.Range{
+				Filename: filepath.Join(".terraform", "modules", "07be448a6067a2bba065bff4beea229d", "module.tf"),
+				Start: hcl.Pos{
+					Line:   4,
+					Column: 1,
+					Byte:   42,
+				},
+				End: hcl.Pos{
+					Line:   4,
+					Column: 22,
+					Byte:   63,
+				},
+			},
+		},
+		"unknown": {
+			Name:        "unknown",
+			Default:     cty.UnknownVal(cty.DynamicPseudoType),
+			Type:        cty.DynamicPseudoType,
+			ParsingMode: configs.VariableParseLiteral,
+			DeclRange: hcl.Range{
+				Filename: filepath.Join(".terraform", "modules", "07be448a6067a2bba065bff4beea229d", "module.tf"),
+				Start: hcl.Pos{
+					Line:   5,
+					Column: 1,
+					Byte:   67,
+				},
+				End: hcl.Pos{
+					Line:   5,
+					Column: 19,
+					Byte:   85,
+				},
+			},
+		},
+	}
+	if !reflect.DeepEqual(expected, child.Module.Variables) {
+		t.Fatalf("`%s` module variables are unmatch:\n Expected: %s\n Actual: %s", child.Path.String(), pp.Sprint(expected), pp.Sprint(child.Module.Variables))
+	}
+
+	grandchild := runners[1].TFConfig
+	if grandchild.Path.String() != "root.test" {
+		t.Fatalf("Expected child config path name is `root.test`, but get `%s`", grandchild.Path.String())
+	}
+
+	expected = map[string]*configs.Variable{
+		"override": {
+			Name:        "override",
+			Default:     cty.StringVal("foo"),
+			Type:        cty.DynamicPseudoType,
+			ParsingMode: configs.VariableParseLiteral,
+			DeclRange: hcl.Range{
+				Filename: filepath.Join(".terraform", "modules", "a8d8930bc3c2ae53bf6e3bbcb3083d7b", "resource.tf"),
+				Start: hcl.Pos{
+					Line:   1,
+					Column: 1,
+					Byte:   0,
+				},
+				End: hcl.Pos{
+					Line:   1,
+					Column: 20,
+					Byte:   19,
+				},
+			},
+		},
+		"no_default": {
+			Name:        "no_default",
+			Default:     cty.StringVal("bar"),
+			Type:        cty.DynamicPseudoType,
+			ParsingMode: configs.VariableParseLiteral,
+			DeclRange: hcl.Range{
+				Filename: filepath.Join(".terraform", "modules", "a8d8930bc3c2ae53bf6e3bbcb3083d7b", "resource.tf"),
+				Start: hcl.Pos{
+					Line:   4,
+					Column: 1,
+					Byte:   42,
+				},
+				End: hcl.Pos{
+					Line:   4,
+					Column: 22,
+					Byte:   63,
+				},
+			},
+		},
+		"unknown": {
+			Name:        "unknown",
+			Default:     cty.UnknownVal(cty.DynamicPseudoType),
+			Type:        cty.DynamicPseudoType,
+			ParsingMode: configs.VariableParseLiteral,
+			DeclRange: hcl.Range{
+				Filename: filepath.Join(".terraform", "modules", "a8d8930bc3c2ae53bf6e3bbcb3083d7b", "resource.tf"),
+				Start: hcl.Pos{
+					Line:   5,
+					Column: 1,
+					Byte:   67,
+				},
+				End: hcl.Pos{
+					Line:   5,
+					Column: 19,
+					Byte:   85,
+				},
+			},
+		},
+	}
+	if !reflect.DeepEqual(expected, grandchild.Module.Variables) {
+		t.Fatalf("`%s` module variables are unmatch:\n Expected: %s\n Actual: %s", child.Path.String(), pp.Sprint(expected), pp.Sprint(grandchild.Module.Variables))
+	}
+}
+
+func Test_NewModuleRunners_withInvalidExpression(t *testing.T) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "invalid_module_attribute"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loader, err := NewLoader()
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+	cfg, err := loader.LoadConfig()
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+
+	runner := NewRunner(cfg, map[string]*terraform.InputValue{})
+	_, err = NewModuleRunners(runner)
+
+	errText := "Failed to eval an expression in module.tf:4; Invalid \"terraform\" attribute: The terraform.env attribute was deprecated in v0.10 and removed in v0.12. The \"state environment\" concept was rename to \"workspace\" in v0.12, and so the workspace name can now be accessed using the terraform.workspace attribute."
+	errCode := EvaluationError
+	errLevel := ErrorLevel
+
+	if appErr, ok := err.(*Error); ok {
+		if appErr == nil {
+			t.Fatalf("Expected err is `%s`, but nothing occurred", errText)
+		}
+		if appErr.Code != errCode {
+			t.Fatalf("Expected error code is `%d`, but get `%d`", errCode, appErr.Code)
+		}
+		if appErr.Level != errLevel {
+			t.Fatalf("Expected error level is `%d`, but get `%d`", errLevel, appErr.Level)
+		}
+		if appErr.Error() != errText {
+			t.Fatalf("Expected error is `%s`, but get `%s`", errText, appErr.Error())
+		}
+	} else {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+}
+
+func Test_NewModuleRunners_withNotAllowedAttributes(t *testing.T) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "not_allowed_module_attribute"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loader, err := NewLoader()
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+	cfg, err := loader.LoadConfig()
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+
+	runner := NewRunner(cfg, map[string]*terraform.InputValue{})
+	_, err = NewModuleRunners(runner)
+
+	errText := "Attribute of module not allowed was found in module.tf:1; <nil>: Unexpected invalid block; Blocks are not allowed here."
+	errCode := UnexpectedAttributeError
+	errLevel := ErrorLevel
+
+	if appErr, ok := err.(*Error); ok {
+		if appErr == nil {
+			t.Fatalf("Expected err is `%s`, but nothing occurred", errText)
+		}
+		if appErr.Code != errCode {
+			t.Fatalf("Expected error code is `%d`, but get `%d`", errCode, appErr.Code)
+		}
+		if appErr.Level != errLevel {
+			t.Fatalf("Expected error level is `%d`, but get `%d`", errLevel, appErr.Level)
+		}
+		if appErr.Error() != errText {
+			t.Fatalf("Expected error is `%s`, but get `%s`", errText, appErr.Error())
+		}
+	} else {
+		t.Fatalf("Unexpected error occurred: %s", err)
 	}
 }

--- a/tflint/test-fixtures/invalid_module_attribute/.terraform/modules/07be448a6067a2bba065bff4beea229d/resource.tf
+++ b/tflint/test-fixtures/invalid_module_attribute/.terraform/modules/07be448a6067a2bba065bff4beea229d/resource.tf
@@ -1,0 +1,7 @@
+variable "invalid" {
+  default = "foo"
+}
+
+resource "null_resource" "null" {
+  foo = "${var.invalid}"
+}

--- a/tflint/test-fixtures/invalid_module_attribute/.terraform/modules/modules.json
+++ b/tflint/test-fixtures/invalid_module_attribute/.terraform/modules/modules.json
@@ -1,0 +1,1 @@
+{"Modules":[{"Source":"./module","Key":"1.root;./module","Version":"","Dir":".terraform/modules/07be448a6067a2bba065bff4beea229d","Root":""}]}

--- a/tflint/test-fixtures/invalid_module_attribute/module.tf
+++ b/tflint/test-fixtures/invalid_module_attribute/module.tf
@@ -1,0 +1,5 @@
+module "root" {
+  source = "./module"
+
+  invalid = "${terraform.env}"
+}

--- a/tflint/test-fixtures/invalid_module_attribute/module/resource.tf
+++ b/tflint/test-fixtures/invalid_module_attribute/module/resource.tf
@@ -1,0 +1,7 @@
+variable "invalid" {
+  default = "foo"
+}
+
+resource "null_resource" "null" {
+  foo = "${var.invalid}"
+}

--- a/tflint/test-fixtures/nested_modules/.terraform/modules/07be448a6067a2bba065bff4beea229d/module.tf
+++ b/tflint/test-fixtures/nested_modules/.terraform/modules/07be448a6067a2bba065bff4beea229d/module.tf
@@ -1,0 +1,13 @@
+variable "override" {
+  default = "baz"
+}
+variable "no_default" {}
+variable "unknown" {}
+
+module "test" {
+  source = "./module1"
+
+  override = "${var.override}"
+  no_default = "${var.no_default}"
+  unknown = "${var.unknown}"
+}

--- a/tflint/test-fixtures/nested_modules/.terraform/modules/07be448a6067a2bba065bff4beea229d/module1/resource.tf
+++ b/tflint/test-fixtures/nested_modules/.terraform/modules/07be448a6067a2bba065bff4beea229d/module1/resource.tf
@@ -1,0 +1,15 @@
+variable "override" {
+  default = "baz"
+}
+variable "no_default" {}
+variable "unknown" {}
+
+resource "aws_instance" "web" {
+  ami           = "ami-b73b63a0"
+  instance_type = "t1.2xlarge"
+
+  tags {
+    Name = "HelloWorld"
+  }
+}
+

--- a/tflint/test-fixtures/nested_modules/.terraform/modules/a8d8930bc3c2ae53bf6e3bbcb3083d7b/resource.tf
+++ b/tflint/test-fixtures/nested_modules/.terraform/modules/a8d8930bc3c2ae53bf6e3bbcb3083d7b/resource.tf
@@ -1,0 +1,15 @@
+variable "override" {
+  default = "baz"
+}
+variable "no_default" {}
+variable "unknown" {}
+
+resource "aws_instance" "web" {
+  ami           = "ami-b73b63a0"
+  instance_type = "t1.2xlarge"
+
+  tags {
+    Name = "HelloWorld"
+  }
+}
+

--- a/tflint/test-fixtures/nested_modules/.terraform/modules/modules.json
+++ b/tflint/test-fixtures/nested_modules/.terraform/modules/modules.json
@@ -1,0 +1,1 @@
+{"Modules":[{"Source":"./module","Key":"1.root;./module","Version":"","Dir":".terraform/modules/07be448a6067a2bba065bff4beea229d","Root":""},{"Source":"./module1","Key":"1.root;./module|test;./module1","Version":"","Dir":".terraform/modules/a8d8930bc3c2ae53bf6e3bbcb3083d7b","Root":""}]}

--- a/tflint/test-fixtures/nested_modules/module.tf
+++ b/tflint/test-fixtures/nested_modules/module.tf
@@ -1,0 +1,7 @@
+module "root" {
+  source = "./module"
+
+  override = "foo"
+  no_default = "bar"
+  unknown = "${data.aws.ami.id}"
+}

--- a/tflint/test-fixtures/nested_modules/module/module.tf
+++ b/tflint/test-fixtures/nested_modules/module/module.tf
@@ -1,0 +1,13 @@
+variable "override" {
+  default = "baz"
+}
+variable "no_default" {}
+variable "unknown" {}
+
+module "test" {
+  source = "./module1"
+
+  override = "${var.override}"
+  no_default = "${var.no_default}"
+  unknown = "${var.unknown}"
+}

--- a/tflint/test-fixtures/nested_modules/module/module1/resource.tf
+++ b/tflint/test-fixtures/nested_modules/module/module1/resource.tf
@@ -1,0 +1,15 @@
+variable "override" {
+  default = "baz"
+}
+variable "no_default" {}
+variable "unknown" {}
+
+resource "aws_instance" "web" {
+  ami           = "ami-b73b63a0"
+  instance_type = "t1.2xlarge"
+
+  tags {
+    Name = "HelloWorld"
+  }
+}
+

--- a/tflint/test-fixtures/no_modules/resource.tf
+++ b/tflint/test-fixtures/no_modules/resource.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "web" {
+  ami           = "ami-b73b63a0"
+  instance_type = "t1.2xlarge"
+
+  tags {
+    Name = "HelloWorld"
+  }
+}

--- a/tflint/test-fixtures/not_allowed_module_attribute/.terraform/modules/07be448a6067a2bba065bff4beea229d/resource.tf
+++ b/tflint/test-fixtures/not_allowed_module_attribute/.terraform/modules/07be448a6067a2bba065bff4beea229d/resource.tf
@@ -1,0 +1,7 @@
+variable "invalid" {
+  default = "foo"
+}
+
+resource "null_resource" "null" {
+  foo = "${var.invalid}"
+}

--- a/tflint/test-fixtures/not_allowed_module_attribute/.terraform/modules/modules.json
+++ b/tflint/test-fixtures/not_allowed_module_attribute/.terraform/modules/modules.json
@@ -1,0 +1,1 @@
+{"Modules":[{"Source":"./module","Key":"1.root;./module","Version":"","Dir":".terraform/modules/07be448a6067a2bba065bff4beea229d","Root":""}]}

--- a/tflint/test-fixtures/not_allowed_module_attribute/module.tf
+++ b/tflint/test-fixtures/not_allowed_module_attribute/module.tf
@@ -1,0 +1,7 @@
+module "root" {
+  source = "./module"
+
+  invalid {
+    aws = "1.1.3"
+  }
+}

--- a/tflint/test-fixtures/not_allowed_module_attribute/module/resource.tf
+++ b/tflint/test-fixtures/not_allowed_module_attribute/module/resource.tf
@@ -1,0 +1,7 @@
+variable "invalid" {
+  default = "foo"
+}
+
+resource "null_resource" "null" {
+  foo = "${var.invalid}"
+}


### PR DESCRIPTION
This PR introduces new helpers named `NewModuleRunners`. This function recursively searches for the children of `configs.Config` and returns runners as many as `configs.Config`.

Within the generated runner, assign the attributes of the module call as variables so that resources inside the module can be searched.

Variable that cannot be evaluated continues processing as an unknown value. This makes it unnecessary to assign dummy values when inspecting published modules and others.

Also, it introduces`rules.NewRules()` function. This function returns the rules for inspection based on the configuration.