### PR TITLE
Change dockerfile design

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,23 @@
-FROM alpine:3.5
+FROM golang:1.11.5-alpine3.9 as builder
 
 MAINTAINER wata727
 
-RUN apk add --no-cache ca-certificates
+WORKDIR /root
 
-COPY dist/linux_amd64/tflint /usr/local/bin
+ENV GOPATH /root/.go
+ENV PATH $GOPATH/bin:$PATH
 
-ENTRYPOINT ["tflint"]
+RUN apk add --no-cache --update git ca-certificates make gcc g++
+RUN go get -d github.com/wata727/tflint
 
-WORKDIR /data
+WORKDIR /root/.go/src/github.com/wata727/tflint
+
+RUN make build
+
+FROM alpine:3.9
+
+MAINTAINER wata727
+
+COPY --from=builder /root/.go/src/github.com/wata727/tflint/tflint /usr/local/bin/tflint
+
+CMD ["ash"]

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ brew install tflint
 We provide Docker images for each version on [DockerHub](https://hub.docker.com/r/wata727/tflint/). With docker, you can run TFLint without installing it locally.
 
 ```
-$ docker run --rm -v $(pwd):/data -t wata727/tflint
+$ docker run -itv (pwd):/project -w /project --rm wata727/tflint tflint
 ```
 
 ## Quick Start


### PR DESCRIPTION
I'd like to propose this change for the following reasons.

1. ENTRYPOINT is hardly changeable, and it is not good when you use the Docker Image with CI tools since they require an actual command along with an Image.

2. Unnecessary packages such as ca-certificates should not be in the artifact so that I removed it with using Multi-stage Build.

3. I think this is all about your preference, but in most cases you compile a binary within a Dockerfile.