### PR TITLE
Fix panic when checking whether an expression is null

### DIFF
--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -366,7 +366,13 @@ func (r *Runner) EnsureNoError(err error, proc func() error) error {
 
 // IsNullExpr check the passed expression is null
 func (r *Runner) IsNullExpr(expr hcl.Expression) bool {
-	val, _ := r.ctx.EvaluateExpr(expr, cty.DynamicPseudoType, nil)
+	if !isEvaluable(expr) {
+		return false
+	}
+	val, diags := r.ctx.EvaluateExpr(expr, cty.DynamicPseudoType, nil)
+	if diags.HasErrors() {
+		return false
+	}
 	return val.IsNull()
 }
 


### PR DESCRIPTION
Fix #295 

When checking whether an expression is null, it evaluates the expression before making sure that that is evaluable. As a result, it may cause unexpected errors.

Unfortunately, I have not confirmed whether this actually causes panic, but I think that the behavior may change with or without tfstate.