### PR TITLE
Make transit_gateway_id as a valid target on the multiple targets rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ We strongly recommend [upgrading to Terraform v0.12](https://www.terraform.io/up
   - Fixed the problem that overwrites the config under the current directory by homedir config.
 - Improve to check for `aws_db_instance_readable_password`.
   - Previously, false positive occurred when setting values files or environment variables, but this problem has been fixed.
+- Make `transit_gateway_id` as a valid target on `aws_route_specified_multiple_targets`
 
 ### Project Changes
 

--- a/docs/rules/aws_route_specified_multiple_targets.md
+++ b/docs/rules/aws_route_specified_multiple_targets.md
@@ -35,3 +35,4 @@ Check if two or more of the following attributes are specified:
 - instance_id
 - vpc_peering_connection_id
 - network_interface_id
+- transit_gateway_id

--- a/rules/awsrules/aws_route_specified_multiple_targets.go
+++ b/rules/awsrules/aws_route_specified_multiple_targets.go
@@ -67,6 +67,9 @@ func (r *AwsRouteSpecifiedMultipleTargetsRule) Check(runner *tflint.Runner) erro
 				{
 					Name: "network_interface_id",
 				},
+				{
+					Name: "transit_gateway_id",
+				},
 			},
 		})
 		if diags.HasErrors() {


### PR DESCRIPTION
Follow up of #276 

This PR focused on the `aws_route_specified_multiple_targets` rule