### PR TITLE
Release via GoReleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.test
 /vendor
+/dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,30 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    - make mock
+builds:
+  - goos:
+      - linux
+      - darwin
+      - freebsd
+      - netbsd
+      - openbsd
+      - windows
+    goarch:
+      - 386
+      - amd64
+      - arm
+archive:
+  name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+  format: zip
+  files:
+    - none*
+checksum:
+  name_template: 'checksums.txt'
+sign:
+  artifacts: checksum
+release:
+  disable: true
+snapshot:
+  name_template: "{{ .Tag }}-dev"

--- a/Makefile
+++ b/Makefile
@@ -15,24 +15,7 @@ install: test
 	go install
 
 release: test
-	go get github.com/mitchellh/gox
-	gox --output 'dist/{{.OS}}_{{.Arch}}/{{.Dir}}'
-	mkdir -p dist/releases
-	zip -j dist/releases/tflint_darwin_386.zip    dist/darwin_386/tflint
-	zip -j dist/releases/tflint_darwin_amd64.zip  dist/darwin_amd64/tflint
-	zip -j dist/releases/tflint_freebsd_386.zip   dist/freebsd_386/tflint
-	zip -j dist/releases/tflint_freebsd_amd64.zip dist/freebsd_amd64/tflint
-	zip -j dist/releases/tflint_freebsd_arm.zip   dist/freebsd_arm/tflint
-	zip -j dist/releases/tflint_linux_386.zip     dist/linux_386/tflint
-	zip -j dist/releases/tflint_linux_amd64.zip   dist/linux_amd64/tflint
-	zip -j dist/releases/tflint_linux_arm.zip     dist/linux_arm/tflint
-	zip -j dist/releases/tflint_netbsd_386.zip    dist/netbsd_386/tflint
-	zip -j dist/releases/tflint_netbsd_amd64.zip  dist/netbsd_amd64/tflint
-	zip -j dist/releases/tflint_netbsd_arm.zip    dist/netbsd_arm/tflint
-	zip -j dist/releases/tflint_openbsd_386.zip   dist/openbsd_386/tflint
-	zip -j dist/releases/tflint_openbsd_amd64.zip dist/openbsd_amd64/tflint
-	zip -j dist/releases/tflint_windows_386.zip   dist/windows_386/tflint.exe
-	zip -j dist/releases/tflint_windows_amd64.zip dist/windows_amd64/tflint.exe
+	goreleaser --rm-dist
 
 clean:
 	rm -rf dist/


### PR DESCRIPTION
Fixes #252

Switch the release way from [Gox](https://github.com/mitchellh/gox) to [GoReleaser](https://github.com/goreleaser/goreleaser). This allows us to manage release settings in a YAML file and automate things like signing keys.

There is also room for publishing docker images and brew formula, but this is not done here. In addition, a release is done manually on my local machine. Automating releases using GitHub Actions or CIs is also possible, but due to various difficulties, this is not considered here.