### PR TITLE
Add test cases for v0.12 syntaxes

### DIFF
--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -84,6 +84,19 @@ resource "null_resource" "test" {
 			Expected: "one",
 		},
 		{
+			Name: "object item",
+			Content: `
+variable "object" {
+  type = object({ foo = string })
+  default = { foo = "bar" }
+}
+
+resource "null_resource" "test" {
+  key = var.object.foo
+}`,
+			Expected: "bar",
+		},
+		{
 			Name: "convert from integer",
 			Content: `
 variable "string_var" {
@@ -1447,6 +1460,23 @@ resource "null_resource" "test" {
 }`,
 			Vals:  []string{"text", "element"},
 			Lines: []int{10, 10},
+		},
+		{
+			Name: "for expressions",
+			Content: `
+variable "list" {
+  default = ["text", "element", "ignored"]
+}
+
+resource "null_resource" "test" {
+  value = [
+	for e in var.list:
+	e
+	if e != "ignored"
+  ]
+}`,
+			Vals:  []string{"text", "element"},
+			Lines: []int{7, 7},
 		},
 	}
 


### PR DESCRIPTION
As a final step towards the 0.8 release, I will add test cases for v0.12 syntaxes.

As far as I confirmed, we cannot handle [null values](https://www.hashicorp.com/blog/terraform-0-12-conditional-operator-improvements) and [dynamic nested blocks](https://www.hashicorp.com/blog/hashicorp-terraform-0-12-preview-for-and-for-each) correctly. The former will be fixed before releasing v0.8 because it occurs an error. The latter will be fixed in later releases because it doesn't report errors or false positives. To fix the issue, we need to introduce a way to evaluating blocks in Runner.