### PR TITLE
Add terraform_documented_variables/outputs rules

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -67,4 +67,8 @@ These rules relate to Terraform itself, not providers.
 
 These rules suggest to better ways.
 
-- [terraform_module_pinned_source](terraform_module_pinned_source.md)
+|Rule|Enabled by default|
+| --- | --- |
+|[terraform_documented_outputs](terraform_documented_outputs.md)||
+|[terraform_documented_variables](terraform_documented_variables.md)||
+|[terraform_module_pinned_source](terraform_module_pinned_source.md)|✔|

--- a/docs/rules/terraform_documented_outputs.md
+++ b/docs/rules/terraform_documented_outputs.md
@@ -1,0 +1,36 @@
+# terraform_documented_outputs
+
+Disallow `output` declarations without description.
+
+## Example
+
+```hcl
+output "no_description" {
+  value = "value"
+}
+
+output "empty_description" {
+  value = "value"
+  description = ""
+}
+
+output "description" {
+  value = "value"
+  description = "This is description"
+}
+```
+
+```
+$ tflint
+outputs.tf
+        NOTICE:1 `no_description` output has no description (terraform_documented_outputs)
+        NOTICE:5 `empty_description` output has no description (terraform_documented_outputs)
+```
+
+## Why
+
+Since `description` is optional value, it is not always necessary to write it. But this rule is useful if you want to force the writing of description. Especially it is useful when combined with [terraform-docs](https://github.com/segmentio/terraform-docs).
+
+## How To Fix
+
+Write a description other than an empty string.

--- a/docs/rules/terraform_documented_variables.md
+++ b/docs/rules/terraform_documented_variables.md
@@ -1,0 +1,36 @@
+# terraform_documented_variables
+
+Disallow `variable` declarations without description.
+
+## Example
+
+```hcl
+variable "no_description" {
+  default = "value"
+}
+
+variable "empty_description" {
+  default = "value"
+  description = ""
+}
+
+variable "description" {
+  default = "value"
+  description = "This is description"
+}
+```
+
+```
+$ tflint
+variables.tf
+        NOTICE:1 `no_description` variable has no description (terraform_documented_variables)
+        NOTICE:5 `empty_description` variable has no description (terraform_documented_variables)
+```
+
+## Why
+
+Since `description` is optional value, it is not always necessary to write it. But this rule is useful if you want to force the writing of description. Especially it is useful when combined with [terraform-docs](https://github.com/segmentio/terraform-docs).
+
+## How To Fix
+
+Write a description other than an empty string.

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -30,6 +30,8 @@ var manualRules = []Rule{
 	awsrules.NewAwsInstancePreviousTypeRule(),
 	awsrules.NewAwsRouteNotSpecifiedTargetRule(),
 	awsrules.NewAwsRouteSpecifiedMultipleTargetsRule(),
+	terraformrules.NewTerraformDocumentedOutputsRule(),
+	terraformrules.NewTerraformDocumentedVariablesRule(),
 	terraformrules.NewTerraformModulePinnedSourceRule(),
 }
 

--- a/rules/terraformrules/terraform_documented_outputs.go
+++ b/rules/terraformrules/terraform_documented_outputs.go
@@ -1,0 +1,55 @@
+package terraformrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/project"
+	"github.com/wata727/tflint/tflint"
+)
+
+// TerraformDocumentedOutputsRule checks whether outputs have descriptions
+type TerraformDocumentedOutputsRule struct{}
+
+// NewTerraformDocumentedOutputsRule returns a new rule
+func NewTerraformDocumentedOutputsRule() *TerraformDocumentedOutputsRule {
+	return &TerraformDocumentedOutputsRule{}
+}
+
+// Name returns the rule name
+func (r *TerraformDocumentedOutputsRule) Name() string {
+	return "terraform_documented_outputs"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformDocumentedOutputsRule) Enabled() bool {
+	return false
+}
+
+// Type returns the rule severity
+func (r *TerraformDocumentedOutputsRule) Type() string {
+	return issue.NOTICE
+}
+
+// Link returns the rule reference link
+func (r *TerraformDocumentedOutputsRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks whether outputs have descriptions
+func (r *TerraformDocumentedOutputsRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	for _, output := range runner.TFConfig.Module.Outputs {
+		if output.Description == "" {
+			runner.EmitIssue(
+				r,
+				fmt.Sprintf("`%s` output has no description", output.Name),
+				output.DeclRange,
+			)
+		}
+	}
+
+	return nil
+}

--- a/rules/terraformrules/terraform_documented_outputs_test.go
+++ b/rules/terraformrules/terraform_documented_outputs_test.go
@@ -1,0 +1,117 @@
+package terraformrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/project"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_TerraformDocumentedOutputsRule(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected issue.Issues
+	}{
+		{
+			Name: "no description",
+			Content: `
+output "endpoint" {
+  value = aws_alb.main.dns_name
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "terraform_documented_outputs",
+					Type:     issue.NOTICE,
+					Message:  "`endpoint` output has no description",
+					Line:     2,
+					File:     "outputs.tf",
+					Link:     project.ReferenceLink("terraform_documented_outputs"),
+				},
+			},
+		},
+		{
+			Name: "empty description",
+			Content: `
+output "endpoint" {
+  value = aws_alb.main.dns_name
+  description = ""
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "terraform_documented_outputs",
+					Type:     issue.NOTICE,
+					Message:  "`endpoint` output has no description",
+					Line:     2,
+					File:     "outputs.tf",
+					Link:     project.ReferenceLink("terraform_documented_outputs"),
+				},
+			},
+		},
+		{
+			Name: "with description",
+			Content: `
+output "endpoint" {
+  value = aws_alb.main.dns_name
+  description = "DNS Endpoint"
+}`,
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "TerraformDocumentedOutputs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/outputs.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(".")
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		rule := NewTerraformDocumentedOutputsRule()
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}

--- a/rules/terraformrules/terraform_documented_variables.go
+++ b/rules/terraformrules/terraform_documented_variables.go
@@ -1,0 +1,55 @@
+package terraformrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/project"
+	"github.com/wata727/tflint/tflint"
+)
+
+// TerraformDocumentedVariablesRule checks whether variables have descriptions
+type TerraformDocumentedVariablesRule struct{}
+
+// NewTerraformDocumentedVariablesRule returns a new rule
+func NewTerraformDocumentedVariablesRule() *TerraformDocumentedVariablesRule {
+	return &TerraformDocumentedVariablesRule{}
+}
+
+// Name returns the rule name
+func (r *TerraformDocumentedVariablesRule) Name() string {
+	return "terraform_documented_variables"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformDocumentedVariablesRule) Enabled() bool {
+	return false
+}
+
+// Type returns the rule severity
+func (r *TerraformDocumentedVariablesRule) Type() string {
+	return issue.NOTICE
+}
+
+// Link returns the rule reference link
+func (r *TerraformDocumentedVariablesRule) Link() string {
+	return project.ReferenceLink(r.Name())
+}
+
+// Check checks whether variables have descriptions
+func (r *TerraformDocumentedVariablesRule) Check(runner *tflint.Runner) error {
+	log.Printf("[INFO] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	for _, variable := range runner.TFConfig.Module.Variables {
+		if variable.Description == "" {
+			runner.EmitIssue(
+				r,
+				fmt.Sprintf("`%s` variable has no description", variable.Name),
+				variable.DeclRange,
+			)
+		}
+	}
+
+	return nil
+}

