### PR TITLE
Avoid InvalidAMIID errors

### DIFF
--- a/rules/awsrules/aws_instance_invalid_ami.go
+++ b/rules/awsrules/aws_instance_invalid_ami.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/wata727/tflint/issue"
@@ -62,6 +63,21 @@ func (r *AwsInstanceInvalidAMIRule) Check(runner *tflint.Runner) error {
 					ImageIds: aws.StringSlice([]string{ami}),
 				})
 				if err != nil {
+					if aerr, ok := err.(awserr.Error); ok {
+						switch aerr.Code() {
+						case "InvalidAMIID.Malformed":
+							fallthrough
+						case "InvalidAMIID.NotFound":
+							fallthrough
+						case "InvalidAMIID.Unavailable":
+							runner.EmitIssue(
+								r,
+								fmt.Sprintf("\"%s\" is invalid AMI ID.", ami),
+								attribute.Expr.Range(),
+							)
+							return nil
+						}
+					}
 					err := &tflint.Error{
 						Code:    tflint.ExternalAPIError,
 						Level:   tflint.ErrorLevel,

--- a/rules/awsrules/aws_instance_invalid_ami_test.go
+++ b/rules/awsrules/aws_instance_invalid_ami_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
@@ -179,10 +180,28 @@ resource "aws_instance" "valid" {
 			Request: &ec2.DescribeImagesInput{
 				ImageIds: aws.StringSlice([]string{"ami-9ad76sd1"}),
 			},
-			Response:   errors.New("MissingRegion: could not find region configuration"),
+			Response: awserr.New(
+				"MissingRegion",
+				"could not find region configuration",
+				nil,
+			),
 			ErrorCode:  tflint.ExternalAPIError,
 			ErrorLevel: tflint.ErrorLevel,
 			ErrorText:  "An error occurred while describing images; MissingRegion: could not find region configuration",
+		},
+		{
+			Name: "Unexpected error",
+			Content: `
+resource "aws_instance" "valid" {
+  ami = "ami-9ad76sd1"
+}`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"ami-9ad76sd1"}),
+			},
+			Response:   errors.New("Unexpected"),
+			ErrorCode:  tflint.ExternalAPIError,
+			ErrorLevel: tflint.ErrorLevel,
+			ErrorText:  "An error occurred while describing images; Unexpected",
 		},
 	}
 
@@ -203,16 +222,16 @@ resource "aws_instance" "valid" {
 		t.Fatal(err)
 	}
 
