### PR TITLE
Remove duplicate resource rules

### DIFF
--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -13,22 +13,20 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/client"
 	"github.com/wata727/tflint/issue"
-	"github.com/wata727/tflint/state"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
 	"github.com/zclconf/go-cty/cty/gocty"
 )
 
 // Runner checks templates according rules.
-// For variables interplation, it has Terraform eval context,
-// and state. After checking, it accumulates results as issues.
+// For variables interplation, it has Terraform eval context.
+// After checking, it accumulates results as issues.
 type Runner struct {
 	TFConfig  *configs.Config
 	Issues    issue.Issues
 	AwsClient *client.AwsClient
 
 	ctx    terraform.BuiltinEvalContext
-	state  state.TFState
 	config *Config
 }
 


### PR DESCRIPTION
Remove the rules that find duplicate resources from the next minor release. The following rules will be unavailable.

- aws_security_group_duplicate_name
- aws_alb_duplicate_name
- aws_elb_duplicate_name
- aws_db_instance_duplicate_identifier
- aws_elasticache_cluster_duplicate_id
- aws_ecs_cluster_duplicate_name

In this PR, Terraform's state is removed from `Runner`. As a result, TFLint doesn't use Terraform's state.

The big motivation for this is change of tfstate format in Terraform 0.12. It is accompanied by technical difficulties of simultaneously supporting the previous state and new format.

The other is for the user experience. Although this feature is always assumed to be used after the `terraform plan`, many users expect to use in CI or to use with editors. This is a mismatch and it is the reason to review this feature.

In the future, There is a possibility that the same feature may be implemented, but it is not now.