### PR TITLE
Apply `ignore_module` to NewModuleRunners

### DIFF
--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -73,6 +73,10 @@ func NewModuleRunners(parent *Runner) ([]*Runner, error) {
 		if !ok {
 			panic(fmt.Errorf("Expected module call `%s` is not found in `%s`", name, parent.TFConfig.Path.String()))
 		}
+		if parent.TFConfig.Path.IsRoot() && parent.config.IgnoreModule[moduleCall.SourceAddr] {
+			log.Printf("[INFO] Ignore `%s` module", moduleCall.Name)
+			continue
+		}
 
 		attributes, diags := moduleCall.Config.JustAttributes()
 		if diags.HasErrors() {

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -953,6 +953,41 @@ func Test_NewModuleRunners_nestedModules(t *testing.T) {
 	}
 }
 
+func Test_NewModuleRunners_ignoreModules(t *testing.T) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "nested_modules"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loader, err := NewLoader()
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+	cfg, err := loader.LoadConfig()
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+
+	conf := EmptyConfig()
+	conf.IgnoreModule["./module"] = true
+
+	runner := NewRunner(conf, cfg, map[string]*terraform.InputValue{})
+	runners, err := NewModuleRunners(runner)
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+
+	if len(runners) != 0 {
+		t.Fatalf("This function must not return runners because `ignore_module` is set. Got `%d` runner(s)", len(runners))
+	}
+}
+
 func Test_NewModuleRunners_withInvalidExpression(t *testing.T) {
 	currentDir, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
When `ignore_module` is set, do not report issues for the specified module.

As a breaking change, loading modules is necessary always. As a result, users who had avoided errors with this option may be affected by this change.