-	loader, err := configload.NewLoader(&configload.Config{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	for _, tc := range cases {
 		err := ioutil.WriteFile(dir+"/instances.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		loader, err := configload.NewLoader(&configload.Config{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -249,6 +268,152 @@ resource "aws_instance" "valid" {
 			}
 		} else {
 			t.Fatalf("Failed `%s` test: unexpected error occurred: %s", tc.Name, err)
+		}
+	}
+}
+
+func Test_AwsInstanceInvalidAMI_AMIError(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Request  *ec2.DescribeImagesInput
+		Response error
+		Issues   issue.Issues
+		Error    bool
+	}{
+		{
+			Name: "not found",
+			Content: `
+resource "aws_instance" "not_found" {
+	ami = "ami-9ad76sd1"
+}`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"ami-9ad76sd1"}),
+			},
+			Response: awserr.New(
+				"InvalidAMIID.NotFound",
+				"The image id '[ami-9ad76sd1]' does not exist",
+				nil,
+			),
+			Issues: issue.Issues{
+				{
+					Detector: "aws_instance_invalid_ami",
+					Type:     issue.ERROR,
+					Message:  "\"ami-9ad76sd1\" is invalid AMI ID.",
+					Line:     3,
+					File:     "instances.tf",
+				},
+			},
+			Error: false,
+		},
+		{
+			Name: "malformed",
+			Content: `
+resource "aws_instance" "malformed" {
+	ami = "image-9ad76sd1"
+}`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"image-9ad76sd1"}),
+			},
+			Response: awserr.New(
+				"InvalidAMIID.Malformed",
+				"Invalid id: \"image-9ad76sd1\" (expecting \"ami-...\")",
+				nil,
+			),
+			Issues: issue.Issues{
+				{
+					Detector: "aws_instance_invalid_ami",
+					Type:     issue.ERROR,
+					Message:  "\"image-9ad76sd1\" is invalid AMI ID.",
+					Line:     3,
+					File:     "instances.tf",
+				},
+			},
+			Error: false,
+		},
+		{
+			Name: "unavailable",
+			Content: `
+resource "aws_instance" "unavailable" {
+	ami = "ami-1234567"
+}`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"ami-1234567"}),
+			},
+			Response: awserr.New(
+				"InvalidAMIID.Unavailable",
+				"The image ID: 'ami-1234567' is no longer available",
+				nil,
+			),
+			Issues: issue.Issues{
+				{
+					Detector: "aws_instance_invalid_ami",
+					Type:     issue.ERROR,
+					Message:  "\"ami-1234567\" is invalid AMI ID.",
+					Line:     3,
+					File:     "instances.tf",
+				},
+			},
+			Error: false,
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsInstanceInvalidAMI_AMIError")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		err := ioutil.WriteFile(dir+"/instances.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(".")
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsInstanceInvalidAMIRule()
+
+		ec2mock := client.NewMockEC2API(ctrl)
+		ec2mock.EXPECT().DescribeImages(tc.Request).Return(nil, tc.Response)
+		runner.AwsClient.EC2 = ec2mock
+
+		err = rule.Check(runner)
+		if err != nil && !tc.Error {
+			t.Fatalf("Failed `%s` test: unexpected error occurred: %s", tc.Name, err)
+		}
+		if err == nil && tc.Error {
+			t.Fatalf("Failed `%s` test: expected to return an error, but nothing occurred", tc.Name)
+		}
+		if !cmp.Equal(tc.Issues, runner.Issues) {
+			t.Fatalf("Failed `%s` test: expected issues are not matched:\n %s\n", tc.Name, cmp.Diff(tc.Issues, runner.Issues))
 		}
 	}
 }

--- a/rules/awsrules/aws_launch_configuration_invalid_image_id_test.go
+++ b/rules/awsrules/aws_launch_configuration_invalid_image_id_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
@@ -179,10 +180,28 @@ resource "aws_launch_configuration" "valid" {
 			Request: &ec2.DescribeImagesInput{
 				ImageIds: aws.StringSlice([]string{"ami-9ad76sd1"}),
 			},
-			Response:   errors.New("MissingRegion: could not find region configuration"),
+			Response: awserr.New(
+				"MissingRegion",
+				"could not find region configuration",
+				nil,
+			),
 			ErrorCode:  tflint.ExternalAPIError,
 			ErrorLevel: tflint.ErrorLevel,
 			ErrorText:  "An error occurred while describing images; MissingRegion: could not find region configuration",
+		},
+		{
+			Name: "Unexpected error",
+			Content: `
+resource "aws_launch_configuration" "valid" {
+	image_id = "ami-9ad76sd1"
+}`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"ami-9ad76sd1"}),
+			},
+			Response:   errors.New("Unexpected"),
+			ErrorCode:  tflint.ExternalAPIError,
+			ErrorLevel: tflint.ErrorLevel,
+			ErrorText:  "An error occurred while describing images; Unexpected",
 		},
 	}
 
