### PR TITLE
Remove `--fast` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ Application Options:
       --aws-profile=PROFILE                 AWS shared credential profile name used in deep check mode
       --aws-region=REGION                   AWS region used in deep check mode
       --error-with-issues                   Return error code when issues exist
-      --fast                                Ignore slow rules (aws_instance_invalid_ami only)
   -q, --quiet                               Do not output any message when no issues are found (default format only)
 
 Help Options:

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -51,6 +51,9 @@ func (cli *CLI) Run(args []string) int {
 		if option == "debug" {
 			return []string{}, errors.New("`debug` option was removed in v0.8.0. Please set `TFLINT_LOG` environment variables instead")
 		}
+		if option == "fast" {
+			return []string{}, errors.New("`fast` option was removed in v0.9.0. The `aws_instance_invalid_ami` rule is already fast enough")
+		}
 		return []string{}, fmt.Errorf("`%s` is unknown option. Please run `tflint --help`", option)
 	}
 	// Parse commandline flag

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -72,10 +72,16 @@ func TestCLIRun__noIssuesFound(t *testing.T) {
 			Stderr:  "Load error occurred",
 		},
 		{
-			Name:    "deprecated options",
+			Name:    "removed `debug` options",
 			Command: "./tflint --debug",
 			Status:  ExitCodeError,
 			Stderr:  "`debug` option was removed in v0.8.0. Please set `TFLINT_LOG` environment variables instead",
+		},
+		{
+			Name:    "removed `fast` option",
+			Command: "./tflint --fast",
+			Status:  ExitCodeError,
+			Stderr:  "`fast` option was removed in v0.9.0. The `aws_instance_invalid_ami` rule is already fast enough",
 		},
 		{
 			Name:    "invalid options",

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/wata727/tflint/client"
-	"github.com/wata727/tflint/rules/awsrules"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -24,7 +23,6 @@ type Options struct {
 	AwsProfile      string   `long:"aws-profile" description:"AWS shared credential profile name used in deep check mode" value-name:"PROFILE"`
 	AwsRegion       string   `long:"aws-region" description:"AWS region used in deep check mode" value-name:"REGION"`
 	ErrorWithIssues bool     `long:"error-with-issues" description:"Return error code when issues exist"`
-	Fast            bool     `long:"fast" description:"Ignore slow rules (aws_instance_invalid_ami only)"`
 	Quiet           bool     `short:"q" long:"quiet" description:"Do not output any message when no issues are found (default format only)"`
 }
 
@@ -41,10 +39,6 @@ func (opts *Options) toConfig() *tflint.Config {
 		for _, r := range strings.Split(opts.IgnoreRule, ",") {
 			ignoreRule[r] = true
 		}
-	}
-	if opts.Fast {
-		// `aws_instance_invalid_ami` is very slow...
-		ignoreRule[awsrules.NewAwsInstanceInvalidAMIRule().Name()] = true
 	}
 
 	varfile := []string{}

--- a/cmd/option_test.go
+++ b/cmd/option_test.go
@@ -126,20 +126,6 @@ func Test_toConfig(t *testing.T) {
 				Rules:            map[string]*tflint.RuleConfig{},
 			},
 		},
-		{
-			Name:    "--fast",
-			Command: "./tflint --fast",
-			Expected: &tflint.Config{
-				DeepCheck:        false,
-				AwsCredentials:   client.AwsCredentials{},
-				IgnoreModule:     map[string]bool{},
-				IgnoreRule:       map[string]bool{"aws_instance_invalid_ami": true},
-				Varfile:          []string{},
-				Variables:        []string{},
-				TerraformVersion: "",
-				Rules:            map[string]*tflint.RuleConfig{},
-			},
-		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
See also https://github.com/wata727/tflint/pull/308

The `--fast` option was helpful because it disables slow rules automatically. The only slow rule was the `aws_instance_invalid_ami` rule, but this has been faster enough at v0.8.2.

At this time, this option is useless and will be removed.