### PR TITLE
Walk on dynamic blocks partially

### DIFF
--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -1471,6 +1471,33 @@ resource "aws_instance" "test" {
 }`,
 			ErrorText: "Walk instance_type",
 		},
+		{
+			Name: "walk dynamic blocks",
+			Content: `
+resource "aws_instance" "test" {
+  dynamic "instance_type" {
+    for_each = ["foo", "bar"]
+
+    content {
+      foo = instance_type.value
+    }
+  }
+}`,
+			ErrorText: "Walk content",
+		},
+		{
+			Name: "Another dynamic block",
+			Content: `
+resource "aws_instance" "test" {
+  dynamic "key" {
+    for_each = ["foo", "bar"]
+
+    content {
+      foo = key.value
+    }
+  }
+}`,
+		},
 	}
 
 	dir, err := ioutil.TempDir("", "WalkResourceBlocks")


### PR DESCRIPTION
Terraform 0.12 adds support for dynamic nested blocks. At present, the `WalkResourceBlocks` API only extracts the structure on HCL and walks on it, so it cannot support such dynamic blocks.

For complete support, we need to evaluate and expand the blocks like Terraform way. [`ExpandBlock`](https://github.com/hashicorp/terraform/blob/v0.12.0/lang/eval.go#L19-L35) and [`EvalBlock`](https://github.com/hashicorp/terraform/blob/v0.12.0/lang/eval.go#L37-L72) are likely to be helpful. However, when evaluating a block, we must consider the possibility that the block contains unevaluable values such as unknown or unsupported references. Unfortunately, in that case, we must ignore all that block.

In this PR, in order to avoid this problem, we walk the dynamic block partially as the HCL structure without evaluating the block. So we can't still evaluate expressions that contain iterators, but fortunately, the `aws_instance_default_standard_volume` rule doesn't require value evaluation.