### PR TITLE
Migrate route rules that access to multiple attributes to rules

### DIFF
--- a/rules/awsrules/aws_route_not_specified_target.go
+++ b/rules/awsrules/aws_route_not_specified_target.go
@@ -1,0 +1,78 @@
+package awsrules
+
+import (
+	"log"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsRouteNotSpecifiedTargetRule checks whether a route definition has a routing target
+type AwsRouteNotSpecifiedTargetRule struct {
+	resourceType string
+}
+
+// NewAwsRouteNotSpecifiedTargetRule returns new rule with default attributes
+func NewAwsRouteNotSpecifiedTargetRule() *AwsRouteNotSpecifiedTargetRule {
+	return &AwsRouteNotSpecifiedTargetRule{
+		resourceType: "aws_route",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsRouteNotSpecifiedTargetRule) Name() string {
+	return "aws_route_not_specified_target"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsRouteNotSpecifiedTargetRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `gateway_id`, `egress_only_gateway_id`, `nat_gateway_id`, `instance_id`
+// `vpc_peering_connection_id` or `network_interface_id` is defined in a resource
+func (r *AwsRouteNotSpecifiedTargetRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	for _, resource := range runner.LookupResourcesByType(r.resourceType) {
+		body, _, diags := resource.Config.PartialContent(&hcl.BodySchema{
+			Attributes: []hcl.AttributeSchema{
+				{
+					Name: "gateway_id",
+				},
+				{
+					Name: "egress_only_gateway_id",
+				},
+				{
+					Name: "nat_gateway_id",
+				},
+				{
+					Name: "instance_id",
+				},
+				{
+					Name: "vpc_peering_connection_id",
+				},
+				{
+					Name: "network_interface_id",
+				},
+			},
+		})
+		if diags.HasErrors() {
+			return diags
+		}
+
+		if len(body.Attributes) == 0 {
+			runner.Issues = append(runner.Issues, &issue.Issue{
+				Detector: r.Name(),
+				Type:     issue.ERROR,
+				Message:  "The routing target is not specified, each routing must contain either a gateway_id, egress_only_gateway_id a nat_gateway_id, an instance_id or a vpc_peering_connection_id or a network_interface_id.",
+				Line:     resource.DeclRange.Start.Line,
+				File:     runner.GetFileName(resource.DeclRange.Filename),
+				Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_route_not_specified_target.md",
+			})
+		}
+	}
+
+	return nil
+}

--- a/rules/awsrules/aws_route_not_specified_target_test.go
+++ b/rules/awsrules/aws_route_not_specified_target_test.go
@@ -1,0 +1,132 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsRouteNotSpecifiedTarget(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected issue.Issues
+	}{
+		{
+			Name: "route target is not specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_route_not_specified_target",
+					Type:     "ERROR",
+					Message:  "The routing target is not specified, each routing must contain either a gateway_id, egress_only_gateway_id a nat_gateway_id, an instance_id or a vpc_peering_connection_id or a network_interface_id.",
+					Line:     2,
+					File:     "resource.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_route_not_specified_target.md",
+				},
+			},
+		},
+		{
+			Name: "gateway_id is specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    gateway_id = "igw-1234abcd"
+}`,
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "egress_only_gateway_id is specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    egress_only_gateway_id = "eigw-1234abcd"
+}`,
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "nat_gateway_id is specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    nat_gateway_id = "nat-1234abcd"
+}`,
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "instance_id is specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    instance_id = "i-1234abcd"
+}`,
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "vpc_peering_connection_id is specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    vpc_peering_connection_id = "pcx-1234abcd"
+}`,
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "network_interface_id is specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    network_interface_id = "eni-1234abcd"
+}`,
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsRouteNotSpecifiedTarget")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsRouteNotSpecifiedTargetRule()
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_route_specified_multiple_targets.go
+++ b/rules/awsrules/aws_route_specified_multiple_targets.go
@@ -1,0 +1,78 @@
+package awsrules
+
+import (
+	"log"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsRouteSpecifiedMultipleTargetsRule checks whether a route definition has multiple routing targets
+type AwsRouteSpecifiedMultipleTargetsRule struct {
+	resourceType string
+}
+
+// NewAwsRouteSpecifiedMultipleTargetsRule returns new rule with default attributes
+func NewAwsRouteSpecifiedMultipleTargetsRule() *AwsRouteSpecifiedMultipleTargetsRule {
+	return &AwsRouteSpecifiedMultipleTargetsRule{
+		resourceType: "aws_route",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsRouteSpecifiedMultipleTargetsRule) Name() string {
+	return "aws_route_specified_multiple_targets"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsRouteSpecifiedMultipleTargetsRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether a resource defines `gateway_id`, `egress_only_gateway_id`, `nat_gateway_id`
+// `instance_id`, `vpc_peering_connection_id` or `network_interface_id` at the same time
+func (r *AwsRouteSpecifiedMultipleTargetsRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	for _, resource := range runner.LookupResourcesByType(r.resourceType) {
+		body, _, diags := resource.Config.PartialContent(&hcl.BodySchema{
+			Attributes: []hcl.AttributeSchema{
+				{
+					Name: "gateway_id",
+				},
+				{
+					Name: "egress_only_gateway_id",
+				},
+				{
+					Name: "nat_gateway_id",
+				},
+				{
+					Name: "instance_id",
+				},
+				{
+					Name: "vpc_peering_connection_id",
+				},
+				{
+					Name: "network_interface_id",
+				},
+			},
+		})
+		if diags.HasErrors() {
+			return diags
+		}
+
+		if len(body.Attributes) > 1 {
+			runner.Issues = append(runner.Issues, &issue.Issue{
+				Detector: r.Name(),
+				Type:     issue.ERROR,
+				Message:  "More than one routing target specified. It must be one.",
+				Line:     resource.DeclRange.Start.Line,
+				File:     runner.GetFileName(resource.DeclRange.Filename),
+				Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_route_specified_multiple_targets.md",
+			})
+		}
+	}
+
+	return nil
+}

--- a/rules/awsrules/aws_route_specified_multiple_targets_test.go
+++ b/rules/awsrules/aws_route_specified_multiple_targets_test.go
@@ -1,0 +1,89 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsRouteSpecifiedMultipleTargets(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected issue.Issues
+	}{
+		{
+			Name: "multiple route targets are specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    gateway_id = "igw-1234abcd"
+    egress_only_gateway_id = "eigw-1234abcd"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_route_specified_multiple_targets",
+					Type:     "ERROR",
+					Message:  "More than one routing target specified. It must be one.",
+					Line:     2,
+					File:     "resource.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_route_specified_multiple_targets.md",
+				},
+			},
+		},
+		{
+			Name: "single a route target is specified",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    gateway_id = "igw-1234abcd"
+}`,
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsRouteSpecifiedMultipleTargets")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsRouteSpecifiedMultipleTargetsRule()
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -20,6 +20,8 @@ var DefaultRules = []Rule{
 	awsrules.NewAwsDBInstanceReadablePasswordRule(),
 	awsrules.NewAwsInstanceDefaultStandardVolumeRule(),
 	awsrules.NewAwsInstanceInvalidTypeRule(),
+	awsrules.NewAwsRouteNotSpecifiedTargetRule(),
+	awsrules.NewAwsRouteSpecifiedMultipleTargetsRule(),
 	terraformrules.NewTerraformModulePinnedSourceRule(),
 }
 

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -275,7 +275,7 @@ func (r *Runner) LookupIssues(files ...string) issue.Issues {
 
 // WalkResourceAttributes searches for resources and passes the appropriate attributes to the walker function
 func (r *Runner) WalkResourceAttributes(resource, attributeName string, walker func(*hcl.Attribute) error) error {
-	for _, resource := range r.lookupResourcesByType(resource) {
+	for _, resource := range r.LookupResourcesByType(resource) {
 		body, _, diags := resource.Config.PartialContent(&hcl.BodySchema{
 			Attributes: []hcl.AttributeSchema{
 				{
@@ -320,6 +320,19 @@ func (r *Runner) EnsureNoError(err error, proc func() error) error {
 	}
 }
 
+// LookupResourcesByType returns `configs.Resource` list according to the resource type
+func (r *Runner) LookupResourcesByType(resourceType string) []*configs.Resource {
+	ret := []*configs.Resource{}
+
+	for _, resource := range r.TFConfig.Module.ManagedResources {
+		if resource.Type == resourceType {
+			ret = append(ret, resource)
+		}
+	}
+
+	return ret
+}
+
 // prepareVariableValues prepares Terraform variables from configs, input variables and environment variables.
 // Variables in the configuration are overwritten by environment variables.
 // Finally, they are overwritten by received input variable on the received order.
@@ -335,18 +348,6 @@ func prepareVariableValues(configVars map[string]*configs.Variable, variables ..
 		variableValues[""][k] = iv.Value
 	}
 	return variableValues
-}
-
-func (r *Runner) lookupResourcesByType(resourceType string) []*configs.Resource {
-	ret := []*configs.Resource{}
-
-	for _, resource := range r.TFConfig.Module.ManagedResources {
-		if resource.Type == resourceType {
-			ret = append(ret, resource)
-		}
-	}
-
-	return ret
 }
 
 func isEvaluable(expr hcl.Expression) bool {

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -1129,7 +1129,7 @@ func Test_NewModuleRunners_withNotAllowedAttributes(t *testing.T) {
 	}
 }
 
-func Test_lookupResourcesByType(t *testing.T) {
+func Test_LookupResourcesByType(t *testing.T) {
 	dir, err := ioutil.TempDir("", "lookupResourcesByType")
 	if err != nil {
 		t.Fatal(err)
@@ -1167,7 +1167,7 @@ resource "aws_route" "r" {
 	}
 
 	runner := NewRunner(EmptyConfig(), cfg, map[string]*terraform.InputValue{})
-	resources := runner.lookupResourcesByType("aws_instance")
+	resources := runner.LookupResourcesByType("aws_instance")
 
 	if len(resources) != 1 {
 		t.Fatalf("Expected resources size is `1`, but get `%d`", len(resources))


### PR DESCRIPTION
This PR migrates `aws_route_not_specified_target` and `aws_route_specified_multiple_targets` to `rules` from `detectors`.

These rules need to access multiple attributes of a resource rather than walking a specific attribute. For that reason, runner exports the `LookupResourcesByType` API so that it can be used in `rules` package.