### PR TITLE
Migrate `aws_instance_default_standard_volume` to rules

### DIFF
--- a/rules/awsrules/aws_instance_default_standard_volume.go
+++ b/rules/awsrules/aws_instance_default_standard_volume.go
@@ -1,0 +1,65 @@
+package awsrules
+
+import (
+	"log"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsInstanceDefaultStandardVolumeRule checks whether the volume type is unspecified
+type AwsInstanceDefaultStandardVolumeRule struct {
+	resourceType string
+}
+
+// NewAwsInstanceDefaultStandardVolumeRule returns new rule with default attributes
+func NewAwsInstanceDefaultStandardVolumeRule() *AwsInstanceDefaultStandardVolumeRule {
+	return &AwsInstanceDefaultStandardVolumeRule{
+		resourceType: "aws_instance",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsInstanceDefaultStandardVolumeRule) Name() string {
+	return "aws_instance_default_standard_volume"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsInstanceDefaultStandardVolumeRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `volume_type` is defined for `root_block_device` or `ebs_block_device`
+func (r *AwsInstanceDefaultStandardVolumeRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	err := runner.WalkResourceAttributes(r.resourceType, "root_block_device", func(attribute *hcl.Attribute) error {
+		return r.walker(runner, attribute)
+	})
+	if err != nil {
+		return err
+	}
+	return runner.WalkResourceAttributes(r.resourceType, "ebs_block_device", func(attribute *hcl.Attribute) error {
+		return r.walker(runner, attribute)
+	})
+}
+
+func (r *AwsInstanceDefaultStandardVolumeRule) walker(runner *tflint.Runner, attribute *hcl.Attribute) error {
+	var val map[string]string
+	err := runner.EvaluateExpr(attribute.Expr, &val)
+
+	return runner.EnsureNoError(err, func() error {
+		if _, ok := val["volume_type"]; !ok {
+			runner.Issues = append(runner.Issues, &issue.Issue{
+				Detector: r.Name(),
+				Type:     issue.WARNING,
+				Message:  "\"volume_type\" is not specified. Default standard volume type is not recommended. You can use \"gp2\", \"io1\", etc instead.",
+				Line:     attribute.Range.Start.Line,
+				File:     runner.GetFileName(attribute.Range.Filename),
+				Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_instance_default_standard_volume.md",
+			})
+		}
+		return nil
+	})
+}

--- a/rules/awsrules/aws_instance_default_standard_volume_test.go
+++ b/rules/awsrules/aws_instance_default_standard_volume_test.go
@@ -1,0 +1,166 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsInstanceDefaultStandardVolume(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected issue.Issues
+	}{
+		{
+			Name: "volume_type is not specified in root_block_device",
+			Content: `
+resource "aws_instance" "web" {
+    instance_type = "c3.2xlarge"
+
+    root_block_device = {
+        volume_size = "24"
+    }
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_instance_default_standard_volume",
+					Type:     issue.WARNING,
+					Message:  "\"volume_type\" is not specified. Default standard volume type is not recommended. You can use \"gp2\", \"io1\", etc instead.",
+					Line:     5,
+					File:     "resource.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_instance_default_standard_volume.md",
+				},
+			},
+		},
+		{
+			Name: "volume_type is not specified in ebs_block_device",
+			Content: `
+resource "aws_instance" "web" {
+    instance_type = "c3.2xlarge"
+
+    ebs_block_device = {
+        volume_size = "24"
+    }
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_instance_default_standard_volume",
+					Type:     issue.WARNING,
+					Message:  "\"volume_type\" is not specified. Default standard volume type is not recommended. You can use \"gp2\", \"io1\", etc instead.",
+					Line:     5,
+					File:     "resource.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_instance_default_standard_volume.md",
+				},
+			},
+		},
+		{
+			Name: "volume_type is specified",
+			Content: `
+resource "aws_instance" "web" {
+    instance_type = "c3.2xlarge"
+
+    root_block_device = {
+        volume_type = "gp2"
+        volume_size = "24"
+    }
+}`,
+			Expected: []*issue.Issue{},
+		},
+		// TODO: An error occurred in Terraform v0.12. Attribute redefined; The argument "ebs_block_device" was already set
+
+		// 		{
+		// 			Name: "volume_type is not specified in multi devices",
+		// 			Content: `
+		// resource "aws_instance" "web" {
+		//     instance_type = "c3.2xlarge"
+		//     ami = "ami-1234567"
+
+		//     root_block_device = {
+		//         volume_size = "100"
+		//     }
+
+		//     ebs_block_device = {
+		//         device_name = "foo"
+		//         volume_size = "24"
+		//     }
+
+		//     ebs_block_device = {
+		//         device_name = "bar"
+		//         volume_size = "10"
+		//     }
+		// }`,
+		// 			Expected: []*issue.Issue{
+		// 				{
+		// 					Detector: "aws_instance_default_standard_volume",
+		// 					Type:     issue.WARNING,
+		// 					Message:  "\"volume_type\" is not specified. Default standard volume type is not recommended. You can use \"gp2\", \"io1\", etc instead.",
+		// 					Line:     6,
+		// 					File:     "resource.tf",
+		// 					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_instance_default_standard_volume.md",
+		// 				},
+		// 				{
+		// 					Detector: "aws_instance_default_standard_volume",
+		// 					Type:     issue.WARNING,
+		// 					Message:  "\"volume_type\" is not specified. Default standard volume type is not recommended. You can use \"gp2\", \"io1\", etc instead.",
+		// 					Line:     10,
+		// 					File:     "resource.tf",
+		// 					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_instance_default_standard_volume.md",
+		// 				},
+		// 				{
+		// 					Detector: "aws_instance_default_standard_volume",
+		// 					Type:     issue.WARNING,
+		// 					Message:  "\"volume_type\" is not specified. Default standard volume type is not recommended. You can use \"gp2\", \"io1\", etc instead.",
+		// 					Line:     15,
+		// 					File:     "resource.tf",
+		// 					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_instance_default_standard_volume.md",
+		// 				},
+		// 			},
+		// 		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsInstanceDefaultStandardVolume")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsInstanceDefaultStandardVolumeRule()
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -18,6 +18,7 @@ type Rule interface {
 // DefaultRules is rules by default
 var DefaultRules = []Rule{
 	awsrules.NewAwsDBInstanceReadablePasswordRule(),
+	awsrules.NewAwsInstanceDefaultStandardVolumeRule(),
 	awsrules.NewAwsInstanceInvalidTypeRule(),
 	terraformrules.NewTerraformModulePinnedSourceRule(),
 }

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -199,6 +199,10 @@ func (r *Runner) EvaluateExpr(expr hcl.Expression, ret interface{}) error {
 		val, err = convert.Convert(val, cty.List(cty.String))
 	case *[]int:
 		val, err = convert.Convert(val, cty.List(cty.Number))
+	case *map[string]string:
+		val, err = convert.Convert(val, cty.Map(cty.String))
+	case *map[string]int:
+		val, err = convert.Convert(val, cty.Map(cty.Number))
 	}
 
 	if err != nil {


### PR DESCRIPTION
Migrate `aws_instance_default_standard_volume` rule as the process of migrating to the `rules` package from `detectors`.

In this rule, it needs to be able to access a map of a device block, so it makes `EvaluateExpr` API to accept a map value.

NOTE: The `aws_instance` resource can accept multiple `ebs_block_device` block, but an error occurs with the current Terraform's API:

```
Error: Failed to load configurations: instance.tf:14,5-21: Attribute redefined; The argument "ebs_block_device" was already set at instance.tf:9,5-21. Each argument may be set only once.
```

Since this problem may be resolved by the stable release of Terraform, mark this test as TODO in this pull request.