### PR TITLE
Accept files arguments

### DIFF
--- a/cmd/test-fixtures/arguments/README
+++ b/cmd/test-fixtures/arguments/README
@@ -1,0 +1,1 @@
+Hello World

--- a/cmd/test-fixtures/arguments/template.tf
+++ b/cmd/test-fixtures/arguments/template.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "backend" {
+  ami           = "ami-b73b63a0"
+  instance_type = "t1.2xlarge"
+
+  tags {
+    Name = "HelloWorld"
+  }
+}

--- a/cmd/test-fixtures/arguments/test.tf
+++ b/cmd/test-fixtures/arguments/test.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "web" {
+  ami           = "ami-b73b63a0"
+  instance_type = "t1.2xlarge"
+
+  tags {
+    Name = "HelloWorld"
+  }
+}

--- a/mock/loader.go
+++ b/mock/loader.go
@@ -63,3 +63,15 @@ func (m *MockAbstractLoader) LoadValuesFiles(arg0 ...string) ([]terraform.InputV
 func (mr *MockAbstractLoaderMockRecorder) LoadValuesFiles(arg0 ...interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadValuesFiles", reflect.TypeOf((*MockAbstractLoader)(nil).LoadValuesFiles), arg0...)
 }
+
+// IsConfigFile mocks base method
+func (m *MockAbstractLoader) IsConfigFile(arg0 string) bool {
+	ret := m.ctrl.Call(m, "IsConfigFile", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsConfigFile indicates an expected call of IsConfigFile
+func (mr *MockAbstractLoaderMockRecorder) IsConfigFile(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsConfigFile", reflect.TypeOf((*MockAbstractLoader)(nil).IsConfigFile), arg0)
+}

--- a/tflint/loader_test.go
+++ b/tflint/loader_test.go
@@ -311,3 +311,50 @@ func Test_LoadValuesFiles_invalidValuesFile(t *testing.T) {
 		t.Fatalf("Expected error is `%s`, but get `%s`", expected, err.Error())
 	}
 }
+
+func Test_IsConfigFile(t *testing.T) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "is_config_file"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loader, err := NewLoader()
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+
+	cases := []struct {
+		Name     string
+		File     string
+		Expected bool
+	}{
+		{
+			Name:     "config file",
+			File:     "template.tf",
+			Expected: true,
+		},
+		{
+			Name:     "not config file",
+			File:     "README",
+			Expected: false,
+		},
+		{
+			Name:     "not found",
+			File:     "not_found.tf",
+			Expected: false,
+		},
+	}
+
+	for _, tc := range cases {
+		ret := loader.IsConfigFile(tc.File)
+		if ret != tc.Expected {
+			t.Fatalf("Test `%s` failed: expected is `%t`, but get `%t`", tc.Name, tc.Expected, ret)
+		}
+	}
+}

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -238,6 +238,23 @@ func (r *Runner) GetFileName(raw string) string {
 	return filepath.Join(r.TFConfig.Path.String(), filepath.Base(raw))
 }
 
+// LookupIssues returns issues according to the received files
+func (r *Runner) LookupIssues(files ...string) issue.Issues {
+	if len(files) == 0 {
+		return r.Issues
+	}
+
+	issues := []*issue.Issue{}
+	for _, issue := range r.Issues {
+		for _, file := range files {
+			if file == issue.File {
+				issues = append(issues, issue)
+			}
+		}
+	}
+	return issues
+}
+
 // prepareVariableValues prepares Terraform variables from configs, input variables and environment variables.
 // Variables in the configuration are overwritten by environment variables.
 // Finally, they are overwritten by received input variable on the received order.

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/k0kubun/pp"
+	"github.com/wata727/tflint/issue"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -1087,5 +1088,40 @@ resource "aws_route" "r" {
 	}
 	if resources[0].Type != "aws_instance" {
 		t.Fatalf("Expected resource type is `aws_instance`, but get `%s`", resources[0].Type)
+	}
+}
+
+func Test_LookupIssues(t *testing.T) {
+	runner := NewRunner(EmptyConfig(), configs.NewEmptyConfig(), map[string]*terraform.InputValue{})
+	runner.Issues = issue.Issues{
+		{
+			Detector: "test rule",
+			Type:     issue.ERROR,
+			Message:  "This is test rule",
+			Line:     1,
+			File:     "template.tf",
+		},
+		{
+			Detector: "test rule",
+			Type:     issue.ERROR,
+			Message:  "This is test rule",
+			Line:     1,
+			File:     "resource.tf",
+		},
+	}
+
+	ret := runner.LookupIssues("template.tf")
+	expected := issue.Issues{
+		{
+			Detector: "test rule",
+			Type:     issue.ERROR,
+			Message:  "This is test rule",
+			Line:     1,
+			File:     "template.tf",
+		},
+	}
+
+	if !cmp.Equal(expected, ret) {
+		t.Fatalf("Failed test: diff: %s", cmp.Diff(expected, ret))
 	}
 }

--- a/tflint/test-fixtures/is_config_file/README
+++ b/tflint/test-fixtures/is_config_file/README
@@ -1,0 +1,1 @@
+HELLO WORLD

--- a/tflint/test-fixtures/is_config_file/template.tf
+++ b/tflint/test-fixtures/is_config_file/template.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "web" {
+  ami           = "ami-b73b63a0"
+  instance_type = "t1.2xlarge" # invalid type!
+
+  tags {
+    Name = "HelloWorld"
+  }
+}


### PR DESCRIPTION
Previously, file arguments were removed in #217, but I thought that similar feature is necessary for backward compatibility.

In the new TFLint, the file argument does not select the file to parse, it is used to filter issues. Therefore, parse all files regardless of arguments. This is a breaking change.

As a known issue, If file arguments are specified, module's issues are not reported. This will be improved by changing handling of module's issues in the future.