### PR TITLE
Emit issues when the volume type is null

### DIFF
--- a/rules/awsrules/aws_instance_default_standard_volume.go
+++ b/rules/awsrules/aws_instance_default_standard_volume.go
@@ -89,7 +89,11 @@ func (r *AwsInstanceDefaultStandardVolumeRule) blockWalker(runner *tflint.Runner
 		return diags
 	}
 
-	if _, ok := body.Attributes["volume_type"]; !ok {
+	if volumeType, ok := body.Attributes["volume_type"]; ok {
+		if runner.IsNullExpr(volumeType.Expr) {
+			runner.EmitIssue(r, r.message(), volumeType.Expr.Range())
+		}
+	} else {
 		runner.EmitIssue(r, r.message(), block.TypeRange)
 	}
 	return nil

--- a/rules/awsrules/aws_instance_default_standard_volume_test.go
+++ b/rules/awsrules/aws_instance_default_standard_volume_test.go
@@ -139,7 +139,16 @@ resource "aws_instance" "web" {
         volume_size = "24"
     }
 }`,
-			Expected: []*issue.Issue{},
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_instance_default_standard_volume",
+					Type:     issue.WARNING,
+					Message:  "\"volume_type\" is not specified. Default standard volume type is not recommended. You can use \"gp2\", \"io1\", etc instead.",
+					Line:     11,
+					File:     "resource.tf",
+					Link:     project.ReferenceLink("aws_instance_default_standard_volume"),
+				},
+			},
 		},
 		{
 			Name: "volume_type attribute is null",


### PR DESCRIPTION
If `volume_type` is null, `aws_instance_default_standard_volume` rule emits an issue.

Note that the `*_block_device` **attribute** doesn't emit an issue. This is because there is no way to distinguish which value is null when evaluating the attribute as a map. In such cases, TFLint doesn't always emit an issue to avoid false positives.