### PR TITLE
Migrate to rules from detector

### DIFF
--- a/rules/awsrules/aws_alb_invalid_security_group.go
+++ b/rules/awsrules/aws_alb_invalid_security_group.go
@@ -1,0 +1,83 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsALBInvalidSecurityGroupRule checks whether security groups actually exists
+type AwsALBInvalidSecurityGroupRule struct {
+	resourceType   string
+	attributeName  string
+	securityGroups map[string]bool
+	dataPrepared   bool
+}
+
+// NewAwsALBInvalidSecurityGroupRule returns new rule with default attributes
+func NewAwsALBInvalidSecurityGroupRule() *AwsALBInvalidSecurityGroupRule {
+	return &AwsALBInvalidSecurityGroupRule{
+		resourceType:   "aws_alb",
+		attributeName:  "security_groups",
+		securityGroups: map[string]bool{},
+		dataPrepared:   false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsALBInvalidSecurityGroupRule) Name() string {
+	return "aws_alb_invalid_security_group"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsALBInvalidSecurityGroupRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `security_groups` are included in the list retrieved by `DescribeSecurityGroups`
+func (r *AwsALBInvalidSecurityGroupRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch security groups")
+			resp, err := runner.AwsClient.EC2.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing security groups",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, sg := range resp.SecurityGroups {
+				r.securityGroups[*sg.GroupId] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var securityGroups []string
+		err := runner.EvaluateExpr(attribute.Expr, &securityGroups)
+
+		return runner.EnsureNoError(err, func() error {
+			for _, securityGroup := range securityGroups {
+				if !r.securityGroups[securityGroup] {
+					runner.Issues = append(runner.Issues, &issue.Issue{
+						Detector: r.Name(),
+						Type:     issue.ERROR,
+						Message:  fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
+						Line:     attribute.Range.Start.Line,
+						File:     runner.GetFileName(attribute.Range.Filename),
+					})
+				}
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_alb_invalid_security_group_test.go
+++ b/rules/awsrules/aws_alb_invalid_security_group_test.go
@@ -1,0 +1,245 @@
+package awsrules
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsALBInvalidSecurityGroup(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*ec2.SecurityGroup
+		Expected issue.Issues
+	}{
+		{
+			Name: "security group is invalid",
+			Content: `
+resource "aws_alb" "balancer" {
+    security_groups = [
+        "sg-1234abcd",
+        "sg-abcd1234",
+    ]
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-12345678"),
+				},
+				{
+					GroupId: aws.String("sg-abcdefgh"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_alb_invalid_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-1234abcd\" is invalid security group.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+				{
+					Detector: "aws_alb_invalid_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-abcd1234\" is invalid security group.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "security group is valid",
+			Content: `
+resource "aws_alb" "balancer" {
+    security_groups = [
+        "sg-1234abcd",
+        "sg-abcd1234",
+    ]
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-1234abcd"),
+				},
+				{
+					GroupId: aws.String("sg-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "use list variables",
+			Content: `
+variable "security_groups" {
+    default = ["sg-1234abcd", "sg-abcd1234"]
+}
+
+resource "aws_alb" "balancer" {
+    security_groups = "${var.security_groups}"
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-12345678"),
+				},
+				{
+					GroupId: aws.String("sg-abcdefgh"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_alb_invalid_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-1234abcd\" is invalid security group.",
+					Line:     7,
+					File:     "resource.tf",
+				},
+				{
+					Detector: "aws_alb_invalid_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-abcd1234\" is invalid security group.",
+					Line:     7,
+					File:     "resource.tf",
+				},
+			},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsAlbInvalidSecurityGroup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsALBInvalidSecurityGroupRule()
+
+		mock := mock.NewMockEC2API(ctrl)
+		mock.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{}).Return(&ec2.DescribeSecurityGroupsOutput{
+			SecurityGroups: tc.Response,
+		}, nil)
+		runner.AwsClient.EC2 = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}
+
+func Test_AwsAlbInvalidSecurityGroup_error(t *testing.T) {
+	cases := []struct {
+		Name       string
+		Content    string
+		Response   error
+		ErrorCode  int
+		ErrorLevel int
+		ErrorText  string
+	}{
+		{
+			Name: "API error",
+			Content: `
+resource "aws_alb" "balancer" {
+    security_groups = [
+        "sg-1234abcd",
+        "sg-abcd1234",
+    ]
+}`,
+			Response:   errors.New("MissingRegion: could not find region configuration"),
+			ErrorCode:  tflint.ExternalAPIError,
+			ErrorLevel: tflint.ErrorLevel,
+			ErrorText:  "An error occurred while describing security groups; MissingRegion: could not find region configuration",
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsAlbInvalidSecurityGroup_error")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsALBInvalidSecurityGroupRule()
+
+		mock := mock.NewMockEC2API(ctrl)
+		mock.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{}).Return(nil, tc.Response)
+		runner.AwsClient.EC2 = mock
+
+		err = rule.Check(runner)
+		if appErr, ok := err.(*tflint.Error); ok {
+			if appErr == nil {
+				t.Fatalf("Failed `%s` test: expected err is `%s`, but nothing occurred", tc.Name, tc.ErrorText)
+			}
+			if appErr.Code != tc.ErrorCode {
+				t.Fatalf("Failed `%s` test: expected error code is `%d`, but get `%d`", tc.Name, tc.ErrorCode, appErr.Code)
+			}
+			if appErr.Level != tc.ErrorLevel {
+				t.Fatalf("Failed `%s` test: expected error level is `%d`, but get `%d`", tc.Name, tc.ErrorLevel, appErr.Level)
+			}
+			if appErr.Error() != tc.ErrorText {
+				t.Fatalf("Failed `%s` test: expected error is `%s`, but get `%s`", tc.Name, tc.ErrorText, appErr.Error())
+			}
+		} else {
+			t.Fatalf("Failed `%s` test: unexpected error occurred: %s", tc.Name, err)
+		}
+	}
+}

--- a/rules/awsrules/aws_alb_invalid_subnet.go
+++ b/rules/awsrules/aws_alb_invalid_subnet.go
@@ -1,0 +1,83 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsALBInvalidSubnetRule checks whether subnets actually exists
+type AwsALBInvalidSubnetRule struct {
+	resourceType  string
+	attributeName string
+	subnets       map[string]bool
+	dataPrepared  bool
+}
+
+// NewAwsALBInvalidSubnetRule returns new rule with default attributes
+func NewAwsALBInvalidSubnetRule() *AwsALBInvalidSubnetRule {
+	return &AwsALBInvalidSubnetRule{
+		resourceType:  "aws_alb",
+		attributeName: "subnets",
+		subnets:       map[string]bool{},
+		dataPrepared:  false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsALBInvalidSubnetRule) Name() string {
+	return "aws_alb_invalid_subnet"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsALBInvalidSubnetRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `subnets` are included in the list retrieved by `DescribeSubnets`
+func (r *AwsALBInvalidSubnetRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch subnets")
+			resp, err := runner.AwsClient.EC2.DescribeSubnets(&ec2.DescribeSubnetsInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing subnets",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, subnet := range resp.Subnets {
+				r.subnets[*subnet.SubnetId] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var subnets []string
+		err := runner.EvaluateExpr(attribute.Expr, &subnets)
+
+		return runner.EnsureNoError(err, func() error {
+			for _, subnet := range subnets {
+				if !r.subnets[subnet] {
+					runner.Issues = append(runner.Issues, &issue.Issue{
+						Detector: r.Name(),
+						Type:     issue.ERROR,
+						Message:  fmt.Sprintf("\"%s\" is invalid subnet ID.", subnet),
+						Line:     attribute.Range.Start.Line,
+						File:     runner.GetFileName(attribute.Range.Filename),
+					})
+				}
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_alb_invalid_subnet_test.go
+++ b/rules/awsrules/aws_alb_invalid_subnet_test.go
@@ -1,0 +1,148 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsALBInvalidSubnet(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*ec2.Subnet
+		Expected issue.Issues
+	}{
+		{
+			Name: "subnet ID is invalid",
+			Content: `
+resource "aws_alb" "balancer" {
+    subnets = [
+        "subnet-1234abcd",
+        "subnet-abcd1234",
+    ]
+}`,
+			Response: []*ec2.Subnet{
+				{
+					SubnetId: aws.String("subnet-12345678"),
+				},
+				{
+					SubnetId: aws.String("subnet-abcdefgh"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_alb_invalid_subnet",
+					Type:     "ERROR",
+					Message:  "\"subnet-1234abcd\" is invalid subnet ID.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+				{
+					Detector: "aws_alb_invalid_subnet",
+					Type:     "ERROR",
+					Message:  "\"subnet-abcd1234\" is invalid subnet ID.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "subnet ID is valid",
+			Content: `
+resource "aws_alb" "balancer" {
+    subnets = [
+        "subnet-1234abcd",
+        "subnet-abcd1234",
+    ]
+}`,
+			Response: []*ec2.Subnet{
+				{
+					SubnetId: aws.String("subnet-1234abcd"),
+				},
+				{
+					SubnetId: aws.String("subnet-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "use list variables",
+			Content: `
+variable "subnets" {
+    default = ["subnet-1234abcd", "subnet-abcd1234"]
+}
+
+resource "aws_alb" "balancer" {
+    subnets = "${var.subnets}"
+}`,
+			Response: []*ec2.Subnet{
+				{
+					SubnetId: aws.String("subnet-1234abcd"),
+				},
+				{
+					SubnetId: aws.String("subnet-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsALBInvalidSubnet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsALBInvalidSubnetRule()
+
+		mock := mock.NewMockEC2API(ctrl)
+		mock.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{}).Return(&ec2.DescribeSubnetsOutput{
+			Subnets: tc.Response,
+		}, nil)
+		runner.AwsClient.EC2 = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_cloudwatch_metric_alarm_invalid_unit.go
+++ b/rules/awsrules/aws_cloudwatch_metric_alarm_invalid_unit.go
@@ -1,0 +1,89 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsCloudwatchMetricAlarmInvalidUnitRule checks whether the valid unit is used in an alerm
+type AwsCloudwatchMetricAlarmInvalidUnitRule struct {
+	resourceType  string
+	attributeName string
+	validUnits    map[string]bool
+}
+
+// NewAwsCloudwatchMetricAlarmInvalidUnitRule returns new rule with default attributes
+func NewAwsCloudwatchMetricAlarmInvalidUnitRule() *AwsCloudwatchMetricAlarmInvalidUnitRule {
+	return &AwsCloudwatchMetricAlarmInvalidUnitRule{
+		resourceType:  "aws_cloudwatch_metric_alarm",
+		attributeName: "unit",
+		// @see http://docs.aws.amazon.com/cli/latest/reference/cloudwatch/put-metric-alarm.html
+		validUnits: map[string]bool{
+			"Seconds":          true,
+			"Microseconds":     true,
+			"Milliseconds":     true,
+			"Bytes":            true,
+			"Kilobytes":        true,
+			"Megabytes":        true,
+			"Gigabytes":        true,
+			"Terabytes":        true,
+			"Bits":             true,
+			"Kilobits":         true,
+			"Megabits":         true,
+			"Gigabits":         true,
+			"Terabits":         true,
+			"Percent":          true,
+			"Count":            true,
+			"Bytes/Second":     true,
+			"Kilobytes/Second": true,
+			"Megabytes/Second": true,
+			"Gigabytes/Second": true,
+			"Terabytes/Second": true,
+			"Bits/Second":      true,
+			"Kilobits/Second":  true,
+			"Megabits/Second":  true,
+			"Gigabits/Second":  true,
+			"Terabits/Second":  true,
+			"Count/Second":     true,
+			"None":             true,
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsCloudwatchMetricAlarmInvalidUnitRule) Name() string {
+	return "aws_cloudwatch_metric_alarm_invalid_unit"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsCloudwatchMetricAlarmInvalidUnitRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `unit` is included in the valid unit list
+func (r *AwsCloudwatchMetricAlarmInvalidUnitRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var unit string
+		err := runner.EvaluateExpr(attribute.Expr, &unit)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.validUnits[unit] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid unit.", unit),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_cloudwatch_metric_alarm_invalid_unit.md",
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_cloudwatch_metric_alarm_invalid_unit_test.go
+++ b/rules/awsrules/aws_cloudwatch_metric_alarm_invalid_unit_test.go
@@ -1,0 +1,121 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsCloudwatchMetricAlarmInvalidUnit(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected issue.Issues
+	}{
+		{
+			Name: "GB is invalid",
+			Content: `
+resource "aws_cloudwatch_metric_alarm" "test" {
+    metric_name         = "FreeableMemory"
+    namespace           = "AWS/RDS"
+
+    period    = "300"
+    statistic = "Average"
+    threshold = "1"
+    unit      = "GB"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_cloudwatch_metric_alarm_invalid_unit",
+					Type:     "ERROR",
+					Message:  "\"GB\" is invalid unit.",
+					Line:     9,
+					File:     "resource.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_cloudwatch_metric_alarm_invalid_unit.md",
+				},
+			},
+		},
+		{
+			Name: "Lowercase is invalid",
+			Content: `
+resource "aws_cloudwatch_metric_alarm" "test" {
+    metric_name         = "FreeableMemory"
+    namespace           = "AWS/RDS"
+
+    period    = "300"
+    statistic = "Average"
+    threshold = "1"
+    unit      = "gigabytes"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_cloudwatch_metric_alarm_invalid_unit",
+					Type:     "ERROR",
+					Message:  "\"gigabytes\" is invalid unit.",
+					Line:     9,
+					File:     "resource.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_cloudwatch_metric_alarm_invalid_unit.md",
+				},
+			},
+		},
+		{
+			Name: "Gigabytes is valid",
+			Content: `
+resource "aws_cloudwatch_metric_alarm" "test" {
+    metric_name         = "FreeableMemory"
+    namespace           = "AWS/RDS"
+
+    period    = "300"
+    statistic = "Average"
+    threshold = "1"
+    unit      = "Gigabytes"
+}`,
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsCloudwatchMetricAlarmInvalidUnit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsCloudwatchMetricAlarmInvalidUnitRule()
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_db_instance_default_parameter_group.go
+++ b/rules/awsrules/aws_db_instance_default_parameter_group.go
@@ -1,0 +1,61 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsDBInstanceDefaultParameterGroupRule checks whether the db instance use default parameter group
+type AwsDBInstanceDefaultParameterGroupRule struct {
+	resourceType  string
+	attributeName string
+}
+
+// NewAwsDBInstanceDefaultParameterGroupRule returns new rule with default attributes
+func NewAwsDBInstanceDefaultParameterGroupRule() *AwsDBInstanceDefaultParameterGroupRule {
+	return &AwsDBInstanceDefaultParameterGroupRule{
+		resourceType:  "aws_db_instance",
+		attributeName: "parameter_group_name",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsDBInstanceDefaultParameterGroupRule) Name() string {
+	return "aws_db_instance_default_parameter_group"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsDBInstanceDefaultParameterGroupRule) Enabled() bool {
+	return true
+}
+
+var defaultDBParameterGroupRegexp = regexp.MustCompile("^default")
+
+// Check checks the parameter group name starts with `default`
+func (r *AwsDBInstanceDefaultParameterGroupRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var name string
+		err := runner.EvaluateExpr(attribute.Expr, &name)
+
+		return runner.EnsureNoError(err, func() error {
+			if defaultDBParameterGroupRegexp.Match([]byte(name)) {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.NOTICE,
+					Message:  fmt.Sprintf("\"%s\" is default parameter group. You cannot edit it.", name),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_db_instance_default_parameter_group.md",
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_db_instance_default_parameter_group_test.go
+++ b/rules/awsrules/aws_db_instance_default_parameter_group_test.go
@@ -1,0 +1,86 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsDBInstanceDefaultParameterGroup(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected issue.Issues
+	}{
+		{
+			Name: "default.mysql5.6 is default parameter group",
+			Content: `
+resource "aws_db_instance" "db" {
+    parameter_group_name = "default.mysql5.6"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_db_instance_default_parameter_group",
+					Type:     "NOTICE",
+					Message:  "\"default.mysql5.6\" is default parameter group. You cannot edit it.",
+					Line:     3,
+					File:     "resource.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_db_instance_default_parameter_group.md",
+				},
+			},
+		},
+		{
+			Name: "application5.6 is not default parameter group",
+			Content: `
+resource "aws_db_instance" "db" {
+    parameter_group_name = "application5.6"
+}`,
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsDBInstanceDefaultParameterGroup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsDBInstanceDefaultParameterGroupRule()
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_db_instance_invalid_db_subnet_group.go
+++ b/rules/awsrules/aws_db_instance_invalid_db_subnet_group.go
@@ -1,0 +1,81 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsDBInstanceInvalidDBSubnetGroupRule checks whether DB subnet group actually exists
+type AwsDBInstanceInvalidDBSubnetGroupRule struct {
+	resourceType  string
+	attributeName string
+	subnetGroups  map[string]bool
+	dataPrepared  bool
+}
+
+// NewAwsDBInstanceInvalidDBSubnetGroupRule returns new rule with default attributes
+func NewAwsDBInstanceInvalidDBSubnetGroupRule() *AwsDBInstanceInvalidDBSubnetGroupRule {
+	return &AwsDBInstanceInvalidDBSubnetGroupRule{
+		resourceType:  "aws_db_instance",
+		attributeName: "db_subnet_group_name",
+		subnetGroups:  map[string]bool{},
+		dataPrepared:  false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsDBInstanceInvalidDBSubnetGroupRule) Name() string {
+	return "aws_db_instance_invalid_db_subnet_group"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsDBInstanceInvalidDBSubnetGroupRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `db_subnet_group_name` are included in the list retrieved by `DescribeDBSubnetGroups`
+func (r *AwsDBInstanceInvalidDBSubnetGroupRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch DB subnet groups")
+			resp, err := runner.AwsClient.RDS.DescribeDBSubnetGroups(&rds.DescribeDBSubnetGroupsInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing DB subnet groups",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, subnetGroup := range resp.DBSubnetGroups {
+				r.subnetGroups[*subnetGroup.DBSubnetGroupName] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var subnetGroup string
+		err := runner.EvaluateExpr(attribute.Expr, &subnetGroup)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.subnetGroups[subnetGroup] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid DB subnet group name.", subnetGroup),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_db_instance_invalid_db_subnet_group_test.go
+++ b/rules/awsrules/aws_db_instance_invalid_db_subnet_group_test.go
@@ -1,0 +1,118 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsDBInstanceInvalidDBSubnetGroup(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*rds.DBSubnetGroup
+		Expected issue.Issues
+	}{
+		{
+			Name: "db_subnet_group_name is invalid",
+			Content: `
+resource "aws_db_instance" "mysql" {
+    db_subnet_group_name = "app-server"
+}`,
+			Response: []*rds.DBSubnetGroup{
+				{
+					DBSubnetGroupName: aws.String("app-server1"),
+				},
+				{
+					DBSubnetGroupName: aws.String("app-server2"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_db_instance_invalid_db_subnet_group",
+					Type:     "ERROR",
+					Message:  "\"app-server\" is invalid DB subnet group name.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "db_subnet_group_name is valid",
+			Content: `
+resource "aws_db_instance" "mysql" {
+    db_subnet_group_name = "app-server"
+}`,
+			Response: []*rds.DBSubnetGroup{
+				{
+					DBSubnetGroupName: aws.String("app-server1"),
+				},
+				{
+					DBSubnetGroupName: aws.String("app-server2"),
+				},
+				{
+					DBSubnetGroupName: aws.String("app-server"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsDBInstanceInvalidDBSubnetGroup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsDBInstanceInvalidDBSubnetGroupRule()
+
+		mock := mock.NewMockRDSAPI(ctrl)
+		mock.EXPECT().DescribeDBSubnetGroups(&rds.DescribeDBSubnetGroupsInput{}).Return(&rds.DescribeDBSubnetGroupsOutput{
+			DBSubnetGroups: tc.Response,
+		}, nil)
+		runner.AwsClient.RDS = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_db_instance_invalid_option_group.go
+++ b/rules/awsrules/aws_db_instance_invalid_option_group.go
@@ -1,0 +1,81 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsDBInstanceInvalidOptionGroupRule checks whether option group actually exists
+type AwsDBInstanceInvalidOptionGroupRule struct {
+	resourceType  string
+	attributeName string
+	optionGroups  map[string]bool
+	dataPrepared  bool
+}
+
+// NewAwsDBInstanceInvalidOptionGroupRule returns new rule with default attributes
+func NewAwsDBInstanceInvalidOptionGroupRule() *AwsDBInstanceInvalidOptionGroupRule {
+	return &AwsDBInstanceInvalidOptionGroupRule{
+		resourceType:  "aws_db_instance",
+		attributeName: "option_group_name",
+		optionGroups:  map[string]bool{},
+		dataPrepared:  false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsDBInstanceInvalidOptionGroupRule) Name() string {
+	return "aws_db_instance_invalid_option_group"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsDBInstanceInvalidOptionGroupRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `option_group_name` are included in the list retrieved by `DescribeOptionGroups`
+func (r *AwsDBInstanceInvalidOptionGroupRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch option groups")
+			resp, err := runner.AwsClient.RDS.DescribeOptionGroups(&rds.DescribeOptionGroupsInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing option groups",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, optionGroup := range resp.OptionGroupsList {
+				r.optionGroups[*optionGroup.OptionGroupName] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var optionGroup string
+		err := runner.EvaluateExpr(attribute.Expr, &optionGroup)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.optionGroups[optionGroup] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid option group name.", optionGroup),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_db_instance_invalid_option_group_test.go
+++ b/rules/awsrules/aws_db_instance_invalid_option_group_test.go
@@ -1,0 +1,118 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsDBInstanceInvalidOptionGroup(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*rds.OptionGroup
+		Expected issue.Issues
+	}{
+		{
+			Name: "option_group is invalid",
+			Content: `
+resource "aws_db_instance" "mysql" {
+    option_group_name = "app-server"
+}`,
+			Response: []*rds.OptionGroup{
+				{
+					OptionGroupName: aws.String("app-server1"),
+				},
+				{
+					OptionGroupName: aws.String("app-server2"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_db_instance_invalid_option_group",
+					Type:     "ERROR",
+					Message:  "\"app-server\" is invalid option group name.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "option_group is valid",
+			Content: `
+resource "aws_db_instance" "mysql" {
+    option_group_name = "app-server"
+}`,
+			Response: []*rds.OptionGroup{
+				{
+					OptionGroupName: aws.String("app-server1"),
+				},
+				{
+					OptionGroupName: aws.String("app-server2"),
+				},
+				{
+					OptionGroupName: aws.String("app-server"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsDBInstanceInvalidOptionGroup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsDBInstanceInvalidOptionGroupRule()
+
+		mock := mock.NewMockRDSAPI(ctrl)
+		mock.EXPECT().DescribeOptionGroups(&rds.DescribeOptionGroupsInput{}).Return(&rds.DescribeOptionGroupsOutput{
+			OptionGroupsList: tc.Response,
+		}, nil)
+		runner.AwsClient.RDS = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_db_instance_invalid_parameter_group.go
+++ b/rules/awsrules/aws_db_instance_invalid_parameter_group.go
@@ -1,0 +1,81 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsDBInstanceInvalidParameterGroupRule checks whether DB parameter group actually exists
+type AwsDBInstanceInvalidParameterGroupRule struct {
+	resourceType    string
+	attributeName   string
+	parameterGroups map[string]bool
+	dataPrepared    bool
+}
+
+// NewAwsDBInstanceInvalidParameterGroupRule returns new rule with default attributes
+func NewAwsDBInstanceInvalidParameterGroupRule() *AwsDBInstanceInvalidParameterGroupRule {
+	return &AwsDBInstanceInvalidParameterGroupRule{
+		resourceType:    "aws_db_instance",
+		attributeName:   "parameter_group_name",
+		parameterGroups: map[string]bool{},
+		dataPrepared:    false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsDBInstanceInvalidParameterGroupRule) Name() string {
+	return "aws_db_instance_invalid_parameter_group"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsDBInstanceInvalidParameterGroupRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `parameter_group_name` are included in the list retrieved by `DescribeDBParameterGroups`
+func (r *AwsDBInstanceInvalidParameterGroupRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch DB parameter groups")
+			resp, err := runner.AwsClient.RDS.DescribeDBParameterGroups(&rds.DescribeDBParameterGroupsInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing DB parameter groups",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, parameterGroup := range resp.DBParameterGroups {
+				r.parameterGroups[*parameterGroup.DBParameterGroupName] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var parameterGroup string
+		err := runner.EvaluateExpr(attribute.Expr, &parameterGroup)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.parameterGroups[parameterGroup] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid parameter group name.", parameterGroup),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_db_instance_invalid_parameter_group_test.go
+++ b/rules/awsrules/aws_db_instance_invalid_parameter_group_test.go
@@ -1,0 +1,118 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsDBInstanceInvalidParameterGroup(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*rds.DBParameterGroup
+		Expected issue.Issues
+	}{
+		{
+			Name: "parameter_group_name is invalid",
+			Content: `
+resource "aws_db_instance" "mysql" {
+    parameter_group_name = "app-server"
+}`,
+			Response: []*rds.DBParameterGroup{
+				{
+					DBParameterGroupName: aws.String("app-server1"),
+				},
+				{
+					DBParameterGroupName: aws.String("app-server2"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_db_instance_invalid_parameter_group",
+					Type:     "ERROR",
+					Message:  "\"app-server\" is invalid parameter group name.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "parameter_group_name is valid",
+			Content: `
+resource "aws_db_instance" "mysql" {
+    parameter_group_name = "app-server"
+}`,
+			Response: []*rds.DBParameterGroup{
+				{
+					DBParameterGroupName: aws.String("app-server1"),
+				},
+				{
+					DBParameterGroupName: aws.String("app-server2"),
+				},
+				{
+					DBParameterGroupName: aws.String("app-server"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsDBInstanceInvalidParameterGroup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsDBInstanceInvalidParameterGroupRule()
+
+		mock := mock.NewMockRDSAPI(ctrl)
+		mock.EXPECT().DescribeDBParameterGroups(&rds.DescribeDBParameterGroupsInput{}).Return(&rds.DescribeDBParameterGroupsOutput{
+			DBParameterGroups: tc.Response,
+		}, nil)
+		runner.AwsClient.RDS = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_db_instance_invalid_type.go
+++ b/rules/awsrules/aws_db_instance_invalid_type.go
@@ -1,0 +1,105 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsDBInstanceInvalidTypeRule checks whether "aws_db_instance" has invalid intance type.
+type AwsDBInstanceInvalidTypeRule struct {
+	resourceType  string
+	attributeName string
+	instanceTypes map[string]bool
+}
+
+// NewAwsDBInstanceInvalidTypeRule returns new rule with default attributes
+func NewAwsDBInstanceInvalidTypeRule() *AwsDBInstanceInvalidTypeRule {
+	return &AwsDBInstanceInvalidTypeRule{
+		resourceType:  "aws_db_instance",
+		attributeName: "instance_class",
+		instanceTypes: map[string]bool{
+			"db.t2.micro":     true,
+			"db.t2.small":     true,
+			"db.t2.medium":    true,
+			"db.t2.large":     true,
+			"db.t2.xlarge":    true,
+			"db.t2.2xlarge":   true,
+			"db.m4.large":     true,
+			"db.m4.xlarge":    true,
+			"db.m4.2xlarge":   true,
+			"db.m4.4xlarge":   true,
+			"db.m4.10xlarge":  true,
+			"db.m4.16xlarge":  true,
+			"db.m3.medium":    true,
+			"db.m3.large":     true,
+			"db.m3.xlarge":    true,
+			"db.m3.2xlarge":   true,
+			"db.r4.large":     true,
+			"db.r4.xlarge":    true,
+			"db.r4.2xlarge":   true,
+			"db.r4.4xlarge":   true,
+			"db.r4.8xlarge":   true,
+			"db.r4.16xlarge":  true,
+			"db.r3.large":     true,
+			"db.r3.xlarge":    true,
+			"db.r3.2xlarge":   true,
+			"db.r3.4xlarge":   true,
+			"db.r3.8xlarge":   true,
+			"db.t1.micro":     true,
+			"db.m1.small":     true,
+			"db.m1.medium":    true,
+			"db.m1.large":     true,
+			"db.m1.xlarge":    true,
+			"db.m2.xlarge":    true,
+			"db.m2.2xlarge":   true,
+			"db.m2.4xlarge":   true,
+			"db.cr1.8xlarge":  true,
+			"db.x1.16xlarge":  true,
+			"db.x1.32xlarge":  true,
+			"db.x1e.xlarge":   true,
+			"db.x1e.2xlarge":  true,
+			"db.x1e.4xlarge":  true,
+			"db.x1e.8xlarge":  true,
+			"db.x1e.16xlarge": true,
+			"db.x1e.32xlarge": true,
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsDBInstanceInvalidTypeRule) Name() string {
+	return "aws_db_instance_invalid_type"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsDBInstanceInvalidTypeRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether "aws_db_instance" has invalid instance type.
+func (r *AwsDBInstanceInvalidTypeRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var instanceType string
+		err := runner.EvaluateExpr(attribute.Expr, &instanceType)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.instanceTypes[instanceType] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid instance type.", instanceType),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_db_instance_invalid_type.md",
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_db_instance_invalid_type_test.go
+++ b/rules/awsrules/aws_db_instance_invalid_type_test.go
@@ -1,0 +1,86 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsDBInstanceInvalidType(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected issue.Issues
+	}{
+		{
+			Name: "m4.2xlarge is invalid",
+			Content: `
+resource "aws_db_instance" "mysql" {
+    instance_class = "m4.2xlarge"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_db_instance_invalid_type",
+					Type:     "ERROR",
+					Message:  "\"m4.2xlarge\" is invalid instance type.",
+					Line:     3,
+					File:     "resource.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_db_instance_invalid_type.md",
+				},
+			},
+		},
+		{
+			Name: "db.m4.2xlarge is valid",
+			Content: `
+resource "aws_db_instance" "mysql" {
+    instance_class = "db.m4.2xlarge"
+}`,
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsDBInstanceInvalidType")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsDBInstanceInvalidTypeRule()
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_db_instance_invalid_vpc_security_group.go
+++ b/rules/awsrules/aws_db_instance_invalid_vpc_security_group.go
@@ -1,0 +1,83 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsDBInstanceInvalidVPCSecurityGroupRule checks whether security groups actually exists
+type AwsDBInstanceInvalidVPCSecurityGroupRule struct {
+	resourceType   string
+	attributeName  string
+	securityGroups map[string]bool
+	dataPrepared   bool
+}
+
+// NewAwsDBInstanceInvalidVPCSecurityGroupRule returns new rule with default attributes
+func NewAwsDBInstanceInvalidVPCSecurityGroupRule() *AwsDBInstanceInvalidVPCSecurityGroupRule {
+	return &AwsDBInstanceInvalidVPCSecurityGroupRule{
+		resourceType:   "aws_db_instance",
+		attributeName:  "vpc_security_group_ids",
+		securityGroups: map[string]bool{},
+		dataPrepared:   false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsDBInstanceInvalidVPCSecurityGroupRule) Name() string {
+	return "aws_db_instance_invalid_vpc_security_group"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsDBInstanceInvalidVPCSecurityGroupRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `vpc_security_groups` are included in the list retrieved by `DescribeSecurityGroups`
+func (r *AwsDBInstanceInvalidVPCSecurityGroupRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch security groups")
+			resp, err := runner.AwsClient.EC2.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing security groups",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, securityGroup := range resp.SecurityGroups {
+				r.securityGroups[*securityGroup.GroupId] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var securityGroups []string
+		err := runner.EvaluateExpr(attribute.Expr, &securityGroups)
+
+		return runner.EnsureNoError(err, func() error {
+			for _, securityGroup := range securityGroups {
+				if !r.securityGroups[securityGroup] {
+					runner.Issues = append(runner.Issues, &issue.Issue{
+						Detector: r.Name(),
+						Type:     issue.ERROR,
+						Message:  fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
+						Line:     attribute.Range.Start.Line,
+						File:     runner.GetFileName(attribute.Range.Filename),
+					})
+				}
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_db_instance_invalid_vpc_security_group_test.go
+++ b/rules/awsrules/aws_db_instance_invalid_vpc_security_group_test.go
@@ -1,0 +1,163 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsDBInstanceInvalidVPCSecurityGroup(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*ec2.SecurityGroup
+		Expected issue.Issues
+	}{
+		{
+			Name: "security group is invalid",
+			Content: `
+resource "aws_db_instance" "mysql" {
+    vpc_security_group_ids = [
+        "sg-1234abcd",
+        "sg-abcd1234",
+    ]
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-12345678"),
+				},
+				{
+					GroupId: aws.String("sg-abcdefgh"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_db_instance_invalid_vpc_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-1234abcd\" is invalid security group.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+				{
+					Detector: "aws_db_instance_invalid_vpc_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-abcd1234\" is invalid security group.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "security group is valid",
+			Content: `
+resource "aws_db_instance" "mysql" {
+    vpc_security_group_ids = [
+        "sg-1234abcd",
+        "sg-abcd1234",
+    ]
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-1234abcd"),
+				},
+				{
+					GroupId: aws.String("sg-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "use list variable",
+			Content: `
+variable "security_groups" {
+   default = ["sg-1234abcd", "sg-abcd1234"]
+}
+
+resource "aws_db_instance" "mysql" {
+    vpc_security_group_ids = "${var.security_groups}"
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-12345678"),
+				},
+				{
+					GroupId: aws.String("sg-abcdefgh"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_db_instance_invalid_vpc_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-1234abcd\" is invalid security group.",
+					Line:     7,
+					File:     "resource.tf",
+				},
+				{
+					Detector: "aws_db_instance_invalid_vpc_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-abcd1234\" is invalid security group.",
+					Line:     7,
+					File:     "resource.tf",
+				},
+			},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsDBInstanceInvalidVpcSecurityGroup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsDBInstanceInvalidVPCSecurityGroupRule()
+
+		mock := mock.NewMockEC2API(ctrl)
+		mock.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{}).Return(&ec2.DescribeSecurityGroupsOutput{
+			SecurityGroups: tc.Response,
+		}, nil)
+		runner.AwsClient.EC2 = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_db_instance_previous_type.go
+++ b/rules/awsrules/aws_db_instance_previous_type.go
@@ -1,0 +1,70 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsDBInstancePreviousTypeRule checks whether the resource uses previous generation instance type
+type AwsDBInstancePreviousTypeRule struct {
+	resourceType          string
+	attributeName         string
+	previousInstanceTypes map[string]bool
+}
+
+// NewAwsDBInstancePreviousTypeRule returns new rule with default attributes
+func NewAwsDBInstancePreviousTypeRule() *AwsDBInstancePreviousTypeRule {
+	return &AwsDBInstancePreviousTypeRule{
+		resourceType:  "aws_db_instance",
+		attributeName: "instance_class",
+		previousInstanceTypes: map[string]bool{
+			"db.t1.micro":    true,
+			"db.m1.small":    true,
+			"db.m1.medium":   true,
+			"db.m1.large":    true,
+			"db.m1.xlarge":   true,
+			"db.m2.xlarge":   true,
+			"db.m2.2xlarge":  true,
+			"db.m2.4xlarge":  true,
+			"db.cr1.8xlarge": true,
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsDBInstancePreviousTypeRule) Name() string {
+	return "aws_db_instance_previous_type"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsDBInstancePreviousTypeRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether the resource's `instance_class` is included in the list of previous generation instance type
+func (r *AwsDBInstancePreviousTypeRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var instanceType string
+		err := runner.EvaluateExpr(attribute.Expr, &instanceType)
+
+		return runner.EnsureNoError(err, func() error {
+			if r.previousInstanceTypes[instanceType] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.WARNING,
+					Message:  fmt.Sprintf("\"%s\" is previous generation instance type.", instanceType),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_db_instance_previous_type.md",
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_db_instance_previous_type_test.go
+++ b/rules/awsrules/aws_db_instance_previous_type_test.go
@@ -1,0 +1,86 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsDBInstancePreviousType(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected issue.Issues
+	}{
+		{
+			Name: "db.t1.micro is previous type",
+			Content: `
+resource "aws_db_instance" "mysql" {
+    instance_class = "db.t1.micro"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_db_instance_previous_type",
+					Type:     "WARNING",
+					Message:  "\"db.t1.micro\" is previous generation instance type.",
+					Line:     3,
+					File:     "resource.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_db_instance_previous_type.md",
+				},
+			},
+		},
+		{
+			Name: "db.t2.micro is not previous type",
+			Content: `
+resource "aws_db_instance" "mysql" {
+    instance_class = "db.t2.micro"
+}`,
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsDBInstancePreviousType")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsDBInstancePreviousTypeRule()
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_elasticache_cluster_default_parameter_group.go
+++ b/rules/awsrules/aws_elasticache_cluster_default_parameter_group.go
@@ -1,0 +1,61 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsElastiCacheClusterDefaultParameterGroupRule checks whether the cluster use default parameter group
+type AwsElastiCacheClusterDefaultParameterGroupRule struct {
+	resourceType  string
+	attributeName string
+}
+
+// NewAwsElastiCacheClusterDefaultParameterGroupRule returns new rule with default attributes
+func NewAwsElastiCacheClusterDefaultParameterGroupRule() *AwsElastiCacheClusterDefaultParameterGroupRule {
+	return &AwsElastiCacheClusterDefaultParameterGroupRule{
+		resourceType:  "aws_elasticache_cluster",
+		attributeName: "parameter_group_name",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsElastiCacheClusterDefaultParameterGroupRule) Name() string {
+	return "aws_elasticache_cluster_default_parameter_group"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsElastiCacheClusterDefaultParameterGroupRule) Enabled() bool {
+	return true
+}
+
+var defaultElastiCacheParameterGroupRegexp = regexp.MustCompile("^default")
+
+// Check checks the parameter group name starts with `default`
+func (r *AwsElastiCacheClusterDefaultParameterGroupRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var parameterGroup string
+		err := runner.EvaluateExpr(attribute.Expr, &parameterGroup)
+
+		return runner.EnsureNoError(err, func() error {
+			if defaultElastiCacheParameterGroupRegexp.Match([]byte(parameterGroup)) {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.NOTICE,
+					Message:  fmt.Sprintf("\"%s\" is default parameter group. You cannot edit it.", parameterGroup),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_elasticache_cluster_default_parameter_group.md",
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_elasticache_cluster_default_parameter_group_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_default_parameter_group_test.go
@@ -1,0 +1,86 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsElastiCacheClusterDefaultParameterGroup(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected issue.Issues
+	}{
+		{
+			Name: "default.redis3.2 is default parameter group",
+			Content: `
+resource "aws_elasticache_cluster" "cache" {
+    parameter_group_name = "default.redis3.2"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_elasticache_cluster_default_parameter_group",
+					Type:     "NOTICE",
+					Message:  "\"default.redis3.2\" is default parameter group. You cannot edit it.",
+					Line:     3,
+					File:     "resource.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_elasticache_cluster_default_parameter_group.md",
+				},
+			},
+		},
+		{
+			Name: "application3.2 is not default parameter group",
+			Content: `
+resource "aws_elasticache_cluster" "cache" {
+    parameter_group_name = "application3.2"
+}`,
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsElasticacheClusterDefaultParameterGroup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsElastiCacheClusterDefaultParameterGroupRule()
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_elasticache_cluster_invalid_parameter_group.go
+++ b/rules/awsrules/aws_elasticache_cluster_invalid_parameter_group.go
@@ -1,0 +1,81 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsElastiCacheClusterInvalidParameterGroupRule checks whether cache parameter group actually exists
+type AwsElastiCacheClusterInvalidParameterGroupRule struct {
+	resourceType         string
+	attributeName        string
+	cacheParameterGroups map[string]bool
+	dataPrepared         bool
+}
+
+// NewAwsElastiCacheClusterInvalidParameterGroupRule returns new rule with default attributes
+func NewAwsElastiCacheClusterInvalidParameterGroupRule() *AwsElastiCacheClusterInvalidParameterGroupRule {
+	return &AwsElastiCacheClusterInvalidParameterGroupRule{
+		resourceType:         "aws_elasticache_cluster",
+		attributeName:        "parameter_group_name",
+		cacheParameterGroups: map[string]bool{},
+		dataPrepared:         false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsElastiCacheClusterInvalidParameterGroupRule) Name() string {
+	return "aws_elasticache_cluster_invalid_parameter_group"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsElastiCacheClusterInvalidParameterGroupRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `parameter_group_name` are included in the list retrieved by `DescribeCacheParameterGroups`
+func (r *AwsElastiCacheClusterInvalidParameterGroupRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch cache parameter groups")
+			resp, err := runner.AwsClient.ElastiCache.DescribeCacheParameterGroups(&elasticache.DescribeCacheParameterGroupsInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing cache parameter groups",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, parameterGroup := range resp.CacheParameterGroups {
+				r.cacheParameterGroups[*parameterGroup.CacheParameterGroupName] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var parameterGroup string
+		err := runner.EvaluateExpr(attribute.Expr, &parameterGroup)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.cacheParameterGroups[parameterGroup] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid parameter group name.", parameterGroup),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_elasticache_cluster_invalid_parameter_group_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_invalid_parameter_group_test.go
@@ -1,0 +1,118 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsElastiCacheClusterInvalidParameterGroup(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*elasticache.CacheParameterGroup
+		Expected issue.Issues
+	}{
+		{
+			Name: "parameter_group_name is invalid",
+			Content: `
+resource "aws_elasticache_cluster" "redis" {
+    parameter_group_name = "app-server"
+}`,
+			Response: []*elasticache.CacheParameterGroup{
+				{
+					CacheParameterGroupName: aws.String("app-server1"),
+				},
+				{
+					CacheParameterGroupName: aws.String("app-server2"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_elasticache_cluster_invalid_parameter_group",
+					Type:     "ERROR",
+					Message:  "\"app-server\" is invalid parameter group name.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "parameter_group_name is valid",
+			Content: `
+resource "aws_elasticache_cluster" "redis" {
+    parameter_group_name = "app-server"
+}`,
+			Response: []*elasticache.CacheParameterGroup{
+				{
+					CacheParameterGroupName: aws.String("app-server1"),
+				},
+				{
+					CacheParameterGroupName: aws.String("app-server2"),
+				},
+				{
+					CacheParameterGroupName: aws.String("app-server"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsElasticacheClusterInvalidParameterGroup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsElastiCacheClusterInvalidParameterGroupRule()
+
+		mock := mock.NewMockElastiCacheAPI(ctrl)
+		mock.EXPECT().DescribeCacheParameterGroups(&elasticache.DescribeCacheParameterGroupsInput{}).Return(&elasticache.DescribeCacheParameterGroupsOutput{
+			CacheParameterGroups: tc.Response,
+		}, nil)
+		runner.AwsClient.ElastiCache = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_elasticache_cluster_invalid_security_group.go
+++ b/rules/awsrules/aws_elasticache_cluster_invalid_security_group.go
@@ -1,0 +1,83 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsElastiCacheClusterInvalidSecurityGroupRule checks whether security groups actually exists
+type AwsElastiCacheClusterInvalidSecurityGroupRule struct {
+	resourceType   string
+	attributeName  string
+	securityGroups map[string]bool
+	dataPrepared   bool
+}
+
+// NewAwsElastiCacheClusterInvalidSecurityGroupRule returns new rule with default attributes
+func NewAwsElastiCacheClusterInvalidSecurityGroupRule() *AwsElastiCacheClusterInvalidSecurityGroupRule {
+	return &AwsElastiCacheClusterInvalidSecurityGroupRule{
+		resourceType:   "aws_elasticache_cluster",
+		attributeName:  "security_group_ids",
+		securityGroups: map[string]bool{},
+		dataPrepared:   false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsElastiCacheClusterInvalidSecurityGroupRule) Name() string {
+	return "aws_elasticache_cluster_invalid_security_group"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsElastiCacheClusterInvalidSecurityGroupRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `security_group_ids` are included in the list retrieved by `DescribeSecurityGroups`
+func (r *AwsElastiCacheClusterInvalidSecurityGroupRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch security groups")
+			resp, err := runner.AwsClient.EC2.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing security groups",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, securityGroup := range resp.SecurityGroups {
+				r.securityGroups[*securityGroup.GroupId] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var securityGroups []string
+		err := runner.EvaluateExpr(attribute.Expr, &securityGroups)
+
+		return runner.EnsureNoError(err, func() error {
+			for _, securityGroup := range securityGroups {
+				if !r.securityGroups[securityGroup] {
+					runner.Issues = append(runner.Issues, &issue.Issue{
+						Detector: r.Name(),
+						Type:     issue.ERROR,
+						Message:  fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
+						Line:     attribute.Range.Start.Line,
+						File:     runner.GetFileName(attribute.Range.Filename),
+					})
+				}
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_elasticache_cluster_invalid_security_group_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_invalid_security_group_test.go
@@ -1,0 +1,163 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsElastiCacheClusterInvalidSecurityGroup(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*ec2.SecurityGroup
+		Expected issue.Issues
+	}{
+		{
+			Name: "security group is invalid",
+			Content: `
+resource "aws_elasticache_cluster" "redis" {
+    security_group_ids = [
+        "sg-1234abcd",
+        "sg-abcd1234",
+    ]
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-12345678"),
+				},
+				{
+					GroupId: aws.String("sg-abcdefgh"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_elasticache_cluster_invalid_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-1234abcd\" is invalid security group.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+				{
+					Detector: "aws_elasticache_cluster_invalid_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-abcd1234\" is invalid security group.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "security group is valid",
+			Content: `
+resource "aws_elasticache_cluster" "redis" {
+    security_group_ids = [
+        "sg-1234abcd",
+        "sg-abcd1234",
+    ]
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-1234abcd"),
+				},
+				{
+					GroupId: aws.String("sg-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "use list variable",
+			Content: `
+variable "security_groups" {
+    default = ["sg-1234abcd", "sg-abcd1234"]
+}
+
+resource "aws_elasticache_cluster" "redis" {
+    security_group_ids = "${var.security_groups}"
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-12345678"),
+				},
+				{
+					GroupId: aws.String("sg-abcdefgh"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_elasticache_cluster_invalid_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-1234abcd\" is invalid security group.",
+					Line:     7,
+					File:     "resource.tf",
+				},
+				{
+					Detector: "aws_elasticache_cluster_invalid_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-abcd1234\" is invalid security group.",
+					Line:     7,
+					File:     "resource.tf",
+				},
+			},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsElastiCacheClusterInvalidSecurityGroup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsElastiCacheClusterInvalidSecurityGroupRule()
+
+		mock := mock.NewMockEC2API(ctrl)
+		mock.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{}).Return(&ec2.DescribeSecurityGroupsOutput{
+			SecurityGroups: tc.Response,
+		}, nil)
+		runner.AwsClient.EC2 = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_elasticache_cluster_invalid_subnet_group.go
+++ b/rules/awsrules/aws_elasticache_cluster_invalid_subnet_group.go
@@ -1,0 +1,81 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsElastiCacheClusterInvalidSubnetGroupRule checks whether subnet groups actually exists
+type AwsElastiCacheClusterInvalidSubnetGroupRule struct {
+	resourceType      string
+	attributeName     string
+	cacheSubnetGroups map[string]bool
+	dataPrepared      bool
+}
+
+// NewAwsElastiCacheClusterInvalidSubnetGroupRule returns new rule with default attributes
+func NewAwsElastiCacheClusterInvalidSubnetGroupRule() *AwsElastiCacheClusterInvalidSubnetGroupRule {
+	return &AwsElastiCacheClusterInvalidSubnetGroupRule{
+		resourceType:      "aws_elasticache_cluster",
+		attributeName:     "subnet_group_name",
+		cacheSubnetGroups: map[string]bool{},
+		dataPrepared:      false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsElastiCacheClusterInvalidSubnetGroupRule) Name() string {
+	return "aws_elasticache_cluster_invalid_subnet_group"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsElastiCacheClusterInvalidSubnetGroupRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `subnet_group_name` are included in the list retrieved by `DescribeCacheSubnetGroups`
+func (r *AwsElastiCacheClusterInvalidSubnetGroupRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch cache subnet groups")
+			resp, err := runner.AwsClient.ElastiCache.DescribeCacheSubnetGroups(&elasticache.DescribeCacheSubnetGroupsInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing cache subnet groups",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, subnetGroup := range resp.CacheSubnetGroups {
+				r.cacheSubnetGroups[*subnetGroup.CacheSubnetGroupName] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var subnetGroup string
+		err := runner.EvaluateExpr(attribute.Expr, &subnetGroup)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.cacheSubnetGroups[subnetGroup] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid subnet group name.", subnetGroup),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_elasticache_cluster_invalid_subnet_group_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_invalid_subnet_group_test.go
@@ -1,0 +1,118 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsElastiCacheClusterInvalidSubnetGroup(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*elasticache.CacheSubnetGroup
+		Expected issue.Issues
+	}{
+		{
+			Name: "parameter_group_name is invalid",
+			Content: `
+resource "aws_elasticache_cluster" "redis" {
+    subnet_group_name = "app-server"
+}`,
+			Response: []*elasticache.CacheSubnetGroup{
+				{
+					CacheSubnetGroupName: aws.String("app-server1"),
+				},
+				{
+					CacheSubnetGroupName: aws.String("app-server2"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_elasticache_cluster_invalid_subnet_group",
+					Type:     "ERROR",
+					Message:  "\"app-server\" is invalid subnet group name.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "parameter_group_name is valid",
+			Content: `
+resource "aws_elasticache_cluster" "redis" {
+    subnet_group_name = "app-server"
+}`,
+			Response: []*elasticache.CacheSubnetGroup{
+				{
+					CacheSubnetGroupName: aws.String("app-server1"),
+				},
+				{
+					CacheSubnetGroupName: aws.String("app-server2"),
+				},
+				{
+					CacheSubnetGroupName: aws.String("app-server"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsElastiCacheClusterInvalidSubnetGroup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsElastiCacheClusterInvalidSubnetGroupRule()
+
+		mock := mock.NewMockElastiCacheAPI(ctrl)
+		mock.EXPECT().DescribeCacheSubnetGroups(&elasticache.DescribeCacheSubnetGroupsInput{}).Return(&elasticache.DescribeCacheSubnetGroupsOutput{
+			CacheSubnetGroups: tc.Response,
+		}, nil)
+		runner.AwsClient.ElastiCache = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_elasticache_cluster_invalid_type.go
+++ b/rules/awsrules/aws_elasticache_cluster_invalid_type.go
@@ -1,0 +1,93 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsElastiCacheClusterInvalidTypeRule checks whether "aws_elasticache_cluster" has invalid node type.
+type AwsElastiCacheClusterInvalidTypeRule struct {
+	resourceType  string
+	attributeName string
+	nodeTypes     map[string]bool
+}
+
+// NewAwsElastiCacheClusterInvalidTypeRule returns new rule with default attributes
+func NewAwsElastiCacheClusterInvalidTypeRule() *AwsElastiCacheClusterInvalidTypeRule {
+	return &AwsElastiCacheClusterInvalidTypeRule{
+		resourceType:  "aws_elasticache_cluster",
+		attributeName: "node_type",
+		nodeTypes: map[string]bool{
+			"cache.t2.micro":    true,
+			"cache.t2.small":    true,
+			"cache.t2.medium":   true,
+			"cache.m3.medium":   true,
+			"cache.m3.large":    true,
+			"cache.m3.xlarge":   true,
+			"cache.m3.2xlarge":  true,
+			"cache.m4.large":    true,
+			"cache.m4.xlarge":   true,
+			"cache.m4.2xlarge":  true,
+			"cache.m4.4xlarge":  true,
+			"cache.m4.10xlarge": true,
+			"cache.r3.large":    true,
+			"cache.r3.xlarge":   true,
+			"cache.r3.2xlarge":  true,
+			"cache.r3.4xlarge":  true,
+			"cache.r3.8xlarge":  true,
+			"cache.r4.large":    true,
+			"cache.r4.xlarge":   true,
+			"cache.r4.2xlarge":  true,
+			"cache.r4.4xlarge":  true,
+			"cache.r4.8xlarge":  true,
+			"cache.r4.16xlarge": true,
+			"cache.m1.small":    true,
+			"cache.m1.medium":   true,
+			"cache.m1.large":    true,
+			"cache.m1.xlarge":   true,
+			"cache.m2.xlarge":   true,
+			"cache.m2.2xlarge":  true,
+			"cache.m2.4xlarge":  true,
+			"cache.c1.xlarge":   true,
+			"cache.t1.micro":    true,
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsElastiCacheClusterInvalidTypeRule) Name() string {
+	return "aws_elasticache_cluster_invalid_type"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsElastiCacheClusterInvalidTypeRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether "aws_elasticache_cluster" has invalid node type.
+func (r *AwsElastiCacheClusterInvalidTypeRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var nodeType string
+		err := runner.EvaluateExpr(attribute.Expr, &nodeType)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.nodeTypes[nodeType] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid node type.", nodeType),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_elasticache_cluster_invalid_type.md",
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_elasticache_cluster_invalid_type_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_invalid_type_test.go
@@ -1,0 +1,86 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsElastiCacheClusterInvalidType(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected issue.Issues
+	}{
+		{
+			Name: "t2.micro is invalid",
+			Content: `
+resource "aws_elasticache_cluster" "redis" {
+    node_type = "t2.micro"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_elasticache_cluster_invalid_type",
+					Type:     "ERROR",
+					Message:  "\"t2.micro\" is invalid node type.",
+					Line:     3,
+					File:     "resource.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_elasticache_cluster_invalid_type.md",
+				},
+			},
+		},
+		{
+			Name: "cache.t2.micro is valid",
+			Content: `
+resource "aws_elasticache_cluster" "redis" {
+    node_type = "cache.t2.micro"
+}`,
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsElastiCacheClusterInvalidType")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsElastiCacheClusterInvalidTypeRule()
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_elasticache_cluster_previous_type.go
+++ b/rules/awsrules/aws_elasticache_cluster_previous_type.go
@@ -1,0 +1,70 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsElastiCacheClusterPreviousTypeRule checks whether the resource uses previous generation node type
+type AwsElastiCacheClusterPreviousTypeRule struct {
+	resourceType      string
+	attributeName     string
+	previousNodeTypes map[string]bool
+}
+
+// NewAwsElastiCacheClusterPreviousTypeRule returns new rule with default attributes
+func NewAwsElastiCacheClusterPreviousTypeRule() *AwsElastiCacheClusterPreviousTypeRule {
+	return &AwsElastiCacheClusterPreviousTypeRule{
+		resourceType:  "aws_elasticache_cluster",
+		attributeName: "node_type",
+		previousNodeTypes: map[string]bool{
+			"cache.m1.small":   true,
+			"cache.m1.medium":  true,
+			"cache.m1.large":   true,
+			"cache.m1.xlarge":  true,
+			"cache.m2.xlarge":  true,
+			"cache.m2.2xlarge": true,
+			"cache.m2.4xlarge": true,
+			"cache.c1.xlarge":  true,
+			"cache.t1.micro":   true,
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsElastiCacheClusterPreviousTypeRule) Name() string {
+	return "aws_elasticache_cluster_previous_type"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsElastiCacheClusterPreviousTypeRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether the resource's `node_type` is included in the list of previous generation node type
+func (r *AwsElastiCacheClusterPreviousTypeRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var nodeType string
+		err := runner.EvaluateExpr(attribute.Expr, &nodeType)
+
+		return runner.EnsureNoError(err, func() error {
+			if r.previousNodeTypes[nodeType] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.WARNING,
+					Message:  fmt.Sprintf("\"%s\" is previous generation node type.", nodeType),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_elasticache_cluster_previous_type.md",
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_elasticache_cluster_previous_type_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_previous_type_test.go
@@ -1,0 +1,86 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsElastiCacheClusterPreviousType(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected issue.Issues
+	}{
+		{
+			Name: "cache.t1.micro is previous type",
+			Content: `
+resource "aws_elasticache_cluster" "redis" {
+    node_type = "cache.t1.micro"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_elasticache_cluster_previous_type",
+					Type:     "WARNING",
+					Message:  "\"cache.t1.micro\" is previous generation node type.",
+					Line:     3,
+					File:     "resource.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_elasticache_cluster_previous_type.md",
+				},
+			},
+		},
+		{
+			Name: "cache.t2.micro is not previous type",
+			Content: `
+resource "aws_elasticache_cluster" "redis" {
+    node_type = "cache.t2.micro"
+}`,
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsElastiCacheClusterPreviousType")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsElastiCacheClusterPreviousTypeRule()
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_elb_invalid_instance.go
+++ b/rules/awsrules/aws_elb_invalid_instance.go
@@ -1,0 +1,85 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsELBInvalidInstanceRule checks whether instances actually exists
+type AwsELBInvalidInstanceRule struct {
+	resourceType  string
+	attributeName string
+	instances     map[string]bool
+	dataPrepared  bool
+}
+
+// NewAwsELBInvalidInstanceRule returns new rule with default attributes
+func NewAwsELBInvalidInstanceRule() *AwsELBInvalidInstanceRule {
+	return &AwsELBInvalidInstanceRule{
+		resourceType:  "aws_elb",
+		attributeName: "instances",
+		instances:     map[string]bool{},
+		dataPrepared:  false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsELBInvalidInstanceRule) Name() string {
+	return "aws_elb_invalid_instance"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsELBInvalidInstanceRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `instances` are included in the list retrieved by `DescribeInstances`
+func (r *AwsELBInvalidInstanceRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch instances")
+			resp, err := runner.AwsClient.EC2.DescribeInstances(&ec2.DescribeInstancesInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing instances",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, reservation := range resp.Reservations {
+				for _, instance := range reservation.Instances {
+					r.instances[*instance.InstanceId] = true
+				}
+			}
+			r.dataPrepared = true
+		}
+
+		var instances []string
+		err := runner.EvaluateExpr(attribute.Expr, &instances)
+
+		return runner.EnsureNoError(err, func() error {
+			for _, instance := range instances {
+				if !r.instances[instance] {
+					runner.Issues = append(runner.Issues, &issue.Issue{
+						Detector: r.Name(),
+						Type:     issue.ERROR,
+						Message:  fmt.Sprintf("\"%s\" is invalid instance.", instance),
+						Line:     attribute.Range.Start.Line,
+						File:     runner.GetFileName(attribute.Range.Filename),
+					})
+				}
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_elb_invalid_instance_test.go
+++ b/rules/awsrules/aws_elb_invalid_instance_test.go
@@ -1,0 +1,167 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsELBInvalidInstance(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*ec2.Instance
+		Expected issue.Issues
+	}{
+		{
+			Name: "Instance is invalid",
+			Content: `
+resource "aws_elb" "balancer" {
+    instances = [
+        "i-1234abcd",
+        "i-abcd1234",
+    ]
+}`,
+			Response: []*ec2.Instance{
+				{
+					InstanceId: aws.String("i-12345678"),
+				},
+				{
+					InstanceId: aws.String("i-abcdefgh"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_elb_invalid_instance",
+					Type:     "ERROR",
+					Message:  "\"i-1234abcd\" is invalid instance.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+				{
+					Detector: "aws_elb_invalid_instance",
+					Type:     "ERROR",
+					Message:  "\"i-abcd1234\" is invalid instance.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "Instance is valid",
+			Content: `
+resource "aws_elb" "balancer" {
+    instances = [
+        "i-1234abcd",
+        "i-abcd1234",
+    ]
+}`,
+			Response: []*ec2.Instance{
+				{
+					InstanceId: aws.String("i-1234abcd"),
+				},
+				{
+					InstanceId: aws.String("i-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "use list variable",
+			Content: `
+variable "instances" {
+    default = ["i-1234abcd", "i-abcd1234"]
+}
+
+resource "aws_elb" "balancer" {
+    instances = "${var.instances}"
+}`,
+			Response: []*ec2.Instance{
+				{
+					InstanceId: aws.String("i-12345678"),
+				},
+				{
+					InstanceId: aws.String("i-abcdefgh"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_elb_invalid_instance",
+					Type:     "ERROR",
+					Message:  "\"i-1234abcd\" is invalid instance.",
+					Line:     7,
+					File:     "resource.tf",
+				},
+				{
+					Detector: "aws_elb_invalid_instance",
+					Type:     "ERROR",
+					Message:  "\"i-abcd1234\" is invalid instance.",
+					Line:     7,
+					File:     "resource.tf",
+				},
+			},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsELBInvalidInstance")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsELBInvalidInstanceRule()
+
+		mock := mock.NewMockEC2API(ctrl)
+		mock.EXPECT().DescribeInstances(&ec2.DescribeInstancesInput{}).Return(&ec2.DescribeInstancesOutput{
+			Reservations: []*ec2.Reservation{
+				{
+					Instances: tc.Response,
+				},
+			},
+		}, nil)
+		runner.AwsClient.EC2 = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_elb_invalid_security_group.go
+++ b/rules/awsrules/aws_elb_invalid_security_group.go
@@ -1,0 +1,83 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsELBInvalidSecurityGroupRule checks whether security groups actually exists
+type AwsELBInvalidSecurityGroupRule struct {
+	resourceType   string
+	attributeName  string
+	securityGroups map[string]bool
+	dataPrepared   bool
+}
+
+// NewAwsELBInvalidSecurityGroupRule returns new rule with default attributes
+func NewAwsELBInvalidSecurityGroupRule() *AwsELBInvalidSecurityGroupRule {
+	return &AwsELBInvalidSecurityGroupRule{
+		resourceType:   "aws_elb",
+		attributeName:  "security_groups",
+		securityGroups: map[string]bool{},
+		dataPrepared:   false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsELBInvalidSecurityGroupRule) Name() string {
+	return "aws_elb_invalid_security_group"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsELBInvalidSecurityGroupRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `security_groups` are included in the list retrieved by `DescribeSecurityGroups`
+func (r *AwsELBInvalidSecurityGroupRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch security groups")
+			resp, err := runner.AwsClient.EC2.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing security groups",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, securityGroup := range resp.SecurityGroups {
+				r.securityGroups[*securityGroup.GroupId] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var securityGroups []string
+		err := runner.EvaluateExpr(attribute.Expr, &securityGroups)
+
+		return runner.EnsureNoError(err, func() error {
+			for _, securityGroup := range securityGroups {
+				if !r.securityGroups[securityGroup] {
+					runner.Issues = append(runner.Issues, &issue.Issue{
+						Detector: r.Name(),
+						Type:     issue.ERROR,
+						Message:  fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
+						Line:     attribute.Range.Start.Line,
+						File:     runner.GetFileName(attribute.Range.Filename),
+					})
+				}
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_elb_invalid_security_group_test.go
+++ b/rules/awsrules/aws_elb_invalid_security_group_test.go
@@ -1,0 +1,163 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsELBInvalidSecurityGroup(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*ec2.SecurityGroup
+		Expected issue.Issues
+	}{
+		{
+			Name: "security group is invalid",
+			Content: `
+resource "aws_elb" "balancer" {
+    security_groups = [
+        "sg-1234abcd",
+        "sg-abcd1234",
+    ]
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-12345678"),
+				},
+				{
+					GroupId: aws.String("sg-abcdefgh"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_elb_invalid_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-1234abcd\" is invalid security group.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+				{
+					Detector: "aws_elb_invalid_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-abcd1234\" is invalid security group.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "security group is valid",
+			Content: `
+resource "aws_elb" "balancer" {
+    security_groups = [
+        "sg-1234abcd",
+        "sg-abcd1234",
+    ]
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-1234abcd"),
+				},
+				{
+					GroupId: aws.String("sg-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "use list variable",
+			Content: `
+variable "security_groups" {
+    default = ["sg-1234abcd", "sg-abcd1234"]
+}
+
+resource "aws_elb" "balancer" {
+    security_groups = "${var.security_groups}"
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-12345678"),
+				},
+				{
+					GroupId: aws.String("sg-abcdefgh"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_elb_invalid_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-1234abcd\" is invalid security group.",
+					Line:     7,
+					File:     "resource.tf",
+				},
+				{
+					Detector: "aws_elb_invalid_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-abcd1234\" is invalid security group.",
+					Line:     7,
+					File:     "resource.tf",
+				},
+			},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsELBInvalidSecurityGroup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsELBInvalidSecurityGroupRule()
+
+		mock := mock.NewMockEC2API(ctrl)
+		mock.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{}).Return(&ec2.DescribeSecurityGroupsOutput{
+			SecurityGroups: tc.Response,
+		}, nil)
+		runner.AwsClient.EC2 = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_elb_invalid_subnet.go
+++ b/rules/awsrules/aws_elb_invalid_subnet.go
@@ -1,0 +1,83 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsELBInvalidSubnetRule checks whether subnets actually exists
+type AwsELBInvalidSubnetRule struct {
+	resourceType  string
+	attributeName string
+	subnets       map[string]bool
+	dataPrepared  bool
+}
+
+// NewAwsELBInvalidSubnetRule returns new rule with default attributes
+func NewAwsELBInvalidSubnetRule() *AwsELBInvalidSubnetRule {
+	return &AwsELBInvalidSubnetRule{
+		resourceType:  "aws_elb",
+		attributeName: "subnets",
+		subnets:       map[string]bool{},
+		dataPrepared:  false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsELBInvalidSubnetRule) Name() string {
+	return "aws_elb_invalid_subnet"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsELBInvalidSubnetRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `subnets` are included in the list retrieved by `DescribeSubnets`
+func (r *AwsELBInvalidSubnetRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch subnets")
+			resp, err := runner.AwsClient.EC2.DescribeSubnets(&ec2.DescribeSubnetsInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing subnets",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, subnet := range resp.Subnets {
+				r.subnets[*subnet.SubnetId] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var subnets []string
+		err := runner.EvaluateExpr(attribute.Expr, &subnets)
+
+		return runner.EnsureNoError(err, func() error {
+			for _, subnet := range subnets {
+				if !r.subnets[subnet] {
+					runner.Issues = append(runner.Issues, &issue.Issue{
+						Detector: r.Name(),
+						Type:     issue.ERROR,
+						Message:  fmt.Sprintf("\"%s\" is invalid subnet ID.", subnet),
+						Line:     attribute.Range.Start.Line,
+						File:     runner.GetFileName(attribute.Range.Filename),
+					})
+				}
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_elb_invalid_subnet_test.go
+++ b/rules/awsrules/aws_elb_invalid_subnet_test.go
@@ -1,0 +1,163 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsELBInvalidSubnet(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*ec2.Subnet
+		Expected issue.Issues
+	}{
+		{
+			Name: "Subnet ID is invalid",
+			Content: `
+resource "aws_elb" "balancer" {
+    subnets = [
+        "subnet-1234abcd",
+        "subnet-abcd1234",
+    ]
+}`,
+			Response: []*ec2.Subnet{
+				{
+					SubnetId: aws.String("subnet-12345678"),
+				},
+				{
+					SubnetId: aws.String("subnet-abcdefgh"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_elb_invalid_subnet",
+					Type:     "ERROR",
+					Message:  "\"subnet-1234abcd\" is invalid subnet ID.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+				{
+					Detector: "aws_elb_invalid_subnet",
+					Type:     "ERROR",
+					Message:  "\"subnet-abcd1234\" is invalid subnet ID.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "Subnet ID is valid",
+			Content: `
+resource "aws_elb" "balancer" {
+    subnets = [
+        "subnet-1234abcd",
+        "subnet-abcd1234",
+    ]
+}`,
+			Response: []*ec2.Subnet{
+				{
+					SubnetId: aws.String("subnet-1234abcd"),
+				},
+				{
+					SubnetId: aws.String("subnet-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "use list variable",
+			Content: `
+variable "subnets" {
+    default = ["subnet-1234abcd", "subnet-abcd1234"]
+}
+
+resource "aws_elb" "balancer" {
+    subnets = "${var.subnets}"
+}`,
+			Response: []*ec2.Subnet{
+				{
+					SubnetId: aws.String("subnet-12345678"),
+				},
+				{
+					SubnetId: aws.String("subnet-abcdefgh"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_elb_invalid_subnet",
+					Type:     "ERROR",
+					Message:  "\"subnet-1234abcd\" is invalid subnet ID.",
+					Line:     7,
+					File:     "resource.tf",
+				},
+				{
+					Detector: "aws_elb_invalid_subnet",
+					Type:     "ERROR",
+					Message:  "\"subnet-abcd1234\" is invalid subnet ID.",
+					Line:     7,
+					File:     "resource.tf",
+				},
+			},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsELBInvalidSubnet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsELBInvalidSubnetRule()
+
+		mock := mock.NewMockEC2API(ctrl)
+		mock.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{}).Return(&ec2.DescribeSubnetsOutput{
+			Subnets: tc.Response,
+		}, nil)
+		runner.AwsClient.EC2 = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_instance_invalid_iam_profile.go
+++ b/rules/awsrules/aws_instance_invalid_iam_profile.go
@@ -1,0 +1,81 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsInstanceInvalidIAMProfileRule checks whether profile actually exists
+type AwsInstanceInvalidIAMProfileRule struct {
+	resourceType  string
+	attributeName string
+	profiles      map[string]bool
+	dataPrepared  bool
+}
+
+// NewAwsInstanceInvalidIAMProfileRule returns new rule with default attributes
+func NewAwsInstanceInvalidIAMProfileRule() *AwsInstanceInvalidIAMProfileRule {
+	return &AwsInstanceInvalidIAMProfileRule{
+		resourceType:  "aws_instance",
+		attributeName: "iam_instance_profile",
+		profiles:      map[string]bool{},
+		dataPrepared:  false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsInstanceInvalidIAMProfileRule) Name() string {
+	return "aws_instance_invalid_iam_profile"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsInstanceInvalidIAMProfileRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `iam_instance_profile` are included in the list retrieved by `ListInstanceProfiles`
+func (r *AwsInstanceInvalidIAMProfileRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch instance profiles")
+			resp, err := runner.AwsClient.IAM.ListInstanceProfiles(&iam.ListInstanceProfilesInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing instance profiles",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, iamProfile := range resp.InstanceProfiles {
+				r.profiles[*iamProfile.InstanceProfileName] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var profile string
+		err := runner.EvaluateExpr(attribute.Expr, &profile)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.profiles[profile] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid IAM profile name.", profile),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_instance_invalid_iam_profile_test.go
+++ b/rules/awsrules/aws_instance_invalid_iam_profile_test.go
@@ -1,0 +1,118 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsInstanceInvalidIAMProfile(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*iam.InstanceProfile
+		Expected issue.Issues
+	}{
+		{
+			Name: "iam_instance_profile is invalid",
+			Content: `
+resource "aws_instance" "web" {
+    iam_instance_profile = "app-server"
+}`,
+			Response: []*iam.InstanceProfile{
+				{
+					InstanceProfileName: aws.String("app-server1"),
+				},
+				{
+					InstanceProfileName: aws.String("app-server2"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_instance_invalid_iam_profile",
+					Type:     "ERROR",
+					Message:  "\"app-server\" is invalid IAM profile name.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "iam_instance_profile is valid",
+			Content: `
+resource "aws_instance" "web" {
+    iam_instance_profile = "app-server"
+}`,
+			Response: []*iam.InstanceProfile{
+				{
+					InstanceProfileName: aws.String("app-server1"),
+				},
+				{
+					InstanceProfileName: aws.String("app-server2"),
+				},
+				{
+					InstanceProfileName: aws.String("app-server"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsInstanceInvalidIamProfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsInstanceInvalidIAMProfileRule()
+
+		mock := mock.NewMockIAMAPI(ctrl)
+		mock.EXPECT().ListInstanceProfiles(&iam.ListInstanceProfilesInput{}).Return(&iam.ListInstanceProfilesOutput{
+			InstanceProfiles: tc.Response,
+		}, nil)
+		runner.AwsClient.IAM = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_instance_invalid_key_name.go
+++ b/rules/awsrules/aws_instance_invalid_key_name.go
@@ -1,0 +1,81 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsInstanceInvalidKeyNameRule checks whether key pair actually exists
+type AwsInstanceInvalidKeyNameRule struct {
+	resourceType  string
+	attributeName string
+	keypairs      map[string]bool
+	dataPrepared  bool
+}
+
+// NewAwsInstanceInvalidKeyNameRule returns new rule with default attributes
+func NewAwsInstanceInvalidKeyNameRule() *AwsInstanceInvalidKeyNameRule {
+	return &AwsInstanceInvalidKeyNameRule{
+		resourceType:  "aws_instance",
+		attributeName: "key_name",
+		keypairs:      map[string]bool{},
+		dataPrepared:  false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsInstanceInvalidKeyNameRule) Name() string {
+	return "aws_instance_invalid_key_name"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsInstanceInvalidKeyNameRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `key_name` are included in the list retrieved by `DescribeKeyPairs`
+func (r *AwsInstanceInvalidKeyNameRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch key pairs")
+			resp, err := runner.AwsClient.EC2.DescribeKeyPairs(&ec2.DescribeKeyPairsInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing key pairs",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, keyPair := range resp.KeyPairs {
+				r.keypairs[*keyPair.KeyName] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var key string
+		err := runner.EvaluateExpr(attribute.Expr, &key)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.keypairs[key] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid key name.", key),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_instance_invalid_key_name_test.go
+++ b/rules/awsrules/aws_instance_invalid_key_name_test.go
@@ -1,0 +1,115 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsInstanceInvalidKeyName(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*ec2.KeyPairInfo
+		Expected issue.Issues
+	}{
+		{
+			Name: "Key name is invalid",
+			Content: `
+resource "aws_instance" "web" {
+    key_name = "foo"
+}`,
+			Response: []*ec2.KeyPairInfo{
+				{
+					KeyName: aws.String("hogehoge"),
+				},
+				{
+					KeyName: aws.String("fugafuga"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_instance_invalid_key_name",
+					Type:     "ERROR",
+					Message:  "\"foo\" is invalid key name.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "Key name is valid",
+			Content: `
+resource "aws_instance" "web" {
+    key_name = "foo"
+}`,
+			Response: []*ec2.KeyPairInfo{
+				{
+					KeyName: aws.String("foo"),
+				},
+				{
+					KeyName: aws.String("bar"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsInstanceInvalidKeyName")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsInstanceInvalidKeyNameRule()
+
+		mock := mock.NewMockEC2API(ctrl)
+		mock.EXPECT().DescribeKeyPairs(&ec2.DescribeKeyPairsInput{}).Return(&ec2.DescribeKeyPairsOutput{
+			KeyPairs: tc.Response,
+		}, nil)
+		runner.AwsClient.EC2 = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_instance_invalid_subnet.go
+++ b/rules/awsrules/aws_instance_invalid_subnet.go
@@ -1,0 +1,81 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsInstanceInvalidSubnetRule checks whether subnet actually exists
+type AwsInstanceInvalidSubnetRule struct {
+	resourceType  string
+	attributeName string
+	subnets       map[string]bool
+	dataPrepared  bool
+}
+
+// NewAwsInstanceInvalidSubnetRule returns new rule with default attributes
+func NewAwsInstanceInvalidSubnetRule() *AwsInstanceInvalidSubnetRule {
+	return &AwsInstanceInvalidSubnetRule{
+		resourceType:  "aws_instance",
+		attributeName: "subnet_id",
+		subnets:       map[string]bool{},
+		dataPrepared:  false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsInstanceInvalidSubnetRule) Name() string {
+	return "aws_instance_invalid_subnet"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsInstanceInvalidSubnetRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `subnet_id` are included in the list retrieved by `DescribeSubnets`
+func (r *AwsInstanceInvalidSubnetRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch subnets")
+			resp, err := runner.AwsClient.EC2.DescribeSubnets(&ec2.DescribeSubnetsInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing subnets",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, subnet := range resp.Subnets {
+				r.subnets[*subnet.SubnetId] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var subnet string
+		err := runner.EvaluateExpr(attribute.Expr, &subnet)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.subnets[subnet] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid subnet ID.", subnet),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_instance_invalid_subnet_test.go
+++ b/rules/awsrules/aws_instance_invalid_subnet_test.go
@@ -1,0 +1,115 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsInstanceInvalidSubnet(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*ec2.Subnet
+		Expected issue.Issues
+	}{
+		{
+			Name: "Subnet ID is invalid",
+			Content: `
+resource "aws_instance" "web" {
+    subnet_id = "subnet-1234abcd"
+}`,
+			Response: []*ec2.Subnet{
+				{
+					SubnetId: aws.String("subnet-12345678"),
+				},
+				{
+					SubnetId: aws.String("subnet-abcdefgh"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_instance_invalid_subnet",
+					Type:     "ERROR",
+					Message:  "\"subnet-1234abcd\" is invalid subnet ID.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "Subnet ID is valid",
+			Content: `
+resource "aws_instance" "web" {
+    subnet_id = "subnet-1234abcd"
+}`,
+			Response: []*ec2.Subnet{
+				{
+					SubnetId: aws.String("subnet-1234abcd"),
+				},
+				{
+					SubnetId: aws.String("subnet-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsInstanceInvalidSubnet")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsInstanceInvalidSubnetRule()
+
+		mock := mock.NewMockEC2API(ctrl)
+		mock.EXPECT().DescribeSubnets(&ec2.DescribeSubnetsInput{}).Return(&ec2.DescribeSubnetsOutput{
+			Subnets: tc.Response,
+		}, nil)
+		runner.AwsClient.EC2 = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_instance_invalid_vpc_security_group.go
+++ b/rules/awsrules/aws_instance_invalid_vpc_security_group.go
@@ -1,0 +1,83 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsInstanceInvalidVPCSecurityGroupRule checks whether security groups actually exists
+type AwsInstanceInvalidVPCSecurityGroupRule struct {
+	resourceType   string
+	attributeName  string
+	securityGroups map[string]bool
+	dataPrepared   bool
+}
+
+// NewAwsInstanceInvalidVPCSecurityGroupRule returns new rule with default attributes
+func NewAwsInstanceInvalidVPCSecurityGroupRule() *AwsInstanceInvalidVPCSecurityGroupRule {
+	return &AwsInstanceInvalidVPCSecurityGroupRule{
+		resourceType:   "aws_instance",
+		attributeName:  "vpc_security_group_ids",
+		securityGroups: map[string]bool{},
+		dataPrepared:   false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsInstanceInvalidVPCSecurityGroupRule) Name() string {
+	return "aws_instance_invalid_vpc_security_group"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsInstanceInvalidVPCSecurityGroupRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `vpc_security_group_ids` are included in the list retrieved by `DescribeSecurityGroups`
+func (r *AwsInstanceInvalidVPCSecurityGroupRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch security groups")
+			resp, err := runner.AwsClient.EC2.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing security groups",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, securityGroup := range resp.SecurityGroups {
+				r.securityGroups[*securityGroup.GroupId] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var securityGroups []string
+		err := runner.EvaluateExpr(attribute.Expr, &securityGroups)
+
+		return runner.EnsureNoError(err, func() error {
+			for _, securityGroup := range securityGroups {
+				if !r.securityGroups[securityGroup] {
+					runner.Issues = append(runner.Issues, &issue.Issue{
+						Detector: r.Name(),
+						Type:     issue.ERROR,
+						Message:  fmt.Sprintf("\"%s\" is invalid security group.", securityGroup),
+						Line:     attribute.Range.Start.Line,
+						File:     runner.GetFileName(attribute.Range.Filename),
+					})
+				}
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_instance_invalid_vpc_security_group_test.go
+++ b/rules/awsrules/aws_instance_invalid_vpc_security_group_test.go
@@ -1,0 +1,163 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsInstanceInvalidVPCSecurityGroup(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*ec2.SecurityGroup
+		Expected issue.Issues
+	}{
+		{
+			Name: "security group is invalid",
+			Content: `
+resource "aws_instance" "web" {
+    vpc_security_group_ids = [
+        "sg-1234abcd",
+        "sg-abcd1234",
+    ]
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-12345678"),
+				},
+				{
+					GroupId: aws.String("sg-abcdefgh"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_instance_invalid_vpc_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-1234abcd\" is invalid security group.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+				{
+					Detector: "aws_instance_invalid_vpc_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-abcd1234\" is invalid security group.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "security group is valid",
+			Content: `
+resource "aws_instance" "web" {
+    vpc_security_group_ids = [
+        "sg-1234abcd",
+        "sg-abcd1234",
+    ]
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-1234abcd"),
+				},
+				{
+					GroupId: aws.String("sg-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+		{
+			Name: "use list variable",
+			Content: `
+variable "security_groups" {
+    default = ["sg-1234abcd", "sg-abcd1234"]
+}
+
+resource "aws_instance" "web" {
+    vpc_security_group_ids = "${var.security_groups}"
+}`,
+			Response: []*ec2.SecurityGroup{
+				{
+					GroupId: aws.String("sg-12345678"),
+				},
+				{
+					GroupId: aws.String("sg-abcdefgh"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_instance_invalid_vpc_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-1234abcd\" is invalid security group.",
+					Line:     7,
+					File:     "resource.tf",
+				},
+				{
+					Detector: "aws_instance_invalid_vpc_security_group",
+					Type:     "ERROR",
+					Message:  "\"sg-abcd1234\" is invalid security group.",
+					Line:     7,
+					File:     "resource.tf",
+				},
+			},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsInstanceInvalidVPCSecurityGroup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsInstanceInvalidVPCSecurityGroupRule()
+
+		mock := mock.NewMockEC2API(ctrl)
+		mock.EXPECT().DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{}).Return(&ec2.DescribeSecurityGroupsOutput{
+			SecurityGroups: tc.Response,
+		}, nil)
+		runner.AwsClient.EC2 = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_instance_previous_type.go
+++ b/rules/awsrules/aws_instance_previous_type.go
@@ -1,0 +1,76 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsInstancePreviousTypeRule checks whether the resource uses previous generation instance type
+type AwsInstancePreviousTypeRule struct {
+	resourceType          string
+	attributeName         string
+	previousInstanceTypes map[string]bool
+}
+
+// NewAwsInstancePreviousTypeRule returns new rule with default attributes
+func NewAwsInstancePreviousTypeRule() *AwsInstancePreviousTypeRule {
+	return &AwsInstancePreviousTypeRule{
+		resourceType:  "aws_instance",
+		attributeName: "instance_type",
+		previousInstanceTypes: map[string]bool{
+			"t1.micro":    true,
+			"m1.small":    true,
+			"m1.medium":   true,
+			"m1.large":    true,
+			"m1.xlarge":   true,
+			"c1.medium":   true,
+			"c1.xlarge":   true,
+			"cc2.8xlarge": true,
+			"cg1.4xlarge": true,
+			"m2.xlarge":   true,
+			"m2.2xlarge":  true,
+			"m2.4xlarge":  true,
+			"cr1.8xlarge": true,
+			"hi1.4xlarge": true,
+			"hs1.8xlarge": true,
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsInstancePreviousTypeRule) Name() string {
+	return "aws_instance_previous_type"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsInstancePreviousTypeRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether the resource's `instance_type` is included in the list of previous generation instance type
+func (r *AwsInstancePreviousTypeRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var instanceType string
+		err := runner.EvaluateExpr(attribute.Expr, &instanceType)
+
+		return runner.EnsureNoError(err, func() error {
+			if r.previousInstanceTypes[instanceType] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.WARNING,
+					Message:  fmt.Sprintf("\"%s\" is previous generation instance type.", instanceType),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_instance_previous_type.md",
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_instance_previous_type_test.go
+++ b/rules/awsrules/aws_instance_previous_type_test.go
@@ -1,0 +1,86 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsInstancePreviousType(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected issue.Issues
+	}{
+		{
+			Name: "t1.micro is previous type",
+			Content: `
+resource "aws_instance" "web" {
+    instance_type = "t1.micro"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_instance_previous_type",
+					Type:     "WARNING",
+					Message:  "\"t1.micro\" is previous generation instance type.",
+					Line:     3,
+					File:     "resource.tf",
+					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_instance_previous_type.md",
+				},
+			},
+		},
+		{
+			Name: "t2.micro is not previous type",
+			Content: `
+resource "aws_instance" "web" {
+    instance_type = "t2.micro"
+}`,
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsInstancePreviousType")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsInstancePreviousTypeRule()
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_route_invalid_egress_only_gateway.go
+++ b/rules/awsrules/aws_route_invalid_egress_only_gateway.go
@@ -1,0 +1,81 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsRouteInvalidEgressOnlyGatewayRule checks whether egress only gateway actually exists
+type AwsRouteInvalidEgressOnlyGatewayRule struct {
+	resourceType  string
+	attributeName string
+	egateways     map[string]bool
+	dataPrepared  bool
+}
+
+// NewAwsRouteInvalidEgressOnlyGatewayRule returns new rule with default attributes
+func NewAwsRouteInvalidEgressOnlyGatewayRule() *AwsRouteInvalidEgressOnlyGatewayRule {
+	return &AwsRouteInvalidEgressOnlyGatewayRule{
+		resourceType:  "aws_route",
+		attributeName: "egress_only_gateway_id",
+		egateways:     map[string]bool{},
+		dataPrepared:  false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsRouteInvalidEgressOnlyGatewayRule) Name() string {
+	return "aws_route_invalid_egress_only_gateway"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsRouteInvalidEgressOnlyGatewayRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `egress_only_gateway_id` are included in the list retrieved by `DescribeEgressOnlyInternetGateways`
+func (r *AwsRouteInvalidEgressOnlyGatewayRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch egress only internet gateways")
+			resp, err := runner.AwsClient.EC2.DescribeEgressOnlyInternetGateways(&ec2.DescribeEgressOnlyInternetGatewaysInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing egress only internet gateways",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, egateway := range resp.EgressOnlyInternetGateways {
+				r.egateways[*egateway.EgressOnlyInternetGatewayId] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var egateway string
+		err := runner.EvaluateExpr(attribute.Expr, &egateway)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.egateways[egateway] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid egress only internet gateway ID.", egateway),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_route_invalid_egress_only_gateway_test.go
+++ b/rules/awsrules/aws_route_invalid_egress_only_gateway_test.go
@@ -1,0 +1,115 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsRouteInvalidEgressOnlyGateway(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*ec2.EgressOnlyInternetGateway
+		Expected issue.Issues
+	}{
+		{
+			Name: "egress only gateway id is invalid",
+			Content: `
+resource "aws_route" "foo" {
+    egress_only_gateway_id = "igw-1234abcd"
+}`,
+			Response: []*ec2.EgressOnlyInternetGateway{
+				{
+					EgressOnlyInternetGatewayId: aws.String("eigw-1234abcd"),
+				},
+				{
+					EgressOnlyInternetGatewayId: aws.String("eigw-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_route_invalid_egress_only_gateway",
+					Type:     "ERROR",
+					Message:  "\"igw-1234abcd\" is invalid egress only internet gateway ID.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "egress only gateway id is valid",
+			Content: `
+resource "aws_route" "foo" {
+    egress_only_gateway_id = "eigw-1234abcd"
+}`,
+			Response: []*ec2.EgressOnlyInternetGateway{
+				{
+					EgressOnlyInternetGatewayId: aws.String("eigw-1234abcd"),
+				},
+				{
+					EgressOnlyInternetGatewayId: aws.String("eigw-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsRouteInvalidEgressOnlyGateway")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsRouteInvalidEgressOnlyGatewayRule()
+
+		mock := mock.NewMockEC2API(ctrl)
+		mock.EXPECT().DescribeEgressOnlyInternetGateways(&ec2.DescribeEgressOnlyInternetGatewaysInput{}).Return(&ec2.DescribeEgressOnlyInternetGatewaysOutput{
+			EgressOnlyInternetGateways: tc.Response,
+		}, nil)
+		runner.AwsClient.EC2 = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_route_invalid_gateway.go
+++ b/rules/awsrules/aws_route_invalid_gateway.go
@@ -1,0 +1,81 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsRouteInvalidGatewayRule checks whether internet gateway actually exists
+type AwsRouteInvalidGatewayRule struct {
+	resourceType  string
+	attributeName string
+	gateways      map[string]bool
+	dataPrepared  bool
+}
+
+// NewAwsRouteInvalidGatewayRule returns new rule with default attributes
+func NewAwsRouteInvalidGatewayRule() *AwsRouteInvalidGatewayRule {
+	return &AwsRouteInvalidGatewayRule{
+		resourceType:  "aws_route",
+		attributeName: "gateway_id",
+		gateways:      map[string]bool{},
+		dataPrepared:  false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsRouteInvalidGatewayRule) Name() string {
+	return "aws_route_invalid_gateway"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsRouteInvalidGatewayRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `gateway_id` are included in the list retrieved by `DescribeInternetGateways`
+func (r *AwsRouteInvalidGatewayRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch internet gateways")
+			resp, err := runner.AwsClient.EC2.DescribeInternetGateways(&ec2.DescribeInternetGatewaysInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing internet gateways",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, gateway := range resp.InternetGateways {
+				r.gateways[*gateway.InternetGatewayId] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var gateway string
+		err := runner.EvaluateExpr(attribute.Expr, &gateway)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.gateways[gateway] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid internet gateway ID.", gateway),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_route_invalid_gateway_test.go
+++ b/rules/awsrules/aws_route_invalid_gateway_test.go
@@ -1,0 +1,115 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsRouteInvalidGateway(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*ec2.InternetGateway
+		Expected issue.Issues
+	}{
+		{
+			Name: "gateway id is invalid",
+			Content: `
+resource "aws_route" "foo" {
+    gateway_id = "eigw-1234abcd"
+}`,
+			Response: []*ec2.InternetGateway{
+				{
+					InternetGatewayId: aws.String("igw-1234abcd"),
+				},
+				{
+					InternetGatewayId: aws.String("igw-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_route_invalid_gateway",
+					Type:     "ERROR",
+					Message:  "\"eigw-1234abcd\" is invalid internet gateway ID.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "gateway id is valid",
+			Content: `
+resource "aws_route" "foo" {
+    gateway_id = "igw-1234abcd"
+}`,
+			Response: []*ec2.InternetGateway{
+				{
+					InternetGatewayId: aws.String("igw-1234abcd"),
+				},
+				{
+					InternetGatewayId: aws.String("igw-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsRouteInvalidGateway")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsRouteInvalidGatewayRule()
+
+		mock := mock.NewMockEC2API(ctrl)
+		mock.EXPECT().DescribeInternetGateways(&ec2.DescribeInternetGatewaysInput{}).Return(&ec2.DescribeInternetGatewaysOutput{
+			InternetGateways: tc.Response,
+		}, nil)
+		runner.AwsClient.EC2 = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_route_invalid_instance.go
+++ b/rules/awsrules/aws_route_invalid_instance.go
@@ -1,0 +1,83 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsRouteInvalidInstanceRule checks whether instance actually exists
+type AwsRouteInvalidInstanceRule struct {
+	resourceType  string
+	attributeName string
+	instances     map[string]bool
+	dataPrepared  bool
+}
+
+// NewAwsRouteInvalidInstanceRule returns new rule with default attributes
+func NewAwsRouteInvalidInstanceRule() *AwsRouteInvalidInstanceRule {
+	return &AwsRouteInvalidInstanceRule{
+		resourceType:  "aws_route",
+		attributeName: "instance_id",
+		instances:     map[string]bool{},
+		dataPrepared:  false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsRouteInvalidInstanceRule) Name() string {
+	return "aws_route_invalid_instance"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsRouteInvalidInstanceRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `instance_id` are included in the list retrieved by `DescribeInstances`
+func (r *AwsRouteInvalidInstanceRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch instances")
+			resp, err := runner.AwsClient.EC2.DescribeInstances(&ec2.DescribeInstancesInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing instances",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, reservation := range resp.Reservations {
+				for _, instance := range reservation.Instances {
+					r.instances[*instance.InstanceId] = true
+				}
+			}
+			r.dataPrepared = true
+		}
+
+		var instance string
+		err := runner.EvaluateExpr(attribute.Expr, &instance)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.instances[instance] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid instance ID.", instance),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_route_invalid_instance_test.go
+++ b/rules/awsrules/aws_route_invalid_instance_test.go
@@ -1,0 +1,119 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsRouteInvalidInstance(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*ec2.Instance
+		Expected issue.Issues
+	}{
+		{
+			Name: "instance id is invalid",
+			Content: `
+resource "aws_route" "foo" {
+    instance_id = "i-1234abcd"
+}`,
+			Response: []*ec2.Instance{
+				{
+					InstanceId: aws.String("i-5678abcd"),
+				},
+				{
+					InstanceId: aws.String("i-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_route_invalid_instance",
+					Type:     "ERROR",
+					Message:  "\"i-1234abcd\" is invalid instance ID.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "instance id is valid",
+			Content: `
+resource "aws_route" "foo" {
+    instance_id = "i-1234abcd"
+}`,
+			Response: []*ec2.Instance{
+				{
+					InstanceId: aws.String("i-1234abcd"),
+				},
+				{
+					InstanceId: aws.String("i-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsRouteInvalidInstance")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsRouteInvalidInstanceRule()
+
+		mock := mock.NewMockEC2API(ctrl)
+		mock.EXPECT().DescribeInstances(&ec2.DescribeInstancesInput{}).Return(&ec2.DescribeInstancesOutput{
+			Reservations: []*ec2.Reservation{
+				{
+					Instances: tc.Response,
+				},
+			},
+		}, nil)
+		runner.AwsClient.EC2 = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_route_invalid_nat_gateway.go
+++ b/rules/awsrules/aws_route_invalid_nat_gateway.go
@@ -1,0 +1,81 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsRouteInvalidNatGatewayRule checks whether NAT gateway actually exists
+type AwsRouteInvalidNatGatewayRule struct {
+	resourceType  string
+	attributeName string
+	ngateways     map[string]bool
+	dataPrepared  bool
+}
+
+// NewAwsRouteInvalidNatGatewayRule returns new rule with default attributes
+func NewAwsRouteInvalidNatGatewayRule() *AwsRouteInvalidNatGatewayRule {
+	return &AwsRouteInvalidNatGatewayRule{
+		resourceType:  "aws_route",
+		attributeName: "nat_gateway_id",
+		ngateways:     map[string]bool{},
+		dataPrepared:  false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsRouteInvalidNatGatewayRule) Name() string {
+	return "aws_route_invalid_nat_gateway"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsRouteInvalidNatGatewayRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `nat_gateway_id` are included in the list retrieved by `DescribeNatGateways`
+func (r *AwsRouteInvalidNatGatewayRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch NAT gateways")
+			resp, err := runner.AwsClient.EC2.DescribeNatGateways(&ec2.DescribeNatGatewaysInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing NAT gateways",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, ngateway := range resp.NatGateways {
+				r.ngateways[*ngateway.NatGatewayId] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var ngateway string
+		err := runner.EvaluateExpr(attribute.Expr, &ngateway)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.ngateways[ngateway] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid NAT gateway ID.", ngateway),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_route_invalid_nat_gateway_test.go
+++ b/rules/awsrules/aws_route_invalid_nat_gateway_test.go
@@ -1,0 +1,115 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsRouteInvalidNatGateway(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*ec2.NatGateway
+		Expected issue.Issues
+	}{
+		{
+			Name: "NAT gateway id is invalid",
+			Content: `
+resource "aws_route" "foo" {
+    nat_gateway_id = "nat-1234abcd"
+}`,
+			Response: []*ec2.NatGateway{
+				{
+					NatGatewayId: aws.String("nat-5678abcd"),
+				},
+				{
+					NatGatewayId: aws.String("nat-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_route_invalid_nat_gateway",
+					Type:     "ERROR",
+					Message:  "\"nat-1234abcd\" is invalid NAT gateway ID.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "NAT gateway id is valid",
+			Content: `
+resource "aws_route" "foo" {
+    nat_gateway_id = "nat-1234abcd"
+}`,
+			Response: []*ec2.NatGateway{
+				{
+					NatGatewayId: aws.String("nat-1234abcd"),
+				},
+				{
+					NatGatewayId: aws.String("nat-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsRouteInvalidNatGateway")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsRouteInvalidNatGatewayRule()
+
+		mock := mock.NewMockEC2API(ctrl)
+		mock.EXPECT().DescribeNatGateways(&ec2.DescribeNatGatewaysInput{}).Return(&ec2.DescribeNatGatewaysOutput{
+			NatGateways: tc.Response,
+		}, nil)
+		runner.AwsClient.EC2 = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_route_invalid_network_interface.go
+++ b/rules/awsrules/aws_route_invalid_network_interface.go
@@ -1,0 +1,81 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsRouteInvalidNetworkInterfaceRule checks whether network interface actually exists
+type AwsRouteInvalidNetworkInterfaceRule struct {
+	resourceType      string
+	attributeName     string
+	networkInterfaces map[string]bool
+	dataPrepared      bool
+}
+
+// NewAwsRouteInvalidNetworkInterfaceRule returns new rule with default attributes
+func NewAwsRouteInvalidNetworkInterfaceRule() *AwsRouteInvalidNetworkInterfaceRule {
+	return &AwsRouteInvalidNetworkInterfaceRule{
+		resourceType:      "aws_route",
+		attributeName:     "network_interface_id",
+		networkInterfaces: map[string]bool{},
+		dataPrepared:      false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsRouteInvalidNetworkInterfaceRule) Name() string {
+	return "aws_route_invalid_network_interface"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsRouteInvalidNetworkInterfaceRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `network_interface_id` are included in the list retrieved by `DescribeNetworkInterfaces`
+func (r *AwsRouteInvalidNetworkInterfaceRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch network interfaces")
+			resp, err := runner.AwsClient.EC2.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing network interfaces",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, networkInterface := range resp.NetworkInterfaces {
+				r.networkInterfaces[*networkInterface.NetworkInterfaceId] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var networkInterface string
+		err := runner.EvaluateExpr(attribute.Expr, &networkInterface)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.networkInterfaces[networkInterface] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid network interface ID.", networkInterface),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_route_invalid_network_interface_test.go
+++ b/rules/awsrules/aws_route_invalid_network_interface_test.go
@@ -1,0 +1,115 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsRouteInvalidNetworkInterface(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*ec2.NetworkInterface
+		Expected issue.Issues
+	}{
+		{
+			Name: "network interface id is invalid",
+			Content: `
+resource "aws_route" "foo" {
+    network_interface_id = "eni-1234abcd"
+}`,
+			Response: []*ec2.NetworkInterface{
+				{
+					NetworkInterfaceId: aws.String("eni-5678abcd"),
+				},
+				{
+					NetworkInterfaceId: aws.String("eni-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_route_invalid_network_interface",
+					Type:     "ERROR",
+					Message:  "\"eni-1234abcd\" is invalid network interface ID.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "network interface id is valid",
+			Content: `
+resource "aws_route" "foo" {
+    network_interface_id = "eni-1234abcd"
+}`,
+			Response: []*ec2.NetworkInterface{
+				{
+					NetworkInterfaceId: aws.String("eni-1234abcd"),
+				},
+				{
+					NetworkInterfaceId: aws.String("eni-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsRouteInvalidNetworkInterface")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsRouteInvalidNetworkInterfaceRule()
+
+		mock := mock.NewMockEC2API(ctrl)
+		mock.EXPECT().DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{}).Return(&ec2.DescribeNetworkInterfacesOutput{
+			NetworkInterfaces: tc.Response,
+		}, nil)
+		runner.AwsClient.EC2 = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_route_invalid_route_table.go
+++ b/rules/awsrules/aws_route_invalid_route_table.go
@@ -1,0 +1,81 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsRouteInvalidRouteTableRule checks whether route table actually exists
+type AwsRouteInvalidRouteTableRule struct {
+	resourceType  string
+	attributeName string
+	routeTables   map[string]bool
+	dataPrepared  bool
+}
+
+// NewAwsRouteInvalidRouteTableRule returns new rule with default attributes
+func NewAwsRouteInvalidRouteTableRule() *AwsRouteInvalidRouteTableRule {
+	return &AwsRouteInvalidRouteTableRule{
+		resourceType:  "aws_route",
+		attributeName: "route_table_id",
+		routeTables:   map[string]bool{},
+		dataPrepared:  false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsRouteInvalidRouteTableRule) Name() string {
+	return "aws_route_invalid_route_table"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsRouteInvalidRouteTableRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `route_table_id` are included in the list retrieved by `DescribeRouteTables`
+func (r *AwsRouteInvalidRouteTableRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch route tables")
+			resp, err := runner.AwsClient.EC2.DescribeRouteTables(&ec2.DescribeRouteTablesInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing route tables",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, routeTable := range resp.RouteTables {
+				r.routeTables[*routeTable.RouteTableId] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var routeTable string
+		err := runner.EvaluateExpr(attribute.Expr, &routeTable)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.routeTables[routeTable] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid route table ID.", routeTable),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_route_invalid_route_table_test.go
+++ b/rules/awsrules/aws_route_invalid_route_table_test.go
@@ -1,0 +1,115 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsRouteInvalidRouteTable(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*ec2.RouteTable
+		Expected issue.Issues
+	}{
+		{
+			Name: "route table id is invalid",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-nat-gw-a"
+}`,
+			Response: []*ec2.RouteTable{
+				{
+					RouteTableId: aws.String("rtb-1234abcd"),
+				},
+				{
+					RouteTableId: aws.String("rtb-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_route_invalid_route_table",
+					Type:     "ERROR",
+					Message:  "\"rtb-nat-gw-a\" is invalid route table ID.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "route table id is valid",
+			Content: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+}`,
+			Response: []*ec2.RouteTable{
+				{
+					RouteTableId: aws.String("rtb-1234abcd"),
+				},
+				{
+					RouteTableId: aws.String("rtb-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsRouteInvalidRouteTable")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsRouteInvalidRouteTableRule()
+
+		mock := mock.NewMockEC2API(ctrl)
+		mock.EXPECT().DescribeRouteTables(&ec2.DescribeRouteTablesInput{}).Return(&ec2.DescribeRouteTablesOutput{
+			RouteTables: tc.Response,
+		}, nil)
+		runner.AwsClient.EC2 = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_route_invalid_vpc_peering_connection.go
+++ b/rules/awsrules/aws_route_invalid_vpc_peering_connection.go
@@ -1,0 +1,81 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsRouteInvalidVPCPeeringConnectionRule checks whether VPC peering connection actually exists
+type AwsRouteInvalidVPCPeeringConnectionRule struct {
+	resourceType          string
+	attributeName         string
+	vpcPeeringConnections map[string]bool
+	dataPrepared          bool
+}
+
+// NewAwsRouteInvalidVPCPeeringConnectionRule returns new rule with default attributes
+func NewAwsRouteInvalidVPCPeeringConnectionRule() *AwsRouteInvalidVPCPeeringConnectionRule {
+	return &AwsRouteInvalidVPCPeeringConnectionRule{
+		resourceType:          "aws_route",
+		attributeName:         "vpc_peering_connection_id",
+		vpcPeeringConnections: map[string]bool{},
+		dataPrepared:          false,
+	}
+}
+
+// Name returns the rule name
+func (r *AwsRouteInvalidVPCPeeringConnectionRule) Name() string {
+	return "aws_route_invalid_vpc_peering_connection"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsRouteInvalidVPCPeeringConnectionRule) Enabled() bool {
+	return true
+}
+
+// Check checks whether `vpc_peering_connection_id` are included in the list retrieved by `DescribeVpcPeeringConnections`
+func (r *AwsRouteInvalidVPCPeeringConnectionRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		if !r.dataPrepared {
+			log.Print("[DEBUG] Fetch VPC peering connections")
+			resp, err := runner.AwsClient.EC2.DescribeVpcPeeringConnections(&ec2.DescribeVpcPeeringConnectionsInput{})
+			if err != nil {
+				err := &tflint.Error{
+					Code:    tflint.ExternalAPIError,
+					Level:   tflint.ErrorLevel,
+					Message: "An error occurred while describing VPC peering connections",
+					Cause:   err,
+				}
+				log.Printf("[ERROR] %s", err)
+				return err
+			}
+			for _, vpcPeeringConnection := range resp.VpcPeeringConnections {
+				r.vpcPeeringConnections[*vpcPeeringConnection.VpcPeeringConnectionId] = true
+			}
+			r.dataPrepared = true
+		}
+
+		var vpcPeeringConnection string
+		err := runner.EvaluateExpr(attribute.Expr, &vpcPeeringConnection)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.vpcPeeringConnections[vpcPeeringConnection] {
+				runner.Issues = append(runner.Issues, &issue.Issue{
+					Detector: r.Name(),
+					Type:     issue.ERROR,
+					Message:  fmt.Sprintf("\"%s\" is invalid VPC peering connection ID.", vpcPeeringConnection),
+					Line:     attribute.Range.Start.Line,
+					File:     runner.GetFileName(attribute.Range.Filename),
+				})
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_route_invalid_vpc_peering_connection_test.go
+++ b/rules/awsrules/aws_route_invalid_vpc_peering_connection_test.go
@@ -1,0 +1,115 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsRouteInvalidVPCPeeringConnection(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Response []*ec2.VpcPeeringConnection
+		Expected issue.Issues
+	}{
+		{
+			Name: "VPC peering connection id is invalid",
+			Content: `
+resource "aws_route" "foo" {
+    vpc_peering_connection_id = "pcx-1234abcd"
+}`,
+			Response: []*ec2.VpcPeeringConnection{
+				{
+					VpcPeeringConnectionId: aws.String("pcx-5678abcd"),
+				},
+				{
+					VpcPeeringConnectionId: aws.String("pcx-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_route_invalid_vpc_peering_connection",
+					Type:     "ERROR",
+					Message:  "\"pcx-1234abcd\" is invalid VPC peering connection ID.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "VPC peering connection id is valid",
+			Content: `
+resource "aws_route" "foo" {
+    vpc_peering_connection_id = "pcx-1234abcd"
+}`,
+			Response: []*ec2.VpcPeeringConnection{
+				{
+					VpcPeeringConnectionId: aws.String("pcx-1234abcd"),
+				},
+				{
+					VpcPeeringConnectionId: aws.String("pcx-abcd1234"),
+				},
+			},
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsRouteInvalidVPCPeeringConnection")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(dir)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsRouteInvalidVPCPeeringConnectionRule()
+
+		mock := mock.NewMockEC2API(ctrl)
+		mock.EXPECT().DescribeVpcPeeringConnections(&ec2.DescribeVpcPeeringConnectionsInput{}).Return(&ec2.DescribeVpcPeeringConnectionsOutput{
+			VpcPeeringConnections: tc.Response,
+		}, nil)
+		runner.AwsClient.EC2 = mock
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -17,16 +17,47 @@ type Rule interface {
 
 // DefaultRules is rules by default
 var DefaultRules = []Rule{
+	awsrules.NewAwsCloudwatchMetricAlarmInvalidUnitRule(),
+	awsrules.NewAwsDBInstanceDefaultParameterGroupRule(),
+	awsrules.NewAwsDBInstanceInvalidTypeRule(),
+	awsrules.NewAwsDBInstancePreviousTypeRule(),
 	awsrules.NewAwsDBInstanceReadablePasswordRule(),
+	awsrules.NewAwsElastiCacheClusterDefaultParameterGroupRule(),
+	awsrules.NewAwsElastiCacheClusterInvalidTypeRule(),
+	awsrules.NewAwsElastiCacheClusterPreviousTypeRule(),
 	awsrules.NewAwsInstanceDefaultStandardVolumeRule(),
 	awsrules.NewAwsInstanceInvalidTypeRule(),
+	awsrules.NewAwsInstancePreviousTypeRule(),
 	awsrules.NewAwsRouteNotSpecifiedTargetRule(),
 	awsrules.NewAwsRouteSpecifiedMultipleTargetsRule(),
 	terraformrules.NewTerraformModulePinnedSourceRule(),
 }
 
 var deepCheckRules = []Rule{
+	awsrules.NewAwsALBInvalidSecurityGroupRule(),
+	awsrules.NewAwsALBInvalidSubnetRule(),
+	awsrules.NewAwsDBInstanceInvalidDBSubnetGroupRule(),
+	awsrules.NewAwsDBInstanceInvalidOptionGroupRule(),
+	awsrules.NewAwsDBInstanceInvalidParameterGroupRule(),
+	awsrules.NewAwsDBInstanceInvalidVPCSecurityGroupRule(),
+	awsrules.NewAwsElastiCacheClusterInvalidParameterGroupRule(),
+	awsrules.NewAwsElastiCacheClusterInvalidSecurityGroupRule(),
+	awsrules.NewAwsElastiCacheClusterInvalidSubnetGroupRule(),
+	awsrules.NewAwsELBInvalidInstanceRule(),
+	awsrules.NewAwsELBInvalidSecurityGroupRule(),
+	awsrules.NewAwsELBInvalidSubnetRule(),
 	awsrules.NewAwsInstanceInvalidAMIRule(),
+	awsrules.NewAwsInstanceInvalidIAMProfileRule(),
+	awsrules.NewAwsInstanceInvalidKeyNameRule(),
+	awsrules.NewAwsInstanceInvalidSubnetRule(),
+	awsrules.NewAwsInstanceInvalidVPCSecurityGroupRule(),
+	awsrules.NewAwsRouteInvalidEgressOnlyGatewayRule(),
+	awsrules.NewAwsRouteInvalidGatewayRule(),
+	awsrules.NewAwsRouteInvalidInstanceRule(),
+	awsrules.NewAwsRouteInvalidNatGatewayRule(),
+	awsrules.NewAwsRouteInvalidNetworkInterfaceRule(),
+	awsrules.NewAwsRouteInvalidRouteTableRule(),
+	awsrules.NewAwsRouteInvalidVPCPeeringConnectionRule(),
 }
 
 // NewRules returns rules according to configuration

--- a/tools/rule_generator.go
+++ b/tools/rule_generator.go
@@ -47,8 +47,13 @@ func generate(fileName string, tmplName string, meta *metadata) {
 
 func toCamelCase(str string) string {
 	exceptions := map[string]string{
-		"ami": "AMI",
-		"db":  "DB",
+		"ami":         "AMI",
+		"db":          "DB",
+		"alb":         "ALB",
+		"elb":         "ELB",
+		"vpc":         "VPC",
+		"elasticache": "ElastiCache",
+		"iam":         "IAM",
 	}
 	for pattern, conv := range exceptions {
 		str = strings.Replace(str, "_"+pattern+"_", "_"+conv+"_", -1)


### PR DESCRIPTION
Finally, it migrates all rules to `rules` package from `detector` package.

However, there is a problem that the position of the highlighted line is changed in the migrated rules. This problem will be fixed later.

