### PR TITLE
Disable module inspection by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Application Options:
       --ignore-rule=RULE1,RULE2...          Ignore rule names
       --var-file=FILE1,FILE2...             Terraform variable file names
       --var='foo=bar'                       Set a Terraform variable
+      --module                              Inspect modules
       --deep                                Enable deep check mode
       --aws-access-key=ACCESS_KEY           AWS access key used in deep check mode
       --aws-secret-key=SECRET_KEY           AWS secret key used in deep check mode
@@ -120,6 +121,7 @@ The config file is written in [HCL](https://github.com/hashicorp/hcl), and you c
 
 ```hcl
 config {
+  module = true
   deep_check = true
   force = false
 
@@ -264,14 +266,14 @@ module "aws_instance" {
 ```
 
 ```
-$ tflint
+$ tflint --module
 aws_instance/main.tf
         ERROR:6 "t1.2xlarge" is invalid instance type. (aws_instance_invalid_type)
 
 Result: 1 issues  (1 errors , 0 warnings , 0 notices)
 ```
 
-TFLint loads modules in the same way as Terraform. So note that you need to run `terraform init` first.
+Module inspection is disabled by default. Inspection is enabled by running with the `--module` option. Note that you need to run `terraform init` first because of TFLint loads modules in the same way as Terraform. 
 
 You can use the `--ignore-module` option if you want to skip inspection for a particular module. Note that you need to pass module sources rather than module ids for backward compatibility.
 

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -91,7 +91,7 @@ func (cli *CLI) Run(args []string) int {
 
 	// Load Terraform's configurations
 	if !cli.testMode {
-		cli.loader, err = tflint.NewLoader()
+		cli.loader, err = tflint.NewLoader(cfg)
 		if err != nil {
 			cli.printError(fmt.Errorf("Failed to prepare loading: %s", err))
 			return ExitCodeError

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -17,6 +17,7 @@ type Options struct {
 	IgnoreRule   string   `long:"ignore-rule" description:"Ignore rule names" value-name:"RULE1,RULE2..."`
 	Varfile      string   `long:"var-file" description:"Terraform variable file names" value-name:"FILE1,FILE2..."`
 	Variables    []string `long:"var" description:"Set a Terraform variable" value-name:"'foo=bar'"`
+	Module       bool     `long:"module" description:"Inspect modules"`
 	Deep         bool     `long:"deep" description:"Enable deep check mode"`
 	AwsAccessKey string   `long:"aws-access-key" description:"AWS access key used in deep check mode" value-name:"ACCESS_KEY"`
 	AwsSecretKey string   `long:"aws-secret-key" description:"AWS secret key used in deep check mode" value-name:"SECRET_KEY"`
@@ -50,6 +51,7 @@ func (opts *Options) toConfig() *tflint.Config {
 	}
 
 	log.Printf("[DEBUG] CLI Options")
+	log.Printf("[DEBUG]   Module: %t", opts.Module)
 	log.Printf("[DEBUG]   DeepCheck: %t", opts.Deep)
 	log.Printf("[DEBUG]   Force: %t", opts.Force)
 	log.Printf("[DEBUG]   IgnoreModule: %#v", ignoreModule)
@@ -58,6 +60,7 @@ func (opts *Options) toConfig() *tflint.Config {
 	log.Printf("[DEBUG]   Variables: %#v", opts.Variables)
 
 	return &tflint.Config{
+		Module:    opts.Module,
 		DeepCheck: opts.Deep,
 		Force:     opts.Force,
 		AwsCredentials: client.AwsCredentials{

--- a/cmd/option_test.go
+++ b/cmd/option_test.go
@@ -22,9 +22,25 @@ func Test_toConfig(t *testing.T) {
 			Expected: tflint.EmptyConfig(),
 		},
 		{
+			Name:    "--module",
+			Command: "./tflint --module",
+			Expected: &tflint.Config{
+				Module:         true,
+				DeepCheck:      false,
+				Force:          false,
+				AwsCredentials: client.AwsCredentials{},
+				IgnoreModule:   map[string]bool{},
+				IgnoreRule:     map[string]bool{},
+				Varfile:        []string{},
+				Variables:      []string{},
+				Rules:          map[string]*tflint.RuleConfig{},
+			},
+		},
+		{
 			Name:    "--deep",
 			Command: "./tflint --deep",
 			Expected: &tflint.Config{
+				Module:         false,
 				DeepCheck:      true,
 				Force:          false,
 				AwsCredentials: client.AwsCredentials{},
@@ -39,6 +55,7 @@ func Test_toConfig(t *testing.T) {
 			Name:    "--force",
 			Command: "./tflint --force",
 			Expected: &tflint.Config{
+				Module:         false,
 				DeepCheck:      false,
 				Force:          true,
 				AwsCredentials: client.AwsCredentials{},
@@ -53,6 +70,7 @@ func Test_toConfig(t *testing.T) {
 			Name:    "AWS static credentials",
 			Command: "./tflint --aws-access-key AWS_ACCESS_KEY_ID --aws-secret-key AWS_SECRET_ACCESS_KEY --aws-region us-east-1",
 			Expected: &tflint.Config{
+				Module:    false,
 				DeepCheck: false,
 				Force:     false,
 				AwsCredentials: client.AwsCredentials{
@@ -71,6 +89,7 @@ func Test_toConfig(t *testing.T) {
 			Name:    "AWS shared credentials",
 			Command: "./tflint --aws-profile production --aws-region us-east-1",
 			Expected: &tflint.Config{
+				Module:    false,
 				DeepCheck: false,
 				Force:     false,
 				AwsCredentials: client.AwsCredentials{
@@ -88,6 +107,7 @@ func Test_toConfig(t *testing.T) {
 			Name:    "--ignore-module",
 			Command: "./tflint --ignore-module module1,module2",
 			Expected: &tflint.Config{
+				Module:         false,
 				DeepCheck:      false,
 				Force:          false,
 				AwsCredentials: client.AwsCredentials{},
@@ -102,6 +122,7 @@ func Test_toConfig(t *testing.T) {
 			Name:    "--ignore-rule",
 			Command: "./tflint --ignore-rule rule1,rule2",
 			Expected: &tflint.Config{
+				Module:         false,
 				DeepCheck:      false,
 				Force:          false,
 				AwsCredentials: client.AwsCredentials{},
@@ -116,6 +137,7 @@ func Test_toConfig(t *testing.T) {
 			Name:    "--var-file",
 			Command: "./tflint --var-file example1.tfvars,example2.tfvars",
 			Expected: &tflint.Config{
+				Module:         false,
 				DeepCheck:      false,
 				Force:          false,
 				AwsCredentials: client.AwsCredentials{},
@@ -130,6 +152,7 @@ func Test_toConfig(t *testing.T) {
 			Name:    "--var",
 			Command: "./tflint --var foo=bar --var bar=baz",
 			Expected: &tflint.Config{
+				Module:         false,
 				DeepCheck:      false,
 				Force:          false,
 				AwsCredentials: client.AwsCredentials{},

--- a/integration/without_module_init/module.tf
+++ b/integration/without_module_init/module.tf
@@ -1,0 +1,13 @@
+variable "unknown" {}
+
+variable "instance_type" {
+  default = "t1.2xlarge"
+}
+
+// terraform init did not run
+module "instances" {
+  source = "./module"
+
+  unknown = "${var.unknown}"
+  instance_type = "${var.instance_type}"
+}

--- a/integration/without_module_init/result.json
+++ b/integration/without_module_init/result.json
@@ -1,0 +1,11 @@
+[
+    {
+      "detector": "aws_instance_invalid_type",
+      "type": "ERROR",
+      "message": "\"t1.2xlarge\" is invalid instance type.",
+      "line": 2,
+      "file": "template.tf",
+      "link": ""
+    }
+  ]
+  

--- a/integration/without_module_init/template.tf
+++ b/integration/without_module_init/template.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "foo" {
+  instance_type = "t1.2xlarge"
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -47,8 +47,13 @@ func TestIntegration(t *testing.T) {
 		},
 		{
 			Name:    "module",
-			Command: "./tflint --format json",
+			Command: "./tflint --format json --module",
 			Dir:     "module",
+		},
+		{
+			Name:    "without_module_init",
+			Command: "./tflint --format json",
+			Dir:     "without_module_init",
 		},
 		{
 			Name:    "arguments",

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -17,6 +17,7 @@ var fallbackConfigFile = "~/.tflint.hcl"
 
 type rawConfig struct {
 	Config *struct {
+		Module           *bool              `hcl:"module"`
 		DeepCheck        *bool              `hcl:"deep_check"`
 		Force            *bool              `hcl:"force"`
 		AwsCredentials   *map[string]string `hcl:"aws_credentials"`
@@ -31,6 +32,7 @@ type rawConfig struct {
 
 // Config describes the behavior of TFLint
 type Config struct {
+	Module         bool
 	DeepCheck      bool
 	Force          bool
 	AwsCredentials client.AwsCredentials
@@ -51,6 +53,7 @@ type RuleConfig struct {
 // It is mainly used for testing
 func EmptyConfig() *Config {
 	return &Config{
+		Module:         false,
 		DeepCheck:      false,
 		Force:          false,
 		AwsCredentials: client.AwsCredentials{},
@@ -106,6 +109,9 @@ func LoadConfig(file string) (*Config, error) {
 func (c *Config) Merge(other *Config) *Config {
 	ret := c.copy()
 
+	if other.Module {
+		ret.Module = true
+	}
 	if other.DeepCheck {
 		ret.DeepCheck = true
 	}
@@ -160,6 +166,7 @@ func (c *Config) copy() *Config {
 	}
 
 	return &Config{
+		Module:         c.Module,
 		DeepCheck:      c.DeepCheck,
 		Force:          c.Force,
 		AwsCredentials: c.AwsCredentials,
@@ -191,6 +198,7 @@ func loadConfigFromFile(file string) (*Config, error) {
 
 	cfg := raw.toConfig()
 	log.Printf("[DEBUG] Config loaded")
+	log.Printf("[DEBUG]   Module: %t", cfg.Module)
 	log.Printf("[DEBUG]   DeepCheck: %t", cfg.DeepCheck)
 	log.Printf("[DEBUG]   Force: %t", cfg.Force)
 	log.Printf("[DEBUG]   IgnoreModule: %#v", cfg.IgnoreModule)
@@ -229,6 +237,9 @@ func (raw *rawConfig) toConfig() *Config {
 	rc := raw.Config
 
 	if rc != nil {
+		if rc.Module != nil {
+			ret.Module = *rc.Module
+		}
 		if rc.DeepCheck != nil {
 			ret.DeepCheck = *rc.DeepCheck
 		}

--- a/tflint/config_test.go
+++ b/tflint/config_test.go
@@ -26,6 +26,7 @@ func Test_LoadConfig(t *testing.T) {
 			Name: "load file",
 			File: filepath.Join(currentDir, "test-fixtures", "config", "config.hcl"),
 			Expected: &Config{
+				Module:    true,
 				DeepCheck: true,
 				Force:     true,
 				AwsCredentials: client.AwsCredentials{
@@ -64,6 +65,7 @@ func Test_LoadConfig(t *testing.T) {
 			File:     filepath.Join(currentDir, "test-fixtures", "config", "not_found.hcl"),
 			Fallback: filepath.Join(currentDir, "test-fixtures", "config", "fallback.hcl"),
 			Expected: &Config{
+				Module:    false,
 				DeepCheck: true,
 				Force:     true,
 				AwsCredentials: client.AwsCredentials{
@@ -162,6 +164,7 @@ func Test_LoadConfig_error(t *testing.T) {
 
 func Test_Merge(t *testing.T) {
 	cfg := &Config{
+		Module:    true,
 		DeepCheck: true,
 		Force:     true,
 		AwsCredentials: client.AwsCredentials{
@@ -218,6 +221,7 @@ func Test_Merge(t *testing.T) {
 		{
 			Name: "override and merge",
 			Base: &Config{
+				Module:    true,
 				DeepCheck: true,
 				Force:     false,
 				AwsCredentials: client.AwsCredentials{
@@ -248,6 +252,7 @@ func Test_Merge(t *testing.T) {
 				},
 			},
 			Other: &Config{
+				Module:    false,
 				DeepCheck: false,
 				Force:     true,
 				AwsCredentials: client.AwsCredentials{
@@ -277,6 +282,7 @@ func Test_Merge(t *testing.T) {
 				},
 			},
 			Expected: &Config{
+				Module:    true,
 				DeepCheck: true, // DeepCheck will not override
 				Force:     true,
 				AwsCredentials: client.AwsCredentials{
@@ -325,6 +331,7 @@ func Test_Merge(t *testing.T) {
 
 func Test_copy(t *testing.T) {
 	cfg := &Config{
+		Module:    true,
 		DeepCheck: true,
 		Force:     true,
 		AwsCredentials: client.AwsCredentials{
@@ -358,6 +365,12 @@ func Test_copy(t *testing.T) {
 		Name       string
 		SideEffect func(*Config)
 	}{
+		{
+			Name: "Module",
+			SideEffect: func(c *Config) {
+				c.Module = false
+			},
+		},
 		{
 			Name: "DeepCheck",
 			SideEffect: func(c *Config) {

--- a/tflint/loader_test.go
+++ b/tflint/loader_test.go
@@ -27,7 +27,7 @@ func Test_LoadConfig_v0_10_5(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader()
+	loader, err := NewLoader(moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -57,7 +57,7 @@ func Test_LoadConfig_v0_10_6(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader()
+	loader, err := NewLoader(moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -87,7 +87,7 @@ func Test_LoadConfig_v0_10_7(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader()
+	loader, err := NewLoader(moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -117,7 +117,7 @@ func Test_LoadConfig_v0_11_0(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader()
+	loader, err := NewLoader(moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -191,7 +191,7 @@ func Test_LoadConfig_v0_12_0(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader()
+	loader, err := NewLoader(moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -269,7 +269,7 @@ func Test_LoadConfig_moduleNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader()
+	loader, err := NewLoader(moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -281,6 +281,32 @@ func Test_LoadConfig_moduleNotFound(t *testing.T) {
 	expected := "module.tf:1,1-22: `ec2_instance` module is not found. Did you run `terraform init`?; "
 	if err.Error() != expected {
 		t.Fatalf("Expected error is `%s`, but get `%s`", expected, err.Error())
+	}
+}
+
+func Test_LoadConfig_disableModules(t *testing.T) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "before_terraform_init"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loader, err := NewLoader(EmptyConfig())
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+	config, err := loader.LoadConfig(".")
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+
+	if len(config.Children) != 0 {
+		t.Fatalf("Root module has children unexpectedly: %#v", config.Children)
 	}
 }
 
@@ -296,7 +322,7 @@ func Test_LoadConfig_invalidConfiguration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader()
+	loader, err := NewLoader(EmptyConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -322,7 +348,7 @@ func Test_LoadAnnotations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	loader, err := NewLoader()
+	loader, err := NewLoader(EmptyConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -380,7 +406,7 @@ func Test_LoadValuesFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	loader, err := NewLoader()
+	loader, err := NewLoader(EmptyConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -438,7 +464,7 @@ func Test_LoadValuesFiles_invalidValuesFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	loader, err := NewLoader()
+	loader, err := NewLoader(EmptyConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -966,7 +966,7 @@ func Test_NewModuleRunners_noModules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader()
+	loader, err := NewLoader(moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -998,7 +998,7 @@ func Test_NewModuleRunners_nestedModules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader()
+	loader, err := NewLoader(moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -1126,7 +1126,7 @@ func Test_NewModuleRunners_ignoreModules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader()
+	loader, err := NewLoader(moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -1161,7 +1161,7 @@ func Test_NewModuleRunners_withInvalidExpression(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader()
+	loader, err := NewLoader(moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -1207,7 +1207,7 @@ func Test_NewModuleRunners_withNotAllowedAttributes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader()
+	loader, err := NewLoader(moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}

--- a/tflint/test-fixtures/config/config.hcl
+++ b/tflint/test-fixtures/config/config.hcl
@@ -1,4 +1,5 @@
 config {
+  module = true
   deep_check = true
   force = true
 

--- a/tflint/tflint_test.go
+++ b/tflint/tflint_test.go
@@ -59,6 +59,12 @@ func extractAttributeHelper(key string, cfg *configs.Config) (*hcl.Attribute, er
 	return attribute, nil
 }
 
+func moduleConfig() *Config {
+	c := EmptyConfig()
+	c.Module = true
+	return c
+}
+
 func newLine() string {
 	if runtime.GOOS == "windows" {
 		return "\r\n"


### PR DESCRIPTION
Fixes #198, #248 

Disable module inspection by default, as described in #248.

The change allows you to perform an inspection without required additional steps. As before, if you want to do module inspection, perform with the `--module` option:

```
$ tflint --module
```

You can also enable/disable the option from a configuration file as follows:

```hcl
config {
  module = true
}
```