### PR TITLE
Accept a directory as an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ TFLint inspects all configurations under the current directory by default. You c
 ```
 $ tflint --help
 Usage:
-  tflint [OPTIONS]
+  tflint [OPTIONS] [FILE or DIR...]
 
 Application Options:
   -v, --version                             Print TFLint version

--- a/cmd/test-fixtures/arguments/example/test.tf
+++ b/cmd/test-fixtures/arguments/example/test.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "backend" {
+  ami           = "ami-b73b63a0"
+  instance_type = "t1.2xlarge"
+
+  tags {
+    Name = "HelloWorld"
+  }
+}

--- a/integration/arguments/dir/.terraform/modules/modules.json
+++ b/integration/arguments/dir/.terraform/modules/modules.json
@@ -1,0 +1,1 @@
+{"Modules":[{"Key":"","Source":"","Dir":"."},{"Key":"instances","Source":"./module","Dir":"module"}]}

--- a/integration/arguments/dir/example.tf
+++ b/integration/arguments/dir/example.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "example" {
+  instance_type = "t1.2xlarge"
+}

--- a/integration/arguments/dir/module/template.tf
+++ b/integration/arguments/dir/module/template.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "example" {
+  instance_type = "t1.2xlarge"
+}

--- a/integration/arguments/dir/template.tf
+++ b/integration/arguments/dir/template.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "template" {
+  instance_type = "t1.2xlarge"
+}
+
+// `terraform get` in Terraform v0.12
+module "instances" {
+  source = "./module"
+}

--- a/integration/arguments/result.json
+++ b/integration/arguments/result.json
@@ -1,0 +1,10 @@
+[
+  {
+    "detector": "aws_instance_invalid_type",
+    "type": "ERROR",
+    "message": "\"t1.2xlarge\" is invalid instance type.",
+    "line": 2,
+    "file": "dir/template.tf",
+    "link": ""
+  }
+]

--- a/integration/arguments/result_windows.json
+++ b/integration/arguments/result_windows.json
@@ -1,0 +1,10 @@
+[
+  {
+    "detector": "aws_instance_invalid_type",
+    "type": "ERROR",
+    "message": "\"t1.2xlarge\" is invalid instance type.",
+    "line": 2,
+    "file": "dir\\template.tf",
+    "link": ""
+  }
+]

--- a/integration/arguments/template.tf
+++ b/integration/arguments/template.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "default" {
+  instance_type = "t1.2xlarge"
+}

--- a/rules/awsrules/aws_alb_invalid_security_group_test.go
+++ b/rules/awsrules/aws_alb_invalid_security_group_test.go
@@ -121,6 +121,17 @@ resource "aws_alb" "balancer" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -135,7 +146,7 @@ resource "aws_alb" "balancer" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}
@@ -194,6 +205,17 @@ resource "aws_alb" "balancer" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -208,7 +230,7 @@ resource "aws_alb" "balancer" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_alb_invalid_subnet_test.go
+++ b/rules/awsrules/aws_alb_invalid_subnet_test.go
@@ -105,6 +105,17 @@ resource "aws_alb" "balancer" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -119,7 +130,7 @@ resource "aws_alb" "balancer" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_cloudwatch_metric_alarm_invalid_unit_test.go
+++ b/rules/awsrules/aws_cloudwatch_metric_alarm_invalid_unit_test.go
@@ -85,6 +85,17 @@ resource "aws_cloudwatch_metric_alarm" "test" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tc := range cases {
 		loader, err := configload.NewLoader(&configload.Config{})
 		if err != nil {
@@ -96,7 +107,7 @@ resource "aws_cloudwatch_metric_alarm" "test" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_db_instance_default_parameter_group_test.go
+++ b/rules/awsrules/aws_db_instance_default_parameter_group_test.go
@@ -53,6 +53,17 @@ resource "aws_db_instance" "db" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tc := range cases {
 		loader, err := configload.NewLoader(&configload.Config{})
 		if err != nil {
@@ -64,7 +75,7 @@ resource "aws_db_instance" "db" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_db_instance_invalid_db_subnet_group_test.go
+++ b/rules/awsrules/aws_db_instance_invalid_db_subnet_group_test.go
@@ -75,6 +75,17 @@ resource "aws_db_instance" "mysql" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -89,7 +100,7 @@ resource "aws_db_instance" "mysql" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_db_instance_invalid_option_group_test.go
+++ b/rules/awsrules/aws_db_instance_invalid_option_group_test.go
@@ -75,6 +75,17 @@ resource "aws_db_instance" "mysql" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -89,7 +100,7 @@ resource "aws_db_instance" "mysql" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_db_instance_invalid_parameter_group_test.go
+++ b/rules/awsrules/aws_db_instance_invalid_parameter_group_test.go
@@ -75,6 +75,17 @@ resource "aws_db_instance" "mysql" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -89,7 +100,7 @@ resource "aws_db_instance" "mysql" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_db_instance_invalid_type_test.go
+++ b/rules/awsrules/aws_db_instance_invalid_type_test.go
@@ -52,6 +52,17 @@ resource "aws_db_instance" "mysql" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tc := range cases {
 		loader, err := configload.NewLoader(&configload.Config{})
 		if err != nil {
@@ -63,7 +74,7 @@ resource "aws_db_instance" "mysql" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_db_instance_invalid_vpc_security_group_test.go
+++ b/rules/awsrules/aws_db_instance_invalid_vpc_security_group_test.go
@@ -120,6 +120,17 @@ resource "aws_db_instance" "mysql" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -134,7 +145,7 @@ resource "aws_db_instance" "mysql" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_db_instance_previous_type_test.go
+++ b/rules/awsrules/aws_db_instance_previous_type_test.go
@@ -53,6 +53,17 @@ resource "aws_db_instance" "mysql" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tc := range cases {
 		loader, err := configload.NewLoader(&configload.Config{})
 		if err != nil {
@@ -64,7 +75,7 @@ resource "aws_db_instance" "mysql" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_db_instance_readable_password_test.go
+++ b/rules/awsrules/aws_db_instance_readable_password_test.go
@@ -126,6 +126,17 @@ resource "aws_db_instance" "mysql" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tc := range cases {
 		loader, err := configload.NewLoader(&configload.Config{})
 		if err != nil {
@@ -137,7 +148,7 @@ resource "aws_db_instance" "mysql" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_elasticache_cluster_default_parameter_group_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_default_parameter_group_test.go
@@ -53,6 +53,17 @@ resource "aws_elasticache_cluster" "cache" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tc := range cases {
 		loader, err := configload.NewLoader(&configload.Config{})
 		if err != nil {
@@ -64,7 +75,7 @@ resource "aws_elasticache_cluster" "cache" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_elasticache_cluster_invalid_parameter_group_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_invalid_parameter_group_test.go
@@ -75,6 +75,17 @@ resource "aws_elasticache_cluster" "redis" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -89,7 +100,7 @@ resource "aws_elasticache_cluster" "redis" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_elasticache_cluster_invalid_security_group_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_invalid_security_group_test.go
@@ -120,6 +120,17 @@ resource "aws_elasticache_cluster" "redis" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -134,7 +145,7 @@ resource "aws_elasticache_cluster" "redis" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_elasticache_cluster_invalid_subnet_group_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_invalid_subnet_group_test.go
@@ -75,6 +75,17 @@ resource "aws_elasticache_cluster" "redis" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -89,7 +100,7 @@ resource "aws_elasticache_cluster" "redis" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_elasticache_cluster_invalid_type_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_invalid_type_test.go
@@ -52,6 +52,17 @@ resource "aws_elasticache_cluster" "redis" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tc := range cases {
 		loader, err := configload.NewLoader(&configload.Config{})
 		if err != nil {
@@ -63,7 +74,7 @@ resource "aws_elasticache_cluster" "redis" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_elasticache_cluster_previous_type_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_previous_type_test.go
@@ -53,6 +53,17 @@ resource "aws_elasticache_cluster" "redis" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tc := range cases {
 		loader, err := configload.NewLoader(&configload.Config{})
 		if err != nil {
@@ -64,7 +75,7 @@ resource "aws_elasticache_cluster" "redis" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_elb_invalid_instance_test.go
+++ b/rules/awsrules/aws_elb_invalid_instance_test.go
@@ -120,6 +120,17 @@ resource "aws_elb" "balancer" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -134,7 +145,7 @@ resource "aws_elb" "balancer" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_elb_invalid_security_group_test.go
+++ b/rules/awsrules/aws_elb_invalid_security_group_test.go
@@ -120,6 +120,17 @@ resource "aws_elb" "balancer" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -134,7 +145,7 @@ resource "aws_elb" "balancer" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_elb_invalid_subnet_test.go
+++ b/rules/awsrules/aws_elb_invalid_subnet_test.go
@@ -120,6 +120,17 @@ resource "aws_elb" "balancer" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -134,7 +145,7 @@ resource "aws_elb" "balancer" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_instance_default_standard_volume_test.go
+++ b/rules/awsrules/aws_instance_default_standard_volume_test.go
@@ -206,6 +206,17 @@ resource "aws_instance" "web" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tc := range cases {
 		loader, err := configload.NewLoader(&configload.Config{})
 		if err != nil {
@@ -217,7 +228,7 @@ resource "aws_instance" "web" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_instance_invalid_ami_test.go
+++ b/rules/awsrules/aws_instance_invalid_ami_test.go
@@ -25,6 +25,17 @@ func Test_AwsInstanceInvalidAMI_invalid(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	loader, err := configload.NewLoader(&configload.Config{})
 	if err != nil {
 		t.Fatal(err)
@@ -42,7 +53,7 @@ resource "aws_instance" "invalid" {
 		t.Fatal(err)
 	}
 
-	mod, diags := loader.Parser().LoadConfigDir(dir)
+	mod, diags := loader.Parser().LoadConfigDir(".")
 	if diags.HasErrors() {
 		t.Fatal(diags)
 	}
@@ -87,6 +98,17 @@ func Test_AwsInstanceInvalidAMI_valid(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	loader, err := configload.NewLoader(&configload.Config{})
 	if err != nil {
 		t.Fatal(err)
@@ -104,7 +126,7 @@ resource "aws_instance" "valid" {
 		t.Fatal(err)
 	}
 
-	mod, diags := loader.Parser().LoadConfigDir(dir)
+	mod, diags := loader.Parser().LoadConfigDir(".")
 	if diags.HasErrors() {
 		t.Fatal(diags)
 	}
@@ -170,6 +192,17 @@ resource "aws_instance" "valid" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	loader, err := configload.NewLoader(&configload.Config{})
 	if err != nil {
 		t.Fatal(err)
@@ -184,7 +217,7 @@ resource "aws_instance" "valid" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_instance_invalid_iam_profile_test.go
+++ b/rules/awsrules/aws_instance_invalid_iam_profile_test.go
@@ -75,6 +75,17 @@ resource "aws_instance" "web" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -89,7 +100,7 @@ resource "aws_instance" "web" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_instance_invalid_key_name_test.go
+++ b/rules/awsrules/aws_instance_invalid_key_name_test.go
@@ -72,6 +72,17 @@ resource "aws_instance" "web" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -86,7 +97,7 @@ resource "aws_instance" "web" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_instance_invalid_subnet_test.go
+++ b/rules/awsrules/aws_instance_invalid_subnet_test.go
@@ -72,6 +72,17 @@ resource "aws_instance" "web" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -86,7 +97,7 @@ resource "aws_instance" "web" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_instance_invalid_type_test.go
+++ b/rules/awsrules/aws_instance_invalid_type_test.go
@@ -47,6 +47,17 @@ resource "aws_instance" "valid" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	loader, err := configload.NewLoader(&configload.Config{})
 	if err != nil {
 		t.Fatal(err)
@@ -58,7 +69,7 @@ resource "aws_instance" "valid" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_instance_invalid_vpc_security_group_test.go
+++ b/rules/awsrules/aws_instance_invalid_vpc_security_group_test.go
@@ -120,6 +120,17 @@ resource "aws_instance" "web" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -134,7 +145,7 @@ resource "aws_instance" "web" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_instance_previous_type_test.go
+++ b/rules/awsrules/aws_instance_previous_type_test.go
@@ -53,6 +53,17 @@ resource "aws_instance" "web" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tc := range cases {
 		loader, err := configload.NewLoader(&configload.Config{})
 		if err != nil {
@@ -64,7 +75,7 @@ resource "aws_instance" "web" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_route_invalid_egress_only_gateway_test.go
+++ b/rules/awsrules/aws_route_invalid_egress_only_gateway_test.go
@@ -72,6 +72,17 @@ resource "aws_route" "foo" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -86,7 +97,7 @@ resource "aws_route" "foo" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_route_invalid_gateway_test.go
+++ b/rules/awsrules/aws_route_invalid_gateway_test.go
@@ -72,6 +72,17 @@ resource "aws_route" "foo" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -86,7 +97,7 @@ resource "aws_route" "foo" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_route_invalid_instance_test.go
+++ b/rules/awsrules/aws_route_invalid_instance_test.go
@@ -72,6 +72,17 @@ resource "aws_route" "foo" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -86,7 +97,7 @@ resource "aws_route" "foo" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_route_invalid_nat_gateway_test.go
+++ b/rules/awsrules/aws_route_invalid_nat_gateway_test.go
@@ -72,6 +72,17 @@ resource "aws_route" "foo" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -86,7 +97,7 @@ resource "aws_route" "foo" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_route_invalid_network_interface_test.go
+++ b/rules/awsrules/aws_route_invalid_network_interface_test.go
@@ -72,6 +72,17 @@ resource "aws_route" "foo" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -86,7 +97,7 @@ resource "aws_route" "foo" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_route_invalid_route_table_test.go
+++ b/rules/awsrules/aws_route_invalid_route_table_test.go
@@ -72,6 +72,17 @@ resource "aws_route" "foo" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -86,7 +97,7 @@ resource "aws_route" "foo" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_route_invalid_vpc_peering_connection_test.go
+++ b/rules/awsrules/aws_route_invalid_vpc_peering_connection_test.go
@@ -72,6 +72,17 @@ resource "aws_route" "foo" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -86,7 +97,7 @@ resource "aws_route" "foo" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_route_not_specified_target_test.go
+++ b/rules/awsrules/aws_route_not_specified_target_test.go
@@ -131,6 +131,17 @@ resource "aws_route" "foo" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tc := range cases {
 		loader, err := configload.NewLoader(&configload.Config{})
 		if err != nil {
@@ -142,7 +153,7 @@ resource "aws_route" "foo" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/awsrules/aws_route_specified_multiple_targets_test.go
+++ b/rules/awsrules/aws_route_specified_multiple_targets_test.go
@@ -71,6 +71,17 @@ resource "aws_route" "foo" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tc := range cases {
 		loader, err := configload.NewLoader(&configload.Config{})
 		if err != nil {
@@ -82,7 +93,7 @@ resource "aws_route" "foo" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/rules/rule_test.go.tmpl
+++ b/rules/rule_test.go.tmpl
@@ -48,6 +48,11 @@ resource "null_resource" "null" {
 	}
 	defer os.RemoveAll(dir)
 
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -62,7 +67,7 @@ resource "null_resource" "null" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}
@@ -71,7 +76,7 @@ resource "null_resource" "null" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
+		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		rule := New{{ .RuleNameCC }}Rule()
 
 		mock := mock.NewMockAPI(ctrl)

--- a/rules/terraformrules/terraform_module_pinned_source_test.go
+++ b/rules/terraformrules/terraform_module_pinned_source_test.go
@@ -288,6 +288,17 @@ module "pinned_mercurial" {
 	}
 	defer os.RemoveAll(dir)
 
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tc := range cases {
 		loader, err := configload.NewLoader(&configload.Config{})
 		if err != nil {
@@ -299,7 +310,7 @@ module "pinned_mercurial" {
 			t.Fatal(err)
 		}
 
-		mod, diags := loader.Parser().LoadConfigDir(dir)
+		mod, diags := loader.Parser().LoadConfigDir(".")
 		if diags.HasErrors() {
 			t.Fatal(diags)
 		}

--- a/tflint/loader_mock.go
+++ b/tflint/loader_mock.go
@@ -35,29 +35,29 @@ func (m *MockAbstractLoader) EXPECT() *MockAbstractLoaderMockRecorder {
 }
 
 // LoadConfig mocks base method
-func (m *MockAbstractLoader) LoadConfig() (*configs.Config, error) {
-	ret := m.ctrl.Call(m, "LoadConfig")
+func (m *MockAbstractLoader) LoadConfig(arg0 string) (*configs.Config, error) {
+	ret := m.ctrl.Call(m, "LoadConfig", arg0)
 	ret0, _ := ret[0].(*configs.Config)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LoadConfig indicates an expected call of LoadConfig
-func (mr *MockAbstractLoaderMockRecorder) LoadConfig() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadConfig", reflect.TypeOf((*MockAbstractLoader)(nil).LoadConfig))
+func (mr *MockAbstractLoaderMockRecorder) LoadConfig(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadConfig", reflect.TypeOf((*MockAbstractLoader)(nil).LoadConfig), arg0)
 }
 
 // LoadAnnotations mocks base method
-func (m *MockAbstractLoader) LoadAnnotations() (map[string]Annotations, error) {
-	ret := m.ctrl.Call(m, "LoadAnnotations")
+func (m *MockAbstractLoader) LoadAnnotations(arg0 string) (map[string]Annotations, error) {
+	ret := m.ctrl.Call(m, "LoadAnnotations", arg0)
 	ret0, _ := ret[0].(map[string]Annotations)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LoadAnnotations indicates an expected call of LoadAnnotations
-func (mr *MockAbstractLoaderMockRecorder) LoadAnnotations() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadAnnotations", reflect.TypeOf((*MockAbstractLoader)(nil).LoadAnnotations))
+func (mr *MockAbstractLoaderMockRecorder) LoadAnnotations(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadAnnotations", reflect.TypeOf((*MockAbstractLoader)(nil).LoadAnnotations), arg0)
 }
 
 // LoadValuesFiles mocks base method
@@ -75,16 +75,4 @@ func (m *MockAbstractLoader) LoadValuesFiles(arg0 ...string) ([]terraform.InputV
 // LoadValuesFiles indicates an expected call of LoadValuesFiles
 func (mr *MockAbstractLoaderMockRecorder) LoadValuesFiles(arg0 ...interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadValuesFiles", reflect.TypeOf((*MockAbstractLoader)(nil).LoadValuesFiles), arg0...)
-}
-
-// IsConfigFile mocks base method
-func (m *MockAbstractLoader) IsConfigFile(arg0 string) bool {
-	ret := m.ctrl.Call(m, "IsConfigFile", arg0)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsConfigFile indicates an expected call of IsConfigFile
-func (mr *MockAbstractLoaderMockRecorder) IsConfigFile(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsConfigFile", reflect.TypeOf((*MockAbstractLoader)(nil).IsConfigFile), arg0)
 }

--- a/tflint/loader_test.go
+++ b/tflint/loader_test.go
@@ -29,7 +29,7 @@ func Test_LoadConfig_v0_10_5(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
-	config, err := loader.LoadConfig()
+	config, err := loader.LoadConfig(".")
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -59,7 +59,7 @@ func Test_LoadConfig_v0_10_6(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
-	config, err := loader.LoadConfig()
+	config, err := loader.LoadConfig(".")
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -89,7 +89,7 @@ func Test_LoadConfig_v0_10_7(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
-	config, err := loader.LoadConfig()
+	config, err := loader.LoadConfig(".")
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -119,7 +119,7 @@ func Test_LoadConfig_v0_11_0(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
-	config, err := loader.LoadConfig()
+	config, err := loader.LoadConfig(".")
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -193,7 +193,7 @@ func Test_LoadConfig_v0_12_0(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
-	config, err := loader.LoadConfig()
+	config, err := loader.LoadConfig(".")
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -271,7 +271,7 @@ func Test_LoadConfig_moduleNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
-	_, err = loader.LoadConfig()
+	_, err = loader.LoadConfig(".")
 	if err == nil {
 		t.Fatal("Expected error is not occurred")
 	}
@@ -298,7 +298,7 @@ func Test_LoadConfig_invalidConfiguration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
-	_, err = loader.LoadConfig()
+	_, err = loader.LoadConfig(".")
 	if err == nil {
 		t.Fatal("Expected error is not occurred")
 	}
@@ -324,7 +324,7 @@ func Test_LoadAnnotations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
-	ret, err := loader.LoadAnnotations()
+	ret, err := loader.LoadAnnotations(".")
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -447,52 +447,5 @@ func Test_LoadValuesFiles_invalidValuesFile(t *testing.T) {
 	expected := "terraform.tfvars:3,1-9: Unexpected \"resource\" block; Blocks are not allowed here."
 	if err.Error() != expected {
 		t.Fatalf("Expected error is `%s`, but get `%s`", expected, err.Error())
-	}
-}
-
-func Test_IsConfigFile(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "is_config_file"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	loader, err := NewLoader()
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-
-	cases := []struct {
-		Name     string
-		File     string
-		Expected bool
-	}{
-		{
-			Name:     "config file",
-			File:     "template.tf",
-			Expected: true,
-		},
-		{
-			Name:     "not config file",
-			File:     "README",
-			Expected: false,
-		},
-		{
-			Name:     "not found",
-			File:     "not_found.tf",
-			Expected: false,
-		},
-	}
-
-	for _, tc := range cases {
-		ret := loader.IsConfigFile(tc.File)
-		if ret != tc.Expected {
-			t.Fatalf("Test `%s` failed: expected is `%t`, but get `%t`", tc.Name, tc.Expected, ret)
-		}
 	}
 }

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -476,11 +476,11 @@ func (r *Runner) EmitIssue(rule Rule, message string, location hcl.Range) {
 }
 
 // getFileName returns user-friendly file name.
-// It returns base file name when processing root module.
+// It returns a raw path when processing root module.
 // Otherwise, it add the module name as prefix to base file name.
 func (r *Runner) getFileName(raw string) string {
 	if r.TFConfig.Path.IsRoot() {
-		return filepath.Base(raw)
+		return raw
 	}
 	return filepath.Join(r.TFConfig.Path.String(), filepath.Base(raw))
 }

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -475,7 +475,7 @@ resource "null_resource" "test" {
 }`,
 			ErrorCode:  EvaluationError,
 			ErrorLevel: ErrorLevel,
