### PR TITLE
Migrate `aws_db_instance_readable_password` to rules

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -320,6 +320,14 @@
   revision = "3ca8ac2e18d9548ac4ff05e2323bfac023240ed0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:89cd2208bdeb192cc83ee287216af3c987fc87a90b9087718ad6631b636cefcf"
+  name = "github.com/iancoleman/strcase"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3605ed457bf7f8caa1371b4fafadadc026673479"
+
+[[projects]]
   digest = "1:a2cff208d4759f6ba1b1cd228587b0a1869f95f22542ec9cd17fff64430113c7"
   name = "github.com/jessevdk/go-flags"
   packages = ["."]
@@ -615,6 +623,7 @@
     "github.com/hashicorp/terraform/helper/variables",
     "github.com/hashicorp/terraform/lang",
     "github.com/hashicorp/terraform/terraform",
+    "github.com/iancoleman/strcase",
     "github.com/jessevdk/go-flags",
     "github.com/k0kubun/pp",
     "github.com/mattn/go-colorable",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -72,3 +72,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/hashicorp/logutils"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/iancoleman/strcase"

--- a/Makefile
+++ b/Makefile
@@ -54,4 +54,7 @@ image:
 	docker push wata727/tflint:${VERSION}
 	docker push wata727/tflint:latest
 
-.PHONY: default prepare test build install release clean mock image
+rule:
+	go run tools/rule_generator.go
+
+.PHONY: default prepare test build install release clean mock image rule

--- a/rules/awsrules/aws_db_instance_readable_password.go
+++ b/rules/awsrules/aws_db_instance_readable_password.go
@@ -1,0 +1,77 @@
+package awsrules
+
+import (
+	"log"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/terraform/addrs"
+	"github.com/hashicorp/terraform/lang"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsDBInstanceReadablePasswordRule checks whether "aws_db_instance" has readable password field
+type AwsDBInstanceReadablePasswordRule struct {
+	resourceType  string
+	attributeName string
+}
+
+// NewAwsDBInstanceReadablePasswordRule returns new rule with default attributes
+func NewAwsDBInstanceReadablePasswordRule() *AwsDBInstanceReadablePasswordRule {
+	return &AwsDBInstanceReadablePasswordRule{
+		resourceType:  "aws_db_instance",
+		attributeName: "password",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsDBInstanceReadablePasswordRule) Name() string {
+	return "aws_db_instance_readable_password"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsDBInstanceReadablePasswordRule) Enabled() bool {
+	return true
+}
+
+// Check checks password
+func (r *AwsDBInstanceReadablePasswordRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		refs, diags := lang.ReferencesInExpr(attribute.Expr)
+		if diags.HasErrors() {
+			// Maybe this is bug
+			panic(diags.Err())
+		}
+
+		varSubjects := []addrs.InputVariable{}
+		readableSubjects := []addrs.InputVariable{}
+		for _, ref := range refs {
+			if sub, ok := ref.Subject.(addrs.InputVariable); ok {
+				varSubjects = append(varSubjects, sub)
+
+				variable := runner.TFConfig.Module.Variables[sub.Name]
+				if variable == nil {
+					continue
+				}
+				if !variable.Default.IsNull() {
+					readableSubjects = append(readableSubjects, sub)
+				}
+			}
+		}
+
+		if len(varSubjects) == 0 || len(varSubjects) == len(readableSubjects) {
+			runner.Issues = append(runner.Issues, &issue.Issue{
+				Detector: r.Name(),
+				Type:     issue.WARNING,
+				Message:  "Password for the master DB user is readable. Recommend using environment variables or variable files.",
+				Line:     attribute.Range.Start.Line,
+				File:     runner.GetFileName(attribute.Range.Filename),
+				Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_db_instance_readable_password.md",
+			})
+		}
+
+		return nil
+	})
+}

