### PR TITLE
Make rules aware of null values

### DIFF
--- a/rules/awsrules/aws_db_instance_readable_password_test.go
+++ b/rules/awsrules/aws_db_instance_readable_password_test.go
@@ -69,6 +69,19 @@ resource "aws_db_instance" "mysql" {
 			Expected: []*issue.Issue{},
 		},
 		{
+			Name: "with null variable",
+			Content: `
+variable "password" {
+	type    = string
+	default = null
+}
+
+resource "aws_db_instance" "mysql" {
+  password = var.password
+}`,
+			Expected: []*issue.Issue{},
+		},
+		{
 			Name: "with two variables, the one has default",
 			Content: `
 variable "head_password" {}
@@ -141,7 +154,7 @@ resource "aws_db_instance" "mysql" {
 		}
 
 		if !cmp.Equal(tc.Expected, runner.Issues) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+			t.Fatalf("%s - Expected issues are not matched:\n %s\n", tc.Name, cmp.Diff(tc.Expected, runner.Issues))
 		}
 	}
 }

--- a/rules/awsrules/aws_instance_default_standard_volume_test.go
+++ b/rules/awsrules/aws_instance_default_standard_volume_test.go
@@ -123,6 +123,24 @@ resource "aws_instance" "web" {
 				},
 			},
 		},
+		{
+			Name: "volume_type is null",
+			Content: `
+variable "volume_type" {
+	type    = string
+	default = null
+}
+
+resource "aws_instance" "web" {
+    instance_type = "c3.2xlarge"
+
+    ebs_block_device {
+        volume_type = var.volume_type
+        volume_size = "24"
+    }
+}`,
+			Expected: []*issue.Issue{},
+		},
 	}
 
 	dir, err := ioutil.TempDir("", "AwsInstanceDefaultStandardVolume")

--- a/rules/awsrules/aws_route_not_specified_target.go
+++ b/rules/awsrules/aws_route_not_specified_target.go
@@ -76,7 +76,14 @@ func (r *AwsRouteNotSpecifiedTargetRule) Check(runner *tflint.Runner) error {
 			return diags
 		}
 
-		if len(body.Attributes) == 0 {
+		var nullAttributes int
+		for _, attribute := range body.Attributes {
+			if runner.IsNullExpr(attribute.Expr) {
+				nullAttributes = nullAttributes + 1
+			}
+		}
+
+		if len(body.Attributes)-nullAttributes == 0 {
 			runner.EmitIssue(
 				r,
 				"The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, or vpc_peering_connection_id.",

--- a/rules/awsrules/aws_route_not_specified_target_test.go
+++ b/rules/awsrules/aws_route_not_specified_target_test.go
@@ -100,6 +100,29 @@ resource "aws_route" "foo" {
 }`,
 			Expected: []*issue.Issue{},
 		},
+		{
+			Name: "transit_gateway_id is specified, but the value is null",
+			Content: `
+variable "transit_gateway_id" {
+	type    = string
+	default = null
+}
+
+resource "aws_route" "foo" {
+	route_table_id = "rtb-1234abcd"
+	transit_gateway_id = var.transit_gateway_id
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_route_not_specified_target",
+					Type:     "ERROR",
+					Message:  "The routing target is not specified, each aws_route must contain either egress_only_gateway_id, gateway_id, instance_id, nat_gateway_id, network_interface_id, transit_gateway_id, or vpc_peering_connection_id.",
+					Line:     7,
+					File:     "resource.tf",
+					Link:     project.ReferenceLink("aws_route_not_specified_target"),
+				},
+			},
+		},
 	}
 
 	dir, err := ioutil.TempDir("", "AwsRouteNotSpecifiedTarget")

--- a/rules/awsrules/aws_route_specified_multiple_targets.go
+++ b/rules/awsrules/aws_route_specified_multiple_targets.go
@@ -73,7 +73,14 @@ func (r *AwsRouteSpecifiedMultipleTargetsRule) Check(runner *tflint.Runner) erro
 			return diags
 		}
 
-		if len(body.Attributes) > 1 {
+		var nullAttributes int
+		for _, attribute := range body.Attributes {
+			if runner.IsNullExpr(attribute.Expr) {
+				nullAttributes = nullAttributes + 1
+			}
+		}
+
+		if len(body.Attributes)-nullAttributes > 1 {
 			runner.EmitIssue(
 				r,
 				"More than one routing target specified. It must be one.",

--- a/rules/awsrules/aws_route_specified_multiple_targets_test.go
+++ b/rules/awsrules/aws_route_specified_multiple_targets_test.go
@@ -48,6 +48,21 @@ resource "aws_route" "foo" {
 }`,
 			Expected: []*issue.Issue{},
 		},
+		{
+			Name: "multiple targes found, but the second one is null",
+			Content: `
+variable "egress_only_gateway_id" {
+    type    = string
+	default = null
+}
+
+resource "aws_route" "foo" {
+    route_table_id = "rtb-1234abcd"
+    gateway_id = "igw-1234abcd"
+    egress_only_gateway_id = var.egress_only_gateway_id
+}`,
+			Expected: []*issue.Issue{},
+		},
 	}
 
 	dir, err := ioutil.TempDir("", "AwsRouteSpecifiedMultipleTargets")

--- a/tflint/errors.go
+++ b/tflint/errors.go
@@ -7,6 +7,8 @@ const (
 	EvaluationError int = 0
 	// UnknownValueError is an error when an unknown value is referenced
 	UnknownValueError int = 1 + iota
+	// NullValueError is an error when null value is referenced
+	NullValueError
 	// TypeConversionError is an error when type conversion of cty.Value failed
 	TypeConversionError
 	// TypeMismatchError is an error when a type of cty.Value is not as expected

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -196,6 +196,20 @@ func (r *Runner) EvaluateExpr(expr hcl.Expression, ret interface{}) error {
 		return err
 	}
 
+	if val.IsNull() {
+		err := &Error{
+			Code:  NullValueError,
+			Level: WarningLevel,
+			Message: fmt.Sprintf(
+				"Null value found in %s:%d",
+				r.getFileName(expr.Range().Filename),
+				expr.Range().Start.Line,
+			),
+		}
+		log.Printf("[WARN] %s; TFLint ignores an expression includes an null value.", err)
+		return err
+	}
+
 	var err error
 	switch ret.(type) {
 	case *string:
@@ -341,6 +355,12 @@ func (r *Runner) EnsureNoError(err error, proc func() error) error {
 	} else {
 		return err
 	}
+}
+
+// IsNullExpr check the passed expression is null
+func (r *Runner) IsNullExpr(expr hcl.Expression) bool {
+	val, _ := r.ctx.EvaluateExpr(expr, cty.DynamicPseudoType, nil)
+	return val.IsNull()
 }
 
 // LookupResourcesByType returns `configs.Resource` list according to the resource type


### PR DESCRIPTION
Terraform v0.12 introduces `null` value to mark the attribute value as unset. TFLint doesn't handle the null values correctly, so some rules need to be fixed.