### PR TITLE
Update aws_route_not_specified_target to handle transit_gateway_id

### DIFF
--- a/detector/aws_route_not_specified_target.go
+++ b/detector/aws_route_not_specified_target.go
@@ -29,6 +29,7 @@ func (d *AwsRouteNotSpecifiedTargetDetector) Detect(resource *schema.Resource, i
 		"instance_id",
 		"vpc_peering_connection_id",
 		"network_interface_id",
+		"transit_gateway_id",
 	}
 
 	for _, t := range targets {
@@ -40,7 +41,7 @@ func (d *AwsRouteNotSpecifiedTargetDetector) Detect(resource *schema.Resource, i
 	issue := &issue.Issue{
 		Detector: d.Name,
 		Type:     d.IssueType,
-		Message:  "The routing target is not specified, each routing must contain either a gateway_id, egress_only_gateway_id a nat_gateway_id, an instance_id or a vpc_peering_connection_id or a network_interface_id.",
+		Message:  "The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, or vpc_peering_connection_id.",
 		Line:     resource.Pos.Line,
 		File:     resource.Pos.Filename,
 		Link:     d.Link,

--- a/detector/aws_route_not_specified_target_test.go
+++ b/detector/aws_route_not_specified_target_test.go
@@ -25,7 +25,7 @@ resource "aws_route" "foo" {
 				{
 					Detector: "aws_route_not_specified_target",
 					Type:     "ERROR",
-					Message:  "The routing target is not specified, each routing must contain either a gateway_id, egress_only_gateway_id a nat_gateway_id, an instance_id or a vpc_peering_connection_id or a network_interface_id.",
+					Message:  "The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, or vpc_peering_connection_id.",
 					Line:     2,
 					File:     "test.tf",
 					Link:     "https://github.com/wata727/tflint/blob/master/docs/aws_route_not_specified_target.md",
@@ -83,6 +83,15 @@ resource "aws_route" "foo" {
 resource "aws_route" "foo" {
     route_table_id = "rtb-1234abcd"
     network_interface_id = "eni-1234abcd"
+}`,
+			Issues: []*issue.Issue{},
+		},
+		{
+			Name: "transit_gateway_id is specified",
+			Src: `
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    transit_gateway_id = "tgw-1234abcd"
 }`,
 			Issues: []*issue.Issue{},
 		},

--- a/docs/aws_route_not_specified_target.md
+++ b/docs/aws_route_not_specified_target.md
@@ -1,7 +1,9 @@
 # AWS Route Not Specified Target
+
 Report this issue if routing target is not specified. This issue type is ERROR.
 
 ## Example
+
 ```
 resource "aws_route" "foo" {
   route_table_id         = "rtb-1234abcd"
@@ -11,17 +13,18 @@ resource "aws_route" "foo" {
 
 The following is the execution result of TFLint:
 
-
 ```
 $ tflint
 template.tf
-        ERROR:1 The routing target is not specified, each routing must contain either a gateway_id, egress_only_gateway_id a nat_gateway_id, an instance_id or a vpc_peering_connection_id or a network_interface_id. (aws_route_not_specified_target)
+        ERROR:1 The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, or vpc_peering_connection_id. (aws_route_not_specified_target)
 
 Result: 1 issues  (1 errors , 0 warnings , 0 notices)
 ```
 
 ## Why
-`aws_route` creates new routing in route tables. If a routing target is not specified, an error will occur when run `terraform apply`.
+
+[`aws_route`](https://www.terraform.io/docs/providers/aws/r/route.html) creates new routing in route tables. If a routing target is not specified, an error will occur when run `terraform apply`.
 
 ## How To Fix
-Please add a routing target. There are kinds of `gateway_id`, `egress_only_gateway_id`, `nat_gateway_id`, `instance_id`, `vpc_peering_connection_id`, `network_interface_id`.
+
+Please add a routing target. There are [kinds of](https://www.terraform.io/docs/providers/aws/r/route.html#argument-reference) `egress_only_gateway_id`, `gateway_id`, `instance_id`, `nat_gateway_id`, `network_interface_id`, `transit_gateway_id`, `vpc_peering_connection_id`.

--- a/integration/general/result.json
+++ b/integration/general/result.json
@@ -66,7 +66,7 @@
   {
     "detector": "aws_route_not_specified_target",
     "type": "ERROR",
-    "message": "The routing target is not specified, each routing must contain either a gateway_id, egress_only_gateway_id a nat_gateway_id, an instance_id or a vpc_peering_connection_id or a network_interface_id.",
+    "message": "The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, or vpc_peering_connection_id.",
     "line": 28,
     "file": "template.tf",
     "link": "https://github.com/wata727/tflint/blob/master/docs/aws_route_not_specified_target.md"


### PR DESCRIPTION
Add `transit_gateway_id` as a valid argument for `aws_route`. Also clean up the docs and clarify the messages.