--- a/rules/awsrules/aws_db_instance_readable_password_test.go
+++ b/rules/awsrules/aws_db_instance_readable_password_test.go
@@ -1,0 +1,146 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsDBInstanceReadablePassword(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected issue.Issues
+	}{
+		{
+			Name: "write password directly",
+			Content: `
+resource "aws_db_instance" "mysql" {
+  password = "super_secret"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_db_instance_readable_password",
+					Type:     issue.WARNING,
+					Message:  "Password for the master DB user is readable. Recommend using environment variables or variable files.",
+					Line:     3,
+					File:     "resource.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_db_instance_readable_password.md",
+				},
+			},
+		},
+		{
+			Name: "with default variable",
+			Content: `
+variable "password" {
+  default = "super_secret"
+}
+
+resource "aws_db_instance" "mysql" {
+  password = "${var.password}"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_db_instance_readable_password",
+					Type:     issue.WARNING,
+					Message:  "Password for the master DB user is readable. Recommend using environment variables or variable files.",
+					Line:     7,
+					File:     "resource.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_db_instance_readable_password.md",
+				},
+			},
+		},
+		{
+			Name: "with no default variable",
+			Content: `
+variable "password" {}
+
+resource "aws_db_instance" "mysql" {
+  password = "${var.password}"
+}`,
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "with two variables, the one has default",
+			Content: `
+variable "head_password" {}
+variable "tail_password" {
+  default = "tails"
+}
+
+resource "aws_db_instance" "mysql" {
+  password = "${var.head_password}-${var.tail_password}"
+}`,
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "with two variables, both has default",
+			Content: `
+variable "head_password" {
+  default = "heads"
+}
+variable "tail_password" {
+  default = "tails"
+}
+
+resource "aws_db_instance" "mysql" {
+  password = "${var.head_password}-${var.tail_password}"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_db_instance_readable_password",
+					Type:     issue.WARNING,
+					Message:  "Password for the master DB user is readable. Recommend using environment variables or variable files.",
+					Line:     10,
+					File:     "resource.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_db_instance_readable_password.md",
+				},
+			},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsDBInstanceReadablePassword")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsDBInstanceReadablePasswordRule()
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -16,6 +16,7 @@ type Rule interface {
 
 // DefaultRules is rules by default
 var DefaultRules = []Rule{
+	awsrules.NewAwsDBInstanceReadablePasswordRule(),
 	awsrules.NewAwsInstanceInvalidTypeRule(),
 }
 

--- a/rules/rule.go.tmpl
+++ b/rules/rule.go.tmpl
@@ -1,0 +1,77 @@
+package awsrules
+
+import (
+	"log"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// {{ .RuleNameCC }}Rule checks ...
+type {{ .RuleNameCC }}Rule struct {
+	resourceType  string
+	attributeName string
+	// Add more field
+	dataPrepared bool
+}
+
+// New{{ .RuleNameCC }}Rule returns new rule with default attributes
+func New{{ .RuleNameCC }}Rule() *{{ .RuleNameCC }}Rule {
+	return &{{ .RuleNameCC }}Rule{
+		resourceType:  "...",
+		attributeName: "...",
+		dataPrepared:  false,
+	}
+}
+
+// Name returns the rule name
+func (r *{{ .RuleNameCC }}Rule) Name() string {
+	return "{{ .RuleName }}"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *{{ .RuleNameCC }}Rule) Enabled() bool {
+	return true
+}
+
+// Check checks ...
+func (r *{{ .RuleNameCC }}Rule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch ...")
+			resp, err := runner.AwsClient.Service.CallAPI()
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing ...",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			r.Body = resp.Body
+
+			r.dataPrepared = true
+		}
+
+		var val string
+		err := runner.EvaluateExpr(attribute.Expr, &val)
+
+		return runner.EnsureNoError(err, func() error {
+			if isInvalid(val) {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.TODO,
+					Message:  "TODO",
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/rule_test.go.tmpl
+++ b/rules/rule_test.go.tmpl
@@ -1,0 +1,166 @@
+package awsrules
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_{{ .RuleNameCC }}(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response service.Response
+		Expected issue.Issues
+	}{
+		{
+			Name: "basic",
+			Content: `
+resource "null_resource" "null" {
+}
+`,
+			Response: service.Reponse{},
+			Expected: []*issue.Issue{
+				{
+					Detector: "{{ .RuleName }}",
+					Type:     issue.TODO,
+					Message:  "TODO",
+					Line:     0,
+					File:     "resource.tf",
+				},
+			},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "{{ .RuleNameCC }}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := New{{ .RuleNameCC }}Rule()
+
+		mock := mock.NewMockAPI(ctrl)
+		mock.EXPECT().CallAPI().Return(tc.Response, nil)
+		runner.AwsClient.Service = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}
+
+func Test_{{ .RuleNameCC }}_error(t *testing.T) {
+	cases := []struct {
+		Name       string
+		Content    string
+		Response   error
+		ErrorCode  int
+		ErrorLevel int
+		ErrorText  string
+	}{
+		{
+			Name: "API error",
+			Content: `
+resource "null_resource" "null" {
+}`,
+			Response:   errors.New("Some error"),
+			ErrorCode:  tflint.ExternalAPIError,
+			ErrorLevel: tflint.ErrorLevel,
+			ErrorText:  "Some error",
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "{{ .RuleNameCC }}_error")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := New{{ .RuleNameCC }}Rule()
+
+		mock := mock.NewMockAPI(ctrl)
+		mock.EXPECT().CallAPI().Return(nil, tc.Response)
+		runner.AwsClient.Service = mock
+
+		err = rule.Check(runner)
+		if appErr, ok := err.(*tflint.Error); ok {
+			if appErr == nil {
+				t.Fatalf("Failed `%s` test: expected err is `%s`, but nothing occurred", tc.Name, tc.ErrorText)
+			}
+			if appErr.Code != tc.ErrorCode {
+				t.Fatalf("Failed `%s` test: expected error code is `%d`, but get `%d`", tc.Name, tc.ErrorCode, appErr.Code)
+			}
+			if appErr.Level != tc.ErrorLevel {
+				t.Fatalf("Failed `%s` test: expected error level is `%d`, but get `%d`", tc.Name, tc.ErrorLevel, appErr.Level)
+			}
+			if appErr.Error() != tc.ErrorText {
+				t.Fatalf("Failed `%s` test: expected error is `%s`, but get `%s`", tc.Name, tc.ErrorText, appErr.Error())
+			}
+		} else {
+			t.Fatalf("Failed `%s` test: unexpected error occurred: %s", tc.Name, err)
+		}
+	}
+}

--- a/tools/rule_generator.go
+++ b/tools/rule_generator.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/iancoleman/strcase"
+)
+
+type metadata struct {
+	RuleName   string
+	RuleNameCC string
+}
+
+func main() {
+	buf := bufio.NewReader(os.Stdin)
+	fmt.Print("Rule name? (e.g. aws_instance_invalid_type): ")
+	ruleName, err := buf.ReadString('\n')
+	if err != nil {
+		panic(err)
+	}
+	ruleName = strings.Trim(ruleName, "\n")
+
+	meta := &metadata{RuleNameCC: toCamelCase(ruleName), RuleName: ruleName}
+
+	generate(fmt.Sprintf("rules/awsrules/%s.go", ruleName), "rules/rule.go.tmpl", meta)
+	generate(fmt.Sprintf("rules/awsrules/%s_test.go", ruleName), "rules/rule_test.go.tmpl", meta)
+}
+
+func generate(fileName string, tmplName string, meta *metadata) {
+	file, err := os.Create(fileName)
+	if err != nil {
+		panic(err)
+	}
+
+	tmpl := template.Must(template.ParseFiles(tmplName))
+	err = tmpl.Execute(file, meta)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Create: %s\n", fileName)
+}
+
+func toCamelCase(str string) string {
+	exceptions := map[string]string{
+		"ami": "AMI",
+		"db":  "DB",
+	}
+	for pattern, conv := range exceptions {
+		str = strings.Replace(str, "_"+pattern+"_", "_"+conv+"_", -1)
+		str = strings.Replace(str, pattern+"_", conv+"_", -1)
+		str = strings.Replace(str, "_"+pattern, "_"+conv, -1)
+	}
+	return strcase.ToCamel(str)
+}


### PR DESCRIPTION
From this PR I will gradually migrate detectors to rules. At first, implement `aws_db_instance_readable_password` rule.

In the new implementation, it is possible to acquire variable references, so more detailed inspection than before is possible.

In addition, I'm adding a rule generator. This will help you to create new rules.
