### PR TITLE
Migrate `terraform_module_pinned_source` to rules

### DIFF
--- a/rules/provider.go
+++ b/rules/provider.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/wata727/tflint/rules/awsrules"
+	"github.com/wata727/tflint/rules/terraformrules"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -18,6 +19,7 @@ type Rule interface {
 var DefaultRules = []Rule{
 	awsrules.NewAwsDBInstanceReadablePasswordRule(),
 	awsrules.NewAwsInstanceInvalidTypeRule(),
+	terraformrules.NewTerraformModulePinnedSourceRule(),
 }
 
 var deepCheckRules = []Rule{

--- a/rules/terraformrules/terraform_module_pinned_source.go
+++ b/rules/terraformrules/terraform_module_pinned_source.go
@@ -1,0 +1,114 @@
+package terraformrules
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform/configs"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// TerraformModulePinnedSourceRule checks unpinned or default version module source
+type TerraformModulePinnedSourceRule struct {
+	attributeName string
+	link          string
+}
+
+// NewTerraformModulePinnedSourceRule returns new rule with default attributes
+func NewTerraformModulePinnedSourceRule() *TerraformModulePinnedSourceRule {
+	return &TerraformModulePinnedSourceRule{
+		attributeName: "source",
+		link:          "https://github.com/wata727/tflint/blob/master/docs/terraform_module_pinned_source.md",
+	}
+}
+
+// Name returns the rule name
+func (r *TerraformModulePinnedSourceRule) Name() string {
+	return "terraform_module_pinned_source"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformModulePinnedSourceRule) Enabled() bool {
+	return true
+}
+
+var reGithub = regexp.MustCompile("(^github.com/(.+)/(.+)$)|(^git@github.com:(.+)/(.+)$)")
+var reBitbucket = regexp.MustCompile("^bitbucket.org/(.+)/(.+)$")
+var reGenericGit = regexp.MustCompile("(git://(.+)/(.+))|(git::https://(.+)/(.+))|(git::ssh://((.+)@)??(.+)/(.+)/(.+))")
+
+// Check checks if module source version is default or unpinned
+// Note that this rule is valid only for Git or Mercurial source
+func (r *TerraformModulePinnedSourceRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	for _, module := range runner.TFConfig.Module.ModuleCalls {
+		log.Printf("[DEBUG] Walk `%s` attribute", module.Name+".source")
+
+		lower := strings.ToLower(module.SourceAddr)
+
+		if reGithub.MatchString(lower) || reBitbucket.MatchString(lower) || reGenericGit.MatchString(lower) {
+			r.checkGitSource(runner, module)
+		} else if strings.HasPrefix(lower, "hg::") {
+			r.checkMercurialSource(runner, module)
+		}
+	}
+
+	return nil
+}
+
+// If the source has `ref=master` or doesn't have reference, it reports an issue for the module
+func (r *TerraformModulePinnedSourceRule) checkGitSource(runner *tflint.Runner, module *configs.ModuleCall) {
+	lower := strings.ToLower(module.SourceAddr)
+
+	if strings.Contains(lower, "ref=") {
+		if strings.Contains(lower, "ref=master") {
+			runner.Issues = append(runner.Issues, &issue.Issue{
+				Detector: r.Name(),
+				Type:     issue.WARNING,
+				Message:  fmt.Sprintf("Module source \"%s\" uses default ref \"master\"", module.SourceAddr),
+				Line:     module.SourceAddrRange.Start.Line,
+				File:     runner.GetFileName(module.SourceAddrRange.Filename),
+				Link:     r.link,
+			})
+		}
+	} else {
+		runner.Issues = append(runner.Issues, &issue.Issue{
+			Detector: r.Name(),
+			Type:     issue.WARNING,
+			Message:  fmt.Sprintf("Module source \"%s\" is not pinned", module.SourceAddr),
+			Line:     module.SourceAddrRange.Start.Line,
+			File:     runner.GetFileName(module.SourceAddrRange.Filename),
+			Link:     r.link,
+		})
+	}
+}
+
+// If the source has `rev=default` or doesn't have reference, it reports an issue for the module
+func (r *TerraformModulePinnedSourceRule) checkMercurialSource(runner *tflint.Runner, module *configs.ModuleCall) {
+	lower := strings.ToLower(module.SourceAddr)
+
+	if strings.Contains(lower, "rev=") {
+		if strings.Contains(lower, "rev=default") {
+			runner.Issues = append(runner.Issues, &issue.Issue{
+				Detector: r.Name(),
+				Type:     issue.WARNING,
+				Message:  fmt.Sprintf("Module source \"%s\" uses default rev \"default\"", module.SourceAddr),
+				Line:     module.SourceAddrRange.Start.Line,
+				File:     runner.GetFileName(module.SourceAddrRange.Filename),
+				Link:     r.link,
+			})
+		}
+	} else {
+		runner.Issues = append(runner.Issues, &issue.Issue{
+			Detector: r.Name(),
+			Type:     issue.WARNING,
+			Message:  fmt.Sprintf("Module source \"%s\" is not pinned", module.SourceAddr),
+			Line:     module.SourceAddrRange.Start.Line,
+			File:     runner.GetFileName(module.SourceAddrRange.Filename),
+			Link:     r.link,
+		})
+	}
+}

--- a/rules/terraformrules/terraform_module_pinned_source_test.go
+++ b/rules/terraformrules/terraform_module_pinned_source_test.go
@@ -1,0 +1,323 @@
+package terraformrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_TerraformModulePinnedSource(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected issue.Issues
+	}{
+		{
+			Name: "git module is not pinned",
+			Content: `
+module "unpinned" {
+  source = "git://hashicorp.com/consul.git"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "terraform_module_pinned_source",
+					Type:     issue.WARNING,
+					Message:  "Module source \"git://hashicorp.com/consul.git\" is not pinned",
+					Line:     3,
+					File:     "module.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/terraform_module_pinned_source.md",
+				},
+			},
+		},
+		{
+			Name: "git module reference is default",
+			Content: `
+module "default_git" {
+  source = "git://hashicorp.com/consul.git?ref=master"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "terraform_module_pinned_source",
+					Type:     issue.WARNING,
+					Message:  "Module source \"git://hashicorp.com/consul.git?ref=master\" uses default ref \"master\"",
+					Line:     3,
+					File:     "module.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/terraform_module_pinned_source.md",
+				},
+			},
+		},
+		{
+			Name: "git module reference is pinned",
+			Content: `
+module "pinned_git" {
+  source = "git://hashicorp.com/consul.git?ref=pinned"
+}`,
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "github module is not pinned",
+			Content: `
+module "unpinned" {
+  source = "github.com/hashicorp/consul"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "terraform_module_pinned_source",
+					Type:     issue.WARNING,
+					Message:  "Module source \"github.com/hashicorp/consul\" is not pinned",
+					Line:     3,
+					File:     "module.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/terraform_module_pinned_source.md",
+				},
+			},
+		},
+		{
+			Name: "github module reference is default",
+			Content: `
+module "default_git" {
+  source = "github.com/hashicorp/consul.git?ref=master"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "terraform_module_pinned_source",
+					Type:     issue.WARNING,
+					Message:  "Module source \"github.com/hashicorp/consul.git?ref=master\" uses default ref \"master\"",
+					Line:     3,
+					File:     "module.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/terraform_module_pinned_source.md",
+				},
+			},
+		},
+		{
+			Name: "github module reference is pinned",
+			Content: `
+module "pinned_git" {
+  source = "github.com/hashicorp/consul.git?ref=pinned"
+}`,
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "bitbucket module is not pinned",
+			Content: `
+module "unpinned" {
+  source = "bitbucket.org/hashicorp/consul"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "terraform_module_pinned_source",
+					Type:     issue.WARNING,
+					Message:  "Module source \"bitbucket.org/hashicorp/consul\" is not pinned",
+					Line:     3,
+					File:     "module.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/terraform_module_pinned_source.md",
+				},
+			},
+		},
+		{
+			Name: "bitbucket module reference is default",
+			Content: `
+module "default_git" {
+  source = "bitbucket.org/hashicorp/consul.git?ref=master"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "terraform_module_pinned_source",
+					Type:     issue.WARNING,
+					Message:  "Module source \"bitbucket.org/hashicorp/consul.git?ref=master\" uses default ref \"master\"",
+					Line:     3,
+					File:     "module.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/terraform_module_pinned_source.md",
+				},
+			},
+		},
+		{
+			Name: "bitbucket module reference is pinned",
+			Content: `
+module "pinned_git" {
+  source = "bitbucket.org/hashicorp/consul.git?ref=pinned"
+}`,
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "generic git (git::https) module reference is not pinned",
+			Content: `
+module "unpinned_generic_git_https" {
+  source = "git::https://hashicorp.com/consul.git"
+}
+`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "terraform_module_pinned_source",
+					Type:     issue.WARNING,
+					Message:  "Module source \"git::https://hashicorp.com/consul.git\" is not pinned",
+					Line:     3,
+					File:     "module.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/terraform_module_pinned_source.md",
+				},
+			},
+		},
+		{
+			Name: "generic git (git::ssh) module reference is not pinned",
+			Content: `
+module "unpinned_generic_git_ssh" {
+  source = "git::ssh://git@github.com/owner/repo.git"
+}
+`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "terraform_module_pinned_source",
+					Type:     issue.WARNING,
+					Message:  "Module source \"git::ssh://git@github.com/owner/repo.git\" is not pinned",
+					Line:     3,
+					File:     "module.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/terraform_module_pinned_source.md",
+				},
+			},
+		},
+		{
+			Name: "generic git (git::https) module reference is default",
+			Content: `
+module "default_generic_git_https" {
+  source = "git::https://hashicorp.com/consul.git?ref=master"
+}
+`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "terraform_module_pinned_source",
+					Type:     issue.WARNING,
+					Message:  "Module source \"git::https://hashicorp.com/consul.git?ref=master\" uses default ref \"master\"",
+					Line:     3,
+					File:     "module.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/terraform_module_pinned_source.md",
+				},
+			},
+		},
+		{
+			Name: "generic git (git::ssh) module reference is default",
+			Content: `
+module "default_generic_git_ssh" {
+  source = "git::ssh://git@github.com/owner/repo.git?ref=master"
+}
+`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "terraform_module_pinned_source",
+					Type:     issue.WARNING,
+					Message:  "Module source \"git::ssh://git@github.com/owner/repo.git?ref=master\" uses default ref \"master\"",
+					Line:     3,
+					File:     "module.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/terraform_module_pinned_source.md",
+				},
+			},
+		},
+		{
+			Name: "generic git (git::https) module reference is pinned",
+			Content: `
+module "pinned_generic_git_https" {
+  source = "git::https://hashicorp.com/consul.git?ref=pinned"
+}
+`,
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "generic git (git::ssh) module reference is pinned",
+			Content: `
+module "pinned_generic_git_ssh" {
+  source = "git::ssh://git@github.com/owner/repo.git?ref=pinned"
+}
+`,
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "mercurial module is not pinned",
+			Content: `
+module "default_mercurial" {
+  source = "hg::http://hashicorp.com/consul.hg"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "terraform_module_pinned_source",
+					Type:     issue.WARNING,
+					Message:  "Module source \"hg::http://hashicorp.com/consul.hg\" is not pinned",
+					Line:     3,
+					File:     "module.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/terraform_module_pinned_source.md",
+				},
+			},
+		},
+		{
+			Name: "mercurial module reference is default",
+			Content: `
+module "default_mercurial" {
+  source = "hg::http://hashicorp.com/consul.hg?rev=default"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "terraform_module_pinned_source",
+					Type:     issue.WARNING,
+					Message:  "Module source \"hg::http://hashicorp.com/consul.hg?rev=default\" uses default rev \"default\"",
+					Line:     3,
+					File:     "module.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/terraform_module_pinned_source.md",
+				},
+			},
+		},
+		{
+			Name: "mercurial module reference is pinned",
+			Content: `
+module "pinned_mercurial" {
+  source = "hg::http://hashicorp.com/consul.hg?rev=pinned"
+}`,
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "TerraformModulePinnedSource")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/module.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.ModuleWalkerFunc(func(req *configs.ModuleRequest) (*configs.Module, *version.Version, hcl.Diagnostics) {
+			return nil, nil, nil
+		}))
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewTerraformModulePinnedSourceRule()
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/terraformrules/terraformrules_test.go
+++ b/rules/terraformrules/terraformrules_test.go
@@ -1,0 +1,13 @@
+package terraformrules
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	log.SetOutput(ioutil.Discard)
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
This PR introduces `terraformrules` package and migrate `terraform_module_pinned_source` to `rules` from `detector`.

At first, I planned to develop an API for walking module attributes, but since the `source` has been treated as a special attribute in Terraform, it is implemented without new API.

There is no change in behavior due to this migration.