### PR TITLE
Add `WalkResourceAttributes` and `EnsureNoError` helpers

### DIFF
--- a/rules/awsrules/aws_instance_invalid_type_test.go
+++ b/rules/awsrules/aws_instance_invalid_type_test.go
@@ -28,10 +28,6 @@ resource "aws_instance" "invalid" {
 
 resource "aws_instance" "valid" {
   instance_type = "t2.micro"
-}
-
-resource "aws_instance" "missing_key" {
-  ami = "ami-12345678"
 }`,
 			Expected: []*issue.Issue{
 				{


### PR DESCRIPTION
This PR introduces `WalkResourceAttributes` and `EnsureNoError` helpers in Runner. These helpers will be used within `Check()` in rules package. The following is an example:

```go
runner.WalkResourceAttributes("aws_instance", "instance_type", func(attribute *hcl.Attribute) error {
  // Check the attribute...

  var instanceType string
  err := runner.EvaluateExpr(attribute.Expr, &instanceType)
  runner.EnsureNoError(err, func() error {
    // Emit issues...
  })
})
```

`WalkResourceAttributes` searches all attributes of the resource in the configurations and calls the received walker function with `hcl.Attribute`. This allows the caller to focus only on the processing of the target attribute.

`EnsureNoError` ensures that the received function is called only when it is not an error. This makes it unnecessary to handle warning level errors in the caller.

