### PR TITLE
Make aws_instance_invalid_ami rule faster

### DIFF
--- a/rules/awsrules/aws_instance_invalid_ami_test.go
+++ b/rules/awsrules/aws_instance_invalid_ami_test.go
@@ -18,44 +18,8 @@ import (
 	"github.com/wata727/tflint/tflint"
 )
 
-func Test_AwsInstanceInvalidAMI(t *testing.T) {
-	cases := []struct {
-		Name     string
-		Content  string
-		Response []*ec2.Image
-		Expected issue.Issues
-	}{
-		{
-			Name: "basic",
-			Content: `
-resource "aws_instance" "invalid" {
-  ami = "ami-1234abcd"
-}
-
-resource "aws_instance" "valid" {
-  ami = "ami-9ad76sd1"
-}`,
-			Response: []*ec2.Image{
-				{
-					ImageId: aws.String("ami-0c11b26d"),
-				},
-				{
-					ImageId: aws.String("ami-9ad76sd1"),
-				},
-			},
-			Expected: []*issue.Issue{
-				{
-					Detector: "aws_instance_invalid_ami",
-					Type:     issue.ERROR,
-					Message:  "\"ami-1234abcd\" is invalid AMI ID.",
-					Line:     3,
-					File:     "instances.tf",
-				},
-			},
-		},
-	}
-
-	dir, err := ioutil.TempDir("", "AwsInstanceInvalidAMI")
+func Test_AwsInstanceInvalidAMI_invalid(t *testing.T) {
+	dir, err := ioutil.TempDir("", "AwsInstanceInvalidAMI_invalid")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,37 +33,108 @@ resource "aws_instance" "valid" {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	for _, tc := range cases {
-		err := ioutil.WriteFile(dir+"/instances.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
+	content := `
+resource "aws_instance" "invalid" {
+	ami = "ami-1234abcd"
+}`
+	err = ioutil.WriteFile(dir+"/instances.tf", []byte(content), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
+	mod, diags := loader.Parser().LoadConfigDir(dir)
+	if diags.HasErrors() {
+		t.Fatal(diags)
+	}
+	cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+	if tfdiags.HasErrors() {
+		t.Fatal(tfdiags)
+	}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		rule := NewAwsInstanceInvalidAMIRule()
+	runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+	rule := NewAwsInstanceInvalidAMIRule()
 
-		ec2mock := client.NewMockEC2API(ctrl)
-		ec2mock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{}).Return(&ec2.DescribeImagesOutput{
-			Images: tc.Response,
-		}, nil)
-		runner.AwsClient.EC2 = ec2mock
+	ec2mock := client.NewMockEC2API(ctrl)
+	ec2mock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{
+		ImageIds: aws.StringSlice([]string{"ami-1234abcd"}),
+	}).Return(&ec2.DescribeImagesOutput{
+		Images: []*ec2.Image{},
+	}, nil)
+	runner.AwsClient.EC2 = ec2mock
 
-		if err = rule.Check(runner); err != nil {
-			t.Fatalf("Unexpected error occurred: %s", err)
-		}
+	if err = rule.Check(runner); err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
 
-		if !cmp.Equal(tc.Expected, runner.Issues) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
-		}
+	expected := issue.Issues{
+		{
+			Detector: "aws_instance_invalid_ami",
+			Type:     issue.ERROR,
+			Message:  "\"ami-1234abcd\" is invalid AMI ID.",
+			Line:     3,
+			File:     "instances.tf",
+		},
+	}
+	if !cmp.Equal(expected, runner.Issues) {
+		t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(expected, runner.Issues))
+	}
+}
+
+func Test_AwsInstanceInvalidAMI_valid(t *testing.T) {
+	dir, err := ioutil.TempDir("", "AwsInstanceInvalidAMI_invalid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	loader, err := configload.NewLoader(&configload.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	content := `
+resource "aws_instance" "valid" {
+	ami = "ami-9ad76sd1"
+}`
+	err = ioutil.WriteFile(dir+"/instances.tf", []byte(content), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mod, diags := loader.Parser().LoadConfigDir(dir)
+	if diags.HasErrors() {
+		t.Fatal(diags)
+	}
+	cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+	if tfdiags.HasErrors() {
+		t.Fatal(tfdiags)
+	}
+
+	runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+	rule := NewAwsInstanceInvalidAMIRule()
+
+	ec2mock := client.NewMockEC2API(ctrl)
+	ec2mock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{
+		ImageIds: aws.StringSlice([]string{"ami-9ad76sd1"}),
+	}).Return(&ec2.DescribeImagesOutput{
+		Images: []*ec2.Image{
+			{
+				ImageId: aws.String("ami-9ad76sd1"),
+			},
+		},
+	}, nil)
+	runner.AwsClient.EC2 = ec2mock
+
+	if err = rule.Check(runner); err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+
+	expected := issue.Issues{}
+	if !cmp.Equal(expected, runner.Issues) {
+		t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(expected, runner.Issues))
 	}
 }
 
@@ -107,6 +142,7 @@ func Test_AwsInstanceInvalidAMI_error(t *testing.T) {
 	cases := []struct {
 		Name       string
 		Content    string
+		Request    *ec2.DescribeImagesInput
 		Response   error
 		ErrorCode  int
 		ErrorLevel int
@@ -118,6 +154,9 @@ func Test_AwsInstanceInvalidAMI_error(t *testing.T) {
 resource "aws_instance" "valid" {
   ami = "ami-9ad76sd1"
 }`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"ami-9ad76sd1"}),
+			},
 			Response:   errors.New("MissingRegion: could not find region configuration"),
 			ErrorCode:  tflint.ExternalAPIError,
 			ErrorLevel: tflint.ErrorLevel,
@@ -158,7 +197,7 @@ resource "aws_instance" "valid" {
 		rule := NewAwsInstanceInvalidAMIRule()
 
 		ec2mock := client.NewMockEC2API(ctrl)
-		ec2mock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{}).Return(nil, tc.Response)
+		ec2mock.EXPECT().DescribeImages(tc.Request).Return(nil, tc.Response)
 		runner.AwsClient.EC2 = ec2mock
 
 		err = rule.Check(runner)


### PR DESCRIPTION
Currently, `aws_instance_invalid_ami` rule fetches all images first. However, these are very large and take a lot of time to complete the request. We just had to provide the `--fast` option just to disable this rule.

In this pull request, instead of fetching all images first, it will request each time as needed, and cache the list of fetched AMIs. This can reduce the time spent on requests and significantly reduce memory usage.

The number of requests simply increases, but in many cases, it is faster than fetching all images. Here is an example of `time` output:

**Before**
```
tflint --deep  46.28s user 10.51s system 63% cpu 1:29.18 total
```

**After**
```
tflint --deep  0.55s user 0.10s system 8% cpu 7.817 total
```

NOTE: The `--fast` option will be no longer used, and will be removed in v0.9.