--- a/rules/terraformrules/terraform_documented_variables_test.go
+++ b/rules/terraformrules/terraform_documented_variables_test.go
@@ -1,0 +1,115 @@
+package terraformrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/hashicorp/terraform/configs/configload"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/issue"
+	"github.com/wata727/tflint/project"
+	"github.com/wata727/tflint/tflint"
+)
+
+func Test_TerraformDocumentedVariablesRule(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected issue.Issues
+	}{
+		{
+			Name: "no description",
+			Content: `
+variable "no_description" {
+  default = "default"
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "terraform_documented_variables",
+					Type:     issue.NOTICE,
+					Message:  "`no_description` variable has no description",
+					Line:     2,
+					File:     "variables.tf",
+					Link:     project.ReferenceLink("terraform_documented_variables"),
+				},
+			},
+		},
+		{
+			Name: "empty description",
+			Content: `
+variable "empty_description" {
+  description = ""
+}`,
+			Expected: []*issue.Issue{
+				{
+					Detector: "terraform_documented_variables",
+					Type:     issue.NOTICE,
+					Message:  "`empty_description` variable has no description",
+					Line:     2,
+					File:     "variables.tf",
+					Link:     project.ReferenceLink("terraform_documented_variables"),
+				},
+			},
+		},
+		{
+			Name: "with description",
+			Content: `
+variable "with_description" {
+  description = "This is description"
+}`,
+			Expected: []*issue.Issue{},
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "TerraformDocumentedVariables")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range cases {
+		loader, err := configload.NewLoader(&configload.Config{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = ioutil.WriteFile(dir+"/variables.tf", []byte(tc.Content), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mod, diags := loader.Parser().LoadConfigDir(".")
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
+		if tfdiags.HasErrors() {
+			t.Fatal(tfdiags)
+		}
+
+		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		rule := NewTerraformDocumentedVariablesRule()
+
+		if err = rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if !cmp.Equal(tc.Expected, runner.Issues) {
+			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues))
+		}
+	}
+}


### PR DESCRIPTION
Fixes #174 

These rules are disabled by default, so you need to write `.tflint.hcl` like the following if you'd like to enable these:

```hcl
rule "terraform_documented_outputs" {
  enabled = true
}

rule "terraform_documented_variables" {
  enabled = true
}
```

