### PR TITLE
Add "features" word to docs for people explicitly looking

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ template.tf
 Result: 2 issues  (1 errors , 0 warnings , 1 notices)
 ```
 
-If you would like to know more about these issues please check the [documentation](https://github.com/wata727/tflint/tree/master/docs).
+If you would like to know more about these issues and available features please check the [documentation](https://github.com/wata727/tflint/tree/master/docs).
 
 ### Specify Template
 If you want to parse only a specific template, not all templates, you can specify a filename as an argument.


### PR DESCRIPTION
Fixes #236.

Might not be how you'd want this fixed, but I looked through with only eyes for features, and this would have helped (at least since I also did `CTRL+F`).