@@ -249,6 +268,152 @@ resource "aws_launch_configuration" "valid" {
 			}
 		} else {
 			t.Fatalf("Failed `%s` test: unexpected error occurred: %s", tc.Name, err)
+		}
+	}
+}
+
+func Test_AwsLaunchConfigurationInvalidImageID_AMIError(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Request  *ec2.DescribeImagesInput
+		Response error
+		Issues   issue.Issues
+		Error    bool
+	}{
+		{
+			Name: "not found",
+			Content: `
+resource "aws_launch_configuration" "not_found" {
+	image_id = "ami-9ad76sd1"
+}`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"ami-9ad76sd1"}),
+			},
+			Response: awserr.New(
+				"InvalidAMIID.NotFound",
+				"The image id '[ami-9ad76sd1]' does not exist",
+				nil,
+			),
+			Issues: issue.Issues{
+				{
+					Detector: "aws_launch_configuration_invalid_image_id",
+					Type:     issue.ERROR,
+					Message:  "\"ami-9ad76sd1\" is invalid image ID.",
+					Line:     3,
+					File:     "instances.tf",
+				},
+			},
+			Error: false,
+		},
+		{
+			Name: "malformed",
+			Content: `
+resource "aws_launch_configuration" "malformed" {
+	image_id = "image-9ad76sd1"
+}`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"image-9ad76sd1"}),
+			},
+			Response: awserr.New(
+				"InvalidAMIID.Malformed",
+				"Invalid id: \"image-9ad76sd1\" (expecting \"ami-...\")",
+				nil,
+			),
+			Issues: issue.Issues{
+				{
+					Detector: "aws_launch_configuration_invalid_image_id",
+					Type:     issue.ERROR,
+					Message:  "\"image-9ad76sd1\" is invalid image ID.",
+					Line:     3,
+					File:     "instances.tf",
+				},
+			},
+			Error: false,
+		},
+		{
+			Name: "unavailable",
+			Content: `
+resource "aws_launch_configuration" "unavailable" {
+	image_id = "ami-1234567"
+}`,
+			Request: &ec2.DescribeImagesInput{
+				ImageIds: aws.StringSlice([]string{"ami-1234567"}),
+			},
+			Response: awserr.New(
+				"InvalidAMIID.Unavailable",
+				"The image ID: 'ami-1234567' is no longer available",
+				nil,
+			),
+			Issues: issue.Issues{
+				{
+					Detector: "aws_launch_configuration_invalid_image_id",
+					Type:     issue.ERROR,
+					Message:  "\"ami-1234567\" is invalid image ID.",
+					Line:     3,
+					File:     "instances.tf",
+				},
+			},
+			Error: false,
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsLaunchConfigurationInvalidImageID_AMIError")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	for _, tc := range cases {
+		err := ioutil.WriteFile(dir+"/instances.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(".")
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsLaunchConfigurationInvalidImageIDRule()
+
+		ec2mock := client.NewMockEC2API(ctrl)
+		ec2mock.EXPECT().DescribeImages(tc.Request).Return(nil, tc.Response)
+		runner.AwsClient.EC2 = ec2mock
+
+		err = rule.Check(runner)
+		if err != nil && !tc.Error {
+			t.Fatalf("Failed `%s` test: unexpected error occurred: %s", tc.Name, err)
+		}
+		if err == nil && tc.Error {
+			t.Fatalf("Failed `%s` test: expected to return an error, but nothing occurred", tc.Name)
+		}
+		if !cmp.Equal(tc.Issues, runner.Issues) {
+			t.Fatalf("Failed `%s` test: expected issues are not matched:\n %s\n", tc.Name, cmp.Diff(tc.Issues, runner.Issues))
 		}
 	}
 }


### PR DESCRIPTION
`DescribeImages` may return an error when passing an invalid AMI ID. In the case, TFLint aborts the current inspection with the following error message:

```
$ tflint --deep
Error: Failed to check `aws_instance_invalid_ami` rule: An error occurred while describing images; InvalidAMIID.NotFound: The image id '[ami-0abc1234]' does not exist
```

This pull request changes the error handling to avoid these [expected errors](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html#api-error-codes-table-client). It will emit issues instead.