### PR TITLE
Update ec2-instances-info dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -70,14 +70,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:632b6e77d8f1cfce5d783432aefe7e335a0925fd91c9efd5dc514d76f0eb9e35"
+  digest = "1:097fd8bcde8fc0f19cb485d3d9feb206de5b34c73b518b8bb385910f6133fa48"
   name = "github.com/cristim/ec2-instances-info"
   packages = [
     ".",
     "data",
   ]
   pruneopts = "UT"
-  revision = "73c042a5558cd6d8b61fb82502d6f7aec334e9ed"
+  revision = "b8e5ad34236645ef17f7aed90a3b95987672eaf0"
 
 [[projects]]
   digest = "1:938a2672d6ebbb7f7bc63eee3e4b9464c16ffcf77ec8913d3edbf32b4e3984dd"


### PR DESCRIPTION
This pulls in the most recent version of https://github.com/cristim/ec2-instances-info in order to get new instances
```
a1.2xlarge
a1.4xlarge
a1.large
a1.medium
a1.xlarge
c5n.18xlarge
c5n.2xlarge
c5n.4xlarge
c5n.9xlarge
c5n.large
c5n.xlarge
f1.4xlarge
g3s.xlarge
m5a.12xlarge
m5a.24xlarge
m5a.2xlarge
m5a.4xlarge
m5a.large
m5a.xlarge
r5a.12xlarge
r5a.24xlarge
r5a.2xlarge
r5a.4xlarge
r5a.large
r5a.xlarge
u-12tb1.metal
u-6tb1.metal
u-9tb1.metal
```