### PR TITLE
Load Terraform's values files in Loader

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -87,9 +87,14 @@ func (cli *CLI) Run(args []string) int {
 		fmt.Fprintln(cli.errStream, err)
 		return ExitCodeError
 	}
+	valuesFiles, err := cli.loader.LoadValuesFiles(cfg.Varfile...)
+	if err != nil {
+		fmt.Fprintln(cli.errStream, err)
+		return ExitCodeError
+	}
 
 	// Check configurations via Runner
-	runner := tflint.NewRunner(cfg, configs)
+	runner := tflint.NewRunner(cfg, configs, valuesFiles...)
 	runners, err := tflint.NewModuleRunners(runner)
 	if err != nil {
 		fmt.Fprintln(cli.errStream, err)

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/issue"
 	"github.com/wata727/tflint/mock"
 	"github.com/wata727/tflint/rules"
@@ -100,6 +101,7 @@ func TestCLIRun__noIssuesFound(t *testing.T) {
 
 		loader := mock.NewMockAbstractLoader(ctrl)
 		loader.EXPECT().LoadConfig().Return(configs.NewEmptyConfig(), tc.LoadErr).AnyTimes()
+		loader.EXPECT().LoadValuesFiles().Return([]terraform.InputValues{}, tc.LoadErr).AnyTimes()
 		cli.loader = loader
 
 		status := cli.Run(strings.Split(tc.Command, " "))
@@ -206,6 +208,7 @@ func TestCLIRun__issuesFound(t *testing.T) {
 
 		loader := mock.NewMockAbstractLoader(ctrl)
 		loader.EXPECT().LoadConfig().Return(configs.NewEmptyConfig(), nil).AnyTimes()
+		loader.EXPECT().LoadValuesFiles().Return([]terraform.InputValues{}, nil).AnyTimes()
 		cli.loader = loader
 
 		status := cli.Run(strings.Split(tc.Command, " "))

--- a/mock/loader.go
+++ b/mock/loader.go
@@ -7,6 +7,7 @@ package mock
 import (
 	gomock "github.com/golang/mock/gomock"
 	configs "github.com/hashicorp/terraform/configs"
+	terraform "github.com/hashicorp/terraform/terraform"
 	reflect "reflect"
 )
 
@@ -44,4 +45,21 @@ func (m *MockAbstractLoader) LoadConfig() (*configs.Config, error) {
 // LoadConfig indicates an expected call of LoadConfig
 func (mr *MockAbstractLoaderMockRecorder) LoadConfig() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadConfig", reflect.TypeOf((*MockAbstractLoader)(nil).LoadConfig))
+}
+
+// LoadValuesFiles mocks base method
+func (m *MockAbstractLoader) LoadValuesFiles(arg0 ...string) ([]terraform.InputValues, error) {
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "LoadValuesFiles", varargs...)
+	ret0, _ := ret[0].([]terraform.InputValues)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LoadValuesFiles indicates an expected call of LoadValuesFiles
+func (mr *MockAbstractLoaderMockRecorder) LoadValuesFiles(arg0 ...interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadValuesFiles", reflect.TypeOf((*MockAbstractLoader)(nil).LoadValuesFiles), arg0...)
 }

--- a/tflint/terraform.go
+++ b/tflint/terraform.go
@@ -12,6 +12,8 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+var defaultValuesFile = "terraform.tfvars"
+
 func getTFDataDir() string {
 	dir := os.Getenv("TF_DATA_DIR")
 	if dir != "" {

--- a/tflint/test-fixtures/invalid_values_files/terraform.tfvars
+++ b/tflint/test-fixtures/invalid_values_files/terraform.tfvars
@@ -1,0 +1,3 @@
+literal = 1
+
+resource "aws_instance" "web" {}

--- a/tflint/test-fixtures/values_files/auto1.auto.tfvars
+++ b/tflint/test-fixtures/values_files/auto1.auto.tfvars
@@ -1,0 +1,1 @@
+auto1 = "auto1.auto.tfvars"

--- a/tflint/test-fixtures/values_files/auto2.auto.tfvars
+++ b/tflint/test-fixtures/values_files/auto2.auto.tfvars
@@ -1,0 +1,1 @@
+auto2 = "auto2.auto.tfvars"

--- a/tflint/test-fixtures/values_files/cli1.tfvars
+++ b/tflint/test-fixtures/values_files/cli1.tfvars
@@ -1,0 +1,1 @@
+cli1 = "cli1.tfvars"

--- a/tflint/test-fixtures/values_files/cli2.tfvars
+++ b/tflint/test-fixtures/values_files/cli2.tfvars
@@ -1,0 +1,1 @@
+cli2 = "cli2.tfvars"

--- a/tflint/test-fixtures/values_files/terraform.tfvars
+++ b/tflint/test-fixtures/values_files/terraform.tfvars
@@ -1,0 +1,1 @@
+default = "terraform.tfvars"


### PR DESCRIPTION
In this pull request, implements `LoadValuesFiles` API to load Terraform's values files.

This API detects automatically loaded values files such as `terraform.tfvars` and` * .auto.tfvars` and returns `terraform.InputValues` in order of priority. Support for `* .auto.tfvars` is a new feature.

The obtained input values are used to overwrite variables when passing it to `NewRunner`.