-			ErrorText:  "Failed to eval an expression in resource.tf:3; Reference to undeclared input variable: An input variable with the name \"undefined_var\" has not been declared. This variable can be declared with a variable \"undefined_var\" {} block.",
+			ErrorText:  "Failed to eval an expression in %s:3; Reference to undeclared input variable: An input variable with the name \"undefined_var\" has not been declared. This variable can be declared with a variable \"undefined_var\" {} block.",
 		},
 		{
 			Name: "no default value",
@@ -487,7 +487,7 @@ resource "null_resource" "test" {
 }`,
 			ErrorCode:  UnknownValueError,
 			ErrorLevel: WarningLevel,
-			ErrorText:  "Unknown value found in resource.tf:5; Please use environment variables or tfvars to set the value",
+			ErrorText:  "Unknown value found in %s:5; Please use environment variables or tfvars to set the value",
 		},
 		{
 			Name: "null value",
@@ -502,7 +502,7 @@ resource "null_resource" "test" {
 }`,
 			ErrorCode:  NullValueError,
 			ErrorLevel: WarningLevel,
-			ErrorText:  "Null value found in resource.tf:8",
+			ErrorText:  "Null value found in %s:8",
 		},
 		{
 			Name: "terraform env",
@@ -512,7 +512,7 @@ resource "null_resource" "test" {
 }`,
 			ErrorCode:  EvaluationError,
 			ErrorLevel: ErrorLevel,
-			ErrorText:  "Failed to eval an expression in resource.tf:3; Invalid \"terraform\" attribute: The terraform.env attribute was deprecated in v0.10 and removed in v0.12. The \"state environment\" concept was rename to \"workspace\" in v0.12, and so the workspace name can now be accessed using the terraform.workspace attribute.",
+			ErrorText:  "Failed to eval an expression in %s:3; Invalid \"terraform\" attribute: The terraform.env attribute was deprecated in v0.10 and removed in v0.12. The \"state environment\" concept was rename to \"workspace\" in v0.12, and so the workspace name can now be accessed using the terraform.workspace attribute.",
 		},
 		{
 			Name: "type mismatch",
@@ -522,7 +522,7 @@ resource "null_resource" "test" {
 }`,
 			ErrorCode:  TypeConversionError,
 			ErrorLevel: ErrorLevel,
-			ErrorText:  "Invalid type expression in resource.tf:3; string required",
+			ErrorText:  "Invalid type expression in %s:3; string required",
 		},
 		{
 			Name: "unevalauble",
@@ -532,7 +532,7 @@ resource "null_resource" "test" {
 }`,
 			ErrorCode:  UnevaluableError,
 			ErrorLevel: WarningLevel,
-			ErrorText:  "Unevaluable expression found in resource.tf:3",
+			ErrorText:  "Unevaluable expression found in %s:3",
 		},
 	}
 
@@ -559,11 +559,13 @@ resource "null_resource" "test" {
 
 		runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
 
+		expectedText := fmt.Sprintf(tc.ErrorText, filepath.Join(dir, "resource.tf"))
+
 		var ret string
 		err = runner.EvaluateExpr(attribute.Expr, &ret)
 		if appErr, ok := err.(*Error); ok {
 			if appErr == nil {
-				t.Fatalf("Failed `%s` test: expected err is `%s`, but nothing occurred", tc.Name, tc.ErrorText)
+				t.Fatalf("Failed `%s` test: expected err is `%s`, but nothing occurred", tc.Name, expectedText)
 			}
 			if appErr.Code != tc.ErrorCode {
 				t.Fatalf("Failed `%s` test: expected error code is `%d`, but get `%d`", tc.Name, tc.ErrorCode, appErr.Code)
@@ -571,8 +573,8 @@ resource "null_resource" "test" {
 			if appErr.Level != tc.ErrorLevel {
 				t.Fatalf("Failed `%s` test: expected error level is `%d`, but get `%d`", tc.Name, tc.ErrorLevel, appErr.Level)
 			}
-			if appErr.Error() != tc.ErrorText {
-				t.Fatalf("Failed `%s` test: expected error is `%s`, but get `%s`", tc.Name, tc.ErrorText, appErr.Error())
+			if appErr.Error() != expectedText {
+				t.Fatalf("Failed `%s` test: expected error is `%s`, but get `%s`", tc.Name, expectedText, appErr.Error())
 			}
 		} else {
 			t.Fatalf("Failed `%s` test: unexpected error occurred: %s", tc.Name, err)
@@ -598,7 +600,7 @@ resource "null_resource" "test" {
 }`,
 			ErrorCode:  EvaluationError,
 			ErrorLevel: ErrorLevel,
-			ErrorText:  "Failed to eval an expression in resource.tf:3; Reference to undeclared input variable: An input variable with the name \"undefined_var\" has not been declared. This variable can be declared with a variable \"undefined_var\" {} block.",
+			ErrorText:  "Failed to eval an expression in %s:3; Reference to undeclared input variable: An input variable with the name \"undefined_var\" has not been declared. This variable can be declared with a variable \"undefined_var\" {} block.",
 		},
 		{
 			Name: "no default value",
@@ -612,7 +614,7 @@ resource "null_resource" "test" {
 }`,
 			ErrorCode:  UnknownValueError,
 			ErrorLevel: WarningLevel,
-			ErrorText:  "Unknown value found in resource.tf:5; Please use environment variables or tfvars to set the value",
+			ErrorText:  "Unknown value found in %s:5; Please use environment variables or tfvars to set the value",
 		},
 		{
 			Name: "null value",
@@ -629,7 +631,7 @@ resource "null_resource" "test" {
 }`,
 			ErrorCode:  NullValueError,
 			ErrorLevel: WarningLevel,
-			ErrorText:  "Null value found in resource.tf:8",
+			ErrorText:  "Null value found in %s:8",
 		},
 		{
 			Name: "unevalauble",
@@ -641,7 +643,7 @@ resource "null_resource" "test" {
 }`,
 			ErrorCode:  UnevaluableError,
 			ErrorLevel: WarningLevel,
-			ErrorText:  "Unevaluable expression found in resource.tf:3",
+			ErrorText:  "Unevaluable expression found in %s:3",
 		},
 	}
 
@@ -668,11 +670,13 @@ resource "null_resource" "test" {
 
 		runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
 
+		expectedText := fmt.Sprintf(tc.ErrorText, filepath.Join(dir, "resource.tf"))
+
 		var ret map[string]string
 		err = runner.EvaluateExpr(attribute.Expr, &ret)
 		if appErr, ok := err.(*Error); ok {
 			if appErr == nil {
-				t.Fatalf("Failed `%s` test: expected err is `%s`, but nothing occurred", tc.Name, tc.ErrorText)
+				t.Fatalf("Failed `%s` test: expected err is `%s`, but nothing occurred", tc.Name, expectedText)
 			}
 			if appErr.Code != tc.ErrorCode {
 				t.Fatalf("Failed `%s` test: expected error code is `%d`, but get `%d`", tc.Name, tc.ErrorCode, appErr.Code)
@@ -680,8 +684,8 @@ resource "null_resource" "test" {
 			if appErr.Level != tc.ErrorLevel {
 				t.Fatalf("Failed `%s` test: expected error level is `%d`, but get `%d`", tc.Name, tc.ErrorLevel, appErr.Level)
 			}
-			if appErr.Error() != tc.ErrorText {
-				t.Fatalf("Failed `%s` test: expected error is `%s`, but get `%s`", tc.Name, tc.ErrorText, appErr.Error())
+			if appErr.Error() != expectedText {
+				t.Fatalf("Failed `%s` test: expected error is `%s`, but get `%s`", tc.Name, expectedText, appErr.Error())
 			}
 		} else {
 			t.Fatalf("Failed `%s` test: unexpected error occurred: %s", tc.Name, err)
@@ -967,7 +971,7 @@ func Test_NewModuleRunners_noModules(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
-	cfg, err := loader.LoadConfig()
+	cfg, err := loader.LoadConfig(".")
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -999,7 +1003,7 @@ func Test_NewModuleRunners_nestedModules(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
-	cfg, err := loader.LoadConfig()
+	cfg, err := loader.LoadConfig(".")
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -1167,7 +1171,7 @@ func Test_NewModuleRunners_ignoreModules(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
-	cfg, err := loader.LoadConfig()
+	cfg, err := loader.LoadConfig(".")
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -1202,7 +1206,7 @@ func Test_NewModuleRunners_withInvalidExpression(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
-	cfg, err := loader.LoadConfig()
+	cfg, err := loader.LoadConfig(".")
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -1248,7 +1252,7 @@ func Test_NewModuleRunners_withNotAllowedAttributes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
-	cfg, err := loader.LoadConfig()
+	cfg, err := loader.LoadConfig(".")
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}


### PR DESCRIPTION
Fixes https://github.com/wata727/tflint/issues/296

Currently, only files under the current directory are inspected, and an error occurs when passing a directory as an argument like the following:

```
$ tflint tests
Error: Failed to load `tests`: TFLint doesn't accept directories as arguments
```

Initially, this behavior was implemented as a respect to the Terraform behavior, but Terraform can accept a directory of configuration files as an argument. See https://www.terraform.io/docs/commands/plan.html

Based on the above, this PR makes TFLint accept a directory as an argument. However, as with Terraform, you cannot pass multiple directories.

```
$ tflint example tests
Error: Failed to load `example`: Multiple arguments are not allowed when passing a directory
```

Additionally, It also allows files not in the current directory to be accepted. In that case, the directory of the passed files is loaded, and only the issues of the passed files are reported. Therefore, please note that you cannot pass files in different directories at the same time.

```
$ tflint example/*.tf
Awesome! Your code is following the best practices :)
$ tflint example/*.tf terraform/*.tf
Error: Failed to load `terraform/cloudfront.tf`: Multiple files in different directories are not allowed
```
