### PR TITLE
Add new rule: aws_s3_bucket_invalid_acl

### DIFF
--- a/rules/awsrules/aws_s3_bucket_invalid_acl.go
+++ b/rules/awsrules/aws_s3_bucket_invalid_acl.go
@@ -1,0 +1,76 @@
+package awsrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+// AwsS3BucketInvalidAclRule checks whether "aws_s3_bucket" has invalid ACL setting.
+type AwsS3BucketInvalidAclRule struct {
+	resourceType  string
+	attributeName string
+	aclTypes      map[string]bool
+}
+
+// NewAwsS3BucketInvalidAclRule returns new rule with default attributes
+func NewAwsS3BucketInvalidAclRule() *AwsS3BucketInvalidAclRule {
+	return &AwsS3BucketInvalidAclRule{
+		resourceType:  "aws_s3_bucket",
+		attributeName: "acl",
+		aclTypes: map[string]bool{
+			"private":                   true,
+			"public-read":               true,
+			"public-read-write":         true,
+			"aws-exec-read":             true,
+			"authenticated-read":        true,
+			"bucket-owner-read":         true,
+			"bucket-owner-full-control": true,
+			"log-delivery-write":        true,
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsS3BucketInvalidAclRule) Name() string {
+	return "aws_s3_bucket_invalid_acl"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsS3BucketInvalidAclRule) Enabled() bool {
+	return true
+}
+
+// Type returns the rule severity
+func (r *AwsS3BucketInvalidAclRule) Type() string {
+	return issue.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsS3BucketInvalidAclRule) Link() string {
+	return ""
+}
+
+// Check checks whether "aws_s3_bucket" has invalid ACL type.
+func (r *AwsS3BucketInvalidAclRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var acl string
+		err := runner.EvaluateExpr(attribute.Expr, &acl)
+
+		return runner.EnsureNoError(err, func() error {
+			if !r.aclTypes[acl] {
+				runner.EmitIssue(
+					r,
+					fmt.Sprintf("\"%s\" is invalid canned ACL type.", acl),
+					attribute.Expr.Range(),
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/rules/awsrules/aws_s3_bucket_invalid_acl.go
+++ b/rules/awsrules/aws_s3_bucket_invalid_acl.go
@@ -9,16 +9,16 @@ import (
 	"github.com/wata727/tflint/tflint"
 )
 
-// AwsS3BucketInvalidAclRule checks whether "aws_s3_bucket" has invalid ACL setting.
-type AwsS3BucketInvalidAclRule struct {
+// AwsS3BucketInvalidACLRule checks whether "aws_s3_bucket" has invalid ACL setting.
+type AwsS3BucketInvalidACLRule struct {
 	resourceType  string
 	attributeName string
 	aclTypes      map[string]bool
 }
 
-// NewAwsS3BucketInvalidAclRule returns new rule with default attributes
-func NewAwsS3BucketInvalidAclRule() *AwsS3BucketInvalidAclRule {
-	return &AwsS3BucketInvalidAclRule{
+// NewAwsS3BucketInvalidACLRule returns new rule with default attributes
+func NewAwsS3BucketInvalidACLRule() *AwsS3BucketInvalidACLRule {
+	return &AwsS3BucketInvalidACLRule{
 		resourceType:  "aws_s3_bucket",
 		attributeName: "acl",
 		aclTypes: map[string]bool{
@@ -35,27 +35,27 @@ func NewAwsS3BucketInvalidAclRule() *AwsS3BucketInvalidAclRule {
 }
 
 // Name returns the rule name
-func (r *AwsS3BucketInvalidAclRule) Name() string {
+func (r *AwsS3BucketInvalidACLRule) Name() string {
 	return "aws_s3_bucket_invalid_acl"
 }
 
 // Enabled returns whether the rule is enabled by default
-func (r *AwsS3BucketInvalidAclRule) Enabled() bool {
+func (r *AwsS3BucketInvalidACLRule) Enabled() bool {
 	return true
 }
 
 // Type returns the rule severity
-func (r *AwsS3BucketInvalidAclRule) Type() string {
+func (r *AwsS3BucketInvalidACLRule) Type() string {
 	return issue.ERROR
 }
 
 // Link returns the rule reference link
-func (r *AwsS3BucketInvalidAclRule) Link() string {
+func (r *AwsS3BucketInvalidACLRule) Link() string {
 	return ""
 }
 
 // Check checks whether "aws_s3_bucket" has invalid ACL type.
-func (r *AwsS3BucketInvalidAclRule) Check(runner *tflint.Runner) error {
+func (r *AwsS3BucketInvalidACLRule) Check(runner *tflint.Runner) error {
 	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
 
 	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {

--- a/rules/awsrules/aws_s3_bucket_invalid_acl_test.go
+++ b/rules/awsrules/aws_s3_bucket_invalid_acl_test.go
@@ -1,0 +1,92 @@
+package awsrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_AwsS3BucketInvalidAcl(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected issue.Issues
+	}{
+		{
+			Name: "no-access is invalid",
+			Content: `
+resource "aws_s3_bucket" "bucket" {
+		acl = "no-access"
+}
+`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "aws_s3_bucket_invalid_acl",
+					Type:     "ERROR",
+					Message:  "\"no-access\" is invalid canned ACL type.",
+					Line:     3,
+					File:     "resource.tf",
+				},
+			},
+		},
+		{
+			Name: "public-read is valid",
+			Content: `
+resource "aws_s3_bucket" "bucket" {
+		acl = "public-read"
+}
+`,
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "AwsS3BucketInvalidAcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(".")
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		rule := NewAwsS3BucketInvalidAclRule()
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/awsrules/aws_s3_bucket_invalid_acl_test.go
+++ b/rules/awsrules/aws_s3_bucket_invalid_acl_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/wata727/tflint/tflint"
 )
 
-func Test_AwsS3BucketInvalidAcl(t *testing.T) {
+func Test_AwsS3BucketInvalidACL(t *testing.T) {
 	cases := []struct {
 		Name     string
 		Content  string
@@ -47,7 +47,7 @@ resource "aws_s3_bucket" "bucket" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsS3BucketInvalidAcl")
+	dir, err := ioutil.TempDir("", "AwsS3BucketInvalidACL")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ resource "aws_s3_bucket" "bucket" {
 		}
 
 		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		rule := NewAwsS3BucketInvalidAclRule()
+		rule := NewAwsS3BucketInvalidACLRule()
 
 		if err = rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -31,7 +31,7 @@ var DefaultRules = []Rule{
 	awsrules.NewAwsLaunchConfigurationInvalidTypeRule(),
 	awsrules.NewAwsRouteNotSpecifiedTargetRule(),
 	awsrules.NewAwsRouteSpecifiedMultipleTargetsRule(),
-	awsrules.NewAwsS3BucketInvalidAclRule(),
+	awsrules.NewAwsS3BucketInvalidACLRule(),
 	terraformrules.NewTerraformModulePinnedSourceRule(),
 }
 

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -31,6 +31,7 @@ var DefaultRules = []Rule{
 	awsrules.NewAwsLaunchConfigurationInvalidTypeRule(),
 	awsrules.NewAwsRouteNotSpecifiedTargetRule(),
 	awsrules.NewAwsRouteSpecifiedMultipleTargetsRule(),
+	awsrules.NewAwsS3BucketInvalidAclRule(),
 	terraformrules.NewTerraformModulePinnedSourceRule(),
 }
 


### PR DESCRIPTION
Add a new rule to check if the `acl` value specified for an `aws_s3_bucket` matches one of the [canned ACL types](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl).