### PR TITLE
Allow settings shared credentials file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Application Options:
       --aws-access-key=ACCESS_KEY           AWS access key used in deep check mode
       --aws-secret-key=SECRET_KEY           AWS secret key used in deep check mode
       --aws-profile=PROFILE                 AWS shared credential profile name used in deep check mode
+      --aws-creds-file=FILE                 AWS shared credentials file path used in deep checking
       --aws-region=REGION                   AWS region used in deep check mode
       --force                               Return zero exit status even if issues found
   -q, --quiet                               Do not output any message when no issues are found (default format only)

--- a/client/aws_test.go
+++ b/client/aws_test.go
@@ -15,6 +15,7 @@ func Test_newAwsSession(t *testing.T) {
 		Region      *string
 	}
 	path, _ := homedir.Expand("~/.aws/credentials")
+	credPath, _ := homedir.Expand("~/.aws/creds")
 
 	cases := []struct {
 		Name     string
@@ -44,10 +45,25 @@ func Test_newAwsSession(t *testing.T) {
 				Region:      aws.String("us-east-1"),
 			},
 		},
+		{
+			Name: "shared credentials path",
+			Creds: AwsCredentials{
+				Profile:   "default",
+				CredsFile: "~/.aws/creds",
+				Region:    "us-east-1",
+			},
+			Expected: Result{
+				Credentials: credentials.NewSharedCredentials(credPath, "default"),
+				Region:      aws.String("us-east-1"),
+			},
+		},
 	}
 
 	for _, tc := range cases {
-		s := newAwsSession(tc.Creds)
+		s, err := newAwsSession(tc.Creds)
+		if err != nil {
+			t.Fatalf("Failed `%s` test: Unexpected error occurred: %s", tc.Name, err)
+		}
 		if !reflect.DeepEqual(tc.Expected.Credentials, s.Config.Credentials) {
 			t.Fatalf("Failed `%s` test: expected credentials are `%#v`, but get `%#v`", tc.Name, tc.Expected.Credentials, s.Config.Credentials)
 		}

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -121,7 +121,11 @@ func (cli *CLI) Run(args []string) int {
 	variables = append(variables, cliVars)
 
 	// Check configurations via Runner
-	runner := tflint.NewRunner(cfg, annotations, configs, variables...)
+	runner, err := tflint.NewRunner(cfg, annotations, configs, variables...)
+	if err != nil {
+		cli.printError(fmt.Errorf("Failed to initialize a runner: %s", err))
+		return ExitCodeError
+	}
 	runners, err := tflint.NewModuleRunners(runner)
 	if err != nil {
 		cli.printError(fmt.Errorf("Failed to prepare rule checking: %s", err))

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -22,6 +22,7 @@ type Options struct {
 	AwsAccessKey string   `long:"aws-access-key" description:"AWS access key used in deep check mode" value-name:"ACCESS_KEY"`
 	AwsSecretKey string   `long:"aws-secret-key" description:"AWS secret key used in deep check mode" value-name:"SECRET_KEY"`
 	AwsProfile   string   `long:"aws-profile" description:"AWS shared credential profile name used in deep check mode" value-name:"PROFILE"`
+	AwsCredsFile string   `long:"aws-creds-file" description:"AWS shared credentials file path used in deep checking" value-name:"FILE"`
 	AwsRegion    string   `long:"aws-region" description:"AWS region used in deep check mode" value-name:"REGION"`
 	Force        bool     `long:"force" description:"Return zero exit status even if issues found"`
 	Quiet        bool     `short:"q" long:"quiet" description:"Do not output any message when no issues are found (default format only)"`
@@ -67,6 +68,7 @@ func (opts *Options) toConfig() *tflint.Config {
 			AccessKey: opts.AwsAccessKey,
 			SecretKey: opts.AwsSecretKey,
 			Profile:   opts.AwsProfile,
+			CredsFile: opts.AwsCredsFile,
 			Region:    opts.AwsRegion,
 		},
 		IgnoreModule: ignoreModule,

--- a/cmd/option_test.go
+++ b/cmd/option_test.go
@@ -104,6 +104,25 @@ func Test_toConfig(t *testing.T) {
 			},
 		},
 		{
+			Name:    "AWS shared credentials in another file",
+			Command: "./tflint --aws-creds-file ~/.aws/myapp --aws-profile production --aws-region us-east-1",
+			Expected: &tflint.Config{
+				Module:    false,
+				DeepCheck: false,
+				Force:     false,
+				AwsCredentials: client.AwsCredentials{
+					CredsFile: "~/.aws/myapp",
+					Profile:   "production",
+					Region:    "us-east-1",
+				},
+				IgnoreModule: map[string]bool{},
+				IgnoreRule:   map[string]bool{},
+				Varfile:      []string{},
+				Variables:    []string{},
+				Rules:        map[string]*tflint.RuleConfig{},
+			},
+		},
+		{
 			Name:    "--ignore-module",
 			Command: "./tflint --ignore-module module1,module2",
 			Expected: &tflint.Config{

--- a/docs/guides/config.md
+++ b/docs/guides/config.md
@@ -63,7 +63,7 @@ Return zero exit status even if issues found. TFLint returns non-zero exit statu
 
 ## `aws_credentials`
 
-CLI flag: `--aws-access-key`, `--aws-secret-key`, `--aws-profile` and `--aws-region`
+CLI flag: `--aws-access-key`, `--aws-secret-key`, `--aws-profile`, `--aws-creds-file` and `--aws-region`
 
 Configure AWS service crendetials. See [Credentials](credentials.md).
 

--- a/docs/guides/credentials.md
+++ b/docs/guides/credentials.md
@@ -29,17 +29,18 @@ config {
 
 ## Shared Credentials
 
-If you have [shared credentials](https://aws.amazon.com/jp/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/), you can pass the profile name. However, only `~/.aws/credentials` is supported as a credential location.
+If you have [shared credentials](https://aws.amazon.com/jp/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/), you can pass a profile name and credentials file path. If omitted, these will be `default` and `~/.aws/credentials`.
 
 ```
-$ tflint --aws-profile AWS_PROFILE --aws-region us-east-1
+$ tflint --aws-profile AWS_PROFILE --aws-region us-east-1 --aws-creds-file ~/.aws/myapp
 ```
 
 ```hcl
 config {
   aws_credentials = {
-    profile = "AWS_PROFILE"
-    region  = "us-east-1"
+    profile                 = "AWS_PROFILE"
+    region                  = "us-east-1"
+    shared_credentials_file = "~/.aws/myapp"
   }
 }
 ```

--- a/rules/awsrules/aws_alb_invalid_security_group_test.go
+++ b/rules/awsrules/aws_alb_invalid_security_group_test.go
@@ -155,7 +155,10 @@ resource "aws_alb" "balancer" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsALBInvalidSecurityGroupRule()
 
 		mock := client.NewMockEC2API(ctrl)
@@ -239,7 +242,10 @@ resource "aws_alb" "balancer" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsALBInvalidSecurityGroupRule()
 
 		mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_alb_invalid_subnet_test.go
+++ b/rules/awsrules/aws_alb_invalid_subnet_test.go
@@ -139,7 +139,10 @@ resource "aws_alb" "balancer" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsALBInvalidSubnetRule()
 
 		mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_db_instance_default_parameter_group_test.go
+++ b/rules/awsrules/aws_db_instance_default_parameter_group_test.go
@@ -84,7 +84,10 @@ resource "aws_db_instance" "db" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDBInstanceDefaultParameterGroupRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/aws_db_instance_invalid_db_subnet_group_test.go
+++ b/rules/awsrules/aws_db_instance_invalid_db_subnet_group_test.go
@@ -109,7 +109,10 @@ resource "aws_db_instance" "mysql" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDBInstanceInvalidDBSubnetGroupRule()
 
 		mock := client.NewMockRDSAPI(ctrl)

--- a/rules/awsrules/aws_db_instance_invalid_option_group_test.go
+++ b/rules/awsrules/aws_db_instance_invalid_option_group_test.go
@@ -109,7 +109,10 @@ resource "aws_db_instance" "mysql" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDBInstanceInvalidOptionGroupRule()
 
 		mock := client.NewMockRDSAPI(ctrl)

--- a/rules/awsrules/aws_db_instance_invalid_parameter_group_test.go
+++ b/rules/awsrules/aws_db_instance_invalid_parameter_group_test.go
@@ -109,7 +109,10 @@ resource "aws_db_instance" "mysql" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDBInstanceInvalidParameterGroupRule()
 
 		mock := client.NewMockRDSAPI(ctrl)

--- a/rules/awsrules/aws_db_instance_invalid_type_test.go
+++ b/rules/awsrules/aws_db_instance_invalid_type_test.go
@@ -83,7 +83,10 @@ resource "aws_db_instance" "mysql" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDBInstanceInvalidTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/aws_db_instance_invalid_vpc_security_group_test.go
+++ b/rules/awsrules/aws_db_instance_invalid_vpc_security_group_test.go
@@ -154,7 +154,10 @@ resource "aws_db_instance" "mysql" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDBInstanceInvalidVPCSecurityGroupRule()
 
 		mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_db_instance_previous_type_test.go
+++ b/rules/awsrules/aws_db_instance_previous_type_test.go
@@ -84,7 +84,10 @@ resource "aws_db_instance" "mysql" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDBInstancePreviousTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/aws_db_instance_readable_password_test.go
+++ b/rules/awsrules/aws_db_instance_readable_password_test.go
@@ -157,7 +157,10 @@ resource "aws_db_instance" "mysql" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDBInstanceReadablePasswordRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/aws_elasticache_cluster_default_parameter_group_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_default_parameter_group_test.go
@@ -84,7 +84,10 @@ resource "aws_elasticache_cluster" "cache" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsElastiCacheClusterDefaultParameterGroupRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/aws_elasticache_cluster_invalid_parameter_group_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_invalid_parameter_group_test.go
@@ -109,7 +109,10 @@ resource "aws_elasticache_cluster" "redis" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsElastiCacheClusterInvalidParameterGroupRule()
 
 		mock := client.NewMockElastiCacheAPI(ctrl)

--- a/rules/awsrules/aws_elasticache_cluster_invalid_security_group_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_invalid_security_group_test.go
@@ -154,7 +154,10 @@ resource "aws_elasticache_cluster" "redis" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsElastiCacheClusterInvalidSecurityGroupRule()
 
 		mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_elasticache_cluster_invalid_subnet_group_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_invalid_subnet_group_test.go
@@ -109,7 +109,10 @@ resource "aws_elasticache_cluster" "redis" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsElastiCacheClusterInvalidSubnetGroupRule()
 
 		mock := client.NewMockElastiCacheAPI(ctrl)

--- a/rules/awsrules/aws_elasticache_cluster_invalid_type_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_invalid_type_test.go
@@ -83,7 +83,10 @@ resource "aws_elasticache_cluster" "redis" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsElastiCacheClusterInvalidTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/aws_elasticache_cluster_previous_type_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_previous_type_test.go
@@ -84,7 +84,10 @@ resource "aws_elasticache_cluster" "redis" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsElastiCacheClusterPreviousTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/aws_elb_invalid_instance_test.go
+++ b/rules/awsrules/aws_elb_invalid_instance_test.go
@@ -154,7 +154,10 @@ resource "aws_elb" "balancer" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsELBInvalidInstanceRule()
 
 		mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_elb_invalid_security_group_test.go
+++ b/rules/awsrules/aws_elb_invalid_security_group_test.go
@@ -154,7 +154,10 @@ resource "aws_elb" "balancer" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsELBInvalidSecurityGroupRule()
 
 		mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_elb_invalid_subnet_test.go
+++ b/rules/awsrules/aws_elb_invalid_subnet_test.go
@@ -154,7 +154,10 @@ resource "aws_elb" "balancer" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsELBInvalidSubnetRule()
 
 		mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_instance_default_standard_volume_test.go
+++ b/rules/awsrules/aws_instance_default_standard_volume_test.go
@@ -237,7 +237,10 @@ resource "aws_instance" "web" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsInstanceDefaultStandardVolumeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/aws_instance_invalid_ami_test.go
+++ b/rules/awsrules/aws_instance_invalid_ami_test.go
@@ -63,7 +63,10 @@ resource "aws_instance" "invalid" {
 		t.Fatal(tfdiags)
 	}
 
-	runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+	runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	rule := NewAwsInstanceInvalidAMIRule()
 
 	ec2mock := client.NewMockEC2API(ctrl)
@@ -136,7 +139,10 @@ resource "aws_instance" "valid" {
 		t.Fatal(tfdiags)
 	}
 
-	runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+	runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	rule := NewAwsInstanceInvalidAMIRule()
 
 	ec2mock := client.NewMockEC2API(ctrl)
@@ -245,7 +251,10 @@ resource "aws_instance" "valid" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsInstanceInvalidAMIRule()
 
 		ec2mock := client.NewMockEC2API(ctrl)
@@ -398,7 +407,10 @@ resource "aws_instance" "unavailable" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsInstanceInvalidAMIRule()
 
 		ec2mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_instance_invalid_iam_profile_test.go
+++ b/rules/awsrules/aws_instance_invalid_iam_profile_test.go
@@ -109,7 +109,10 @@ resource "aws_instance" "web" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsInstanceInvalidIAMProfileRule()
 
 		mock := client.NewMockIAMAPI(ctrl)

--- a/rules/awsrules/aws_instance_invalid_key_name_test.go
+++ b/rules/awsrules/aws_instance_invalid_key_name_test.go
@@ -106,7 +106,10 @@ resource "aws_instance" "web" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsInstanceInvalidKeyNameRule()
 
 		mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_instance_invalid_subnet_test.go
+++ b/rules/awsrules/aws_instance_invalid_subnet_test.go
@@ -106,7 +106,10 @@ resource "aws_instance" "web" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsInstanceInvalidSubnetRule()
 
 		mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_instance_invalid_vpc_security_group_test.go
+++ b/rules/awsrules/aws_instance_invalid_vpc_security_group_test.go
@@ -154,7 +154,10 @@ resource "aws_instance" "web" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsInstanceInvalidVPCSecurityGroupRule()
 
 		mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_instance_previous_type_test.go
+++ b/rules/awsrules/aws_instance_previous_type_test.go
@@ -84,7 +84,10 @@ resource "aws_instance" "web" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsInstancePreviousTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/aws_launch_configuration_invalid_iam_profile_test.go
+++ b/rules/awsrules/aws_launch_configuration_invalid_iam_profile_test.go
@@ -109,7 +109,10 @@ resource "aws_launch_configuration" "web" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsLaunchConfigurationInvalidIAMProfileRule()
 
 		mock := client.NewMockIAMAPI(ctrl)

--- a/rules/awsrules/aws_launch_configuration_invalid_image_id_test.go
+++ b/rules/awsrules/aws_launch_configuration_invalid_image_id_test.go
@@ -63,7 +63,10 @@ resource "aws_launch_configuration" "invalid" {
 		t.Fatal(tfdiags)
 	}
 
-	runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+	runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	rule := NewAwsLaunchConfigurationInvalidImageIDRule()
 
 	ec2mock := client.NewMockEC2API(ctrl)
@@ -136,7 +139,10 @@ resource "aws_launch_configuration" "valid" {
 		t.Fatal(tfdiags)
 	}
 
-	runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+	runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	rule := NewAwsLaunchConfigurationInvalidImageIDRule()
 
 	ec2mock := client.NewMockEC2API(ctrl)
@@ -245,7 +251,10 @@ resource "aws_launch_configuration" "valid" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsLaunchConfigurationInvalidImageIDRule()
 
 		ec2mock := client.NewMockEC2API(ctrl)
@@ -398,7 +407,10 @@ resource "aws_launch_configuration" "unavailable" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsLaunchConfigurationInvalidImageIDRule()
 
 		ec2mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_route_invalid_egress_only_gateway_test.go
+++ b/rules/awsrules/aws_route_invalid_egress_only_gateway_test.go
@@ -106,7 +106,10 @@ resource "aws_route" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsRouteInvalidEgressOnlyGatewayRule()
 
 		mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_route_invalid_gateway_test.go
+++ b/rules/awsrules/aws_route_invalid_gateway_test.go
@@ -106,7 +106,10 @@ resource "aws_route" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsRouteInvalidGatewayRule()
 
 		mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_route_invalid_instance_test.go
+++ b/rules/awsrules/aws_route_invalid_instance_test.go
@@ -106,7 +106,10 @@ resource "aws_route" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsRouteInvalidInstanceRule()
 
 		mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_route_invalid_nat_gateway_test.go
+++ b/rules/awsrules/aws_route_invalid_nat_gateway_test.go
@@ -106,7 +106,10 @@ resource "aws_route" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsRouteInvalidNatGatewayRule()
 
 		mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_route_invalid_network_interface_test.go
+++ b/rules/awsrules/aws_route_invalid_network_interface_test.go
@@ -106,7 +106,10 @@ resource "aws_route" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsRouteInvalidNetworkInterfaceRule()
 
 		mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_route_invalid_route_table_test.go
+++ b/rules/awsrules/aws_route_invalid_route_table_test.go
@@ -106,7 +106,10 @@ resource "aws_route" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsRouteInvalidRouteTableRule()
 
 		mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_route_invalid_vpc_peering_connection_test.go
+++ b/rules/awsrules/aws_route_invalid_vpc_peering_connection_test.go
@@ -106,7 +106,10 @@ resource "aws_route" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsRouteInvalidVPCPeeringConnectionRule()
 
 		mock := client.NewMockEC2API(ctrl)

--- a/rules/awsrules/aws_route_not_specified_target_test.go
+++ b/rules/awsrules/aws_route_not_specified_target_test.go
@@ -162,7 +162,10 @@ resource "aws_route" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsRouteNotSpecifiedTargetRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/aws_route_specified_multiple_targets_test.go
+++ b/rules/awsrules/aws_route_specified_multiple_targets_test.go
@@ -102,7 +102,10 @@ resource "aws_route" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsRouteSpecifiedMultipleTargetsRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_acm_certificate_invalid_certificate_body_test.go
+++ b/rules/awsrules/models/aws_acm_certificate_invalid_certificate_body_test.go
@@ -121,7 +121,10 @@ TEXT
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAcmCertificateInvalidCertificateBodyRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_acm_certificate_invalid_certificate_chain_test.go
+++ b/rules/awsrules/models/aws_acm_certificate_invalid_certificate_chain_test.go
@@ -139,7 +139,10 @@ TEXT
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAcmCertificateInvalidCertificateChainRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_acm_certificate_invalid_private_key_test.go
+++ b/rules/awsrules/models/aws_acm_certificate_invalid_private_key_test.go
@@ -132,7 +132,10 @@ TEXT
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAcmCertificateInvalidPrivateKeyRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_acmpca_certificate_authority_invalid_type_test.go
+++ b/rules/awsrules/models/aws_acmpca_certificate_authority_invalid_type_test.go
@@ -84,7 +84,10 @@ resource "aws_acmpca_certificate_authority" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAcmpcaCertificateAuthorityInvalidTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ami_invalid_architecture_test.go
+++ b/rules/awsrules/models/aws_ami_invalid_architecture_test.go
@@ -84,7 +84,10 @@ resource "aws_ami" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAMIInvalidArchitectureRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_api_gateway_authorizer_invalid_type_test.go
+++ b/rules/awsrules/models/aws_api_gateway_authorizer_invalid_type_test.go
@@ -84,7 +84,10 @@ resource "aws_api_gateway_authorizer" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAPIGatewayAuthorizerInvalidTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_api_gateway_gateway_response_invalid_response_type_test.go
+++ b/rules/awsrules/models/aws_api_gateway_gateway_response_invalid_response_type_test.go
@@ -84,7 +84,10 @@ resource "aws_api_gateway_gateway_response" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAPIGatewayGatewayResponseInvalidResponseTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_api_gateway_gateway_response_invalid_status_code_test.go
+++ b/rules/awsrules/models/aws_api_gateway_gateway_response_invalid_status_code_test.go
@@ -84,7 +84,10 @@ resource "aws_api_gateway_gateway_response" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAPIGatewayGatewayResponseInvalidStatusCodeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_api_gateway_integration_invalid_connection_type_test.go
+++ b/rules/awsrules/models/aws_api_gateway_integration_invalid_connection_type_test.go
@@ -84,7 +84,10 @@ resource "aws_api_gateway_integration" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAPIGatewayIntegrationInvalidConnectionTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_api_gateway_integration_invalid_content_handling_test.go
+++ b/rules/awsrules/models/aws_api_gateway_integration_invalid_content_handling_test.go
@@ -84,7 +84,10 @@ resource "aws_api_gateway_integration" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAPIGatewayIntegrationInvalidContentHandlingRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_api_gateway_integration_invalid_type_test.go
+++ b/rules/awsrules/models/aws_api_gateway_integration_invalid_type_test.go
@@ -84,7 +84,10 @@ resource "aws_api_gateway_integration" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAPIGatewayIntegrationInvalidTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_api_gateway_rest_api_invalid_api_key_source_test.go
+++ b/rules/awsrules/models/aws_api_gateway_rest_api_invalid_api_key_source_test.go
@@ -84,7 +84,10 @@ resource "aws_api_gateway_rest_api" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAPIGatewayRestAPIInvalidAPIKeySourceRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_api_gateway_stage_invalid_cache_cluster_size_test.go
+++ b/rules/awsrules/models/aws_api_gateway_stage_invalid_cache_cluster_size_test.go
@@ -84,7 +84,10 @@ resource "aws_api_gateway_stage" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAPIGatewayStageInvalidCacheClusterSizeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_appautoscaling_policy_invalid_policy_type_test.go
+++ b/rules/awsrules/models/aws_appautoscaling_policy_invalid_policy_type_test.go
@@ -84,7 +84,10 @@ resource "aws_appautoscaling_policy" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAppautoscalingPolicyInvalidPolicyTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_appautoscaling_policy_invalid_scalable_dimension_test.go
+++ b/rules/awsrules/models/aws_appautoscaling_policy_invalid_scalable_dimension_test.go
@@ -84,7 +84,10 @@ resource "aws_appautoscaling_policy" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAppautoscalingPolicyInvalidScalableDimensionRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_appautoscaling_policy_invalid_service_namespace_test.go
+++ b/rules/awsrules/models/aws_appautoscaling_policy_invalid_service_namespace_test.go
@@ -84,7 +84,10 @@ resource "aws_appautoscaling_policy" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAppautoscalingPolicyInvalidServiceNamespaceRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_appsync_datasource_invalid_name_test.go
+++ b/rules/awsrules/models/aws_appsync_datasource_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_appsync_datasource" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAppsyncDatasourceInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_appsync_datasource_invalid_type_test.go
+++ b/rules/awsrules/models/aws_appsync_datasource_invalid_type_test.go
@@ -84,7 +84,10 @@ resource "aws_appsync_datasource" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAppsyncDatasourceInvalidTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_appsync_graphql_api_invalid_authentication_type_test.go
+++ b/rules/awsrules/models/aws_appsync_graphql_api_invalid_authentication_type_test.go
@@ -84,7 +84,10 @@ resource "aws_appsync_graphql_api" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsAppsyncGraphqlAPIInvalidAuthenticationTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_backup_selection_invalid_name_test.go
+++ b/rules/awsrules/models/aws_backup_selection_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_backup_selection" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsBackupSelectionInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_backup_vault_invalid_name_test.go
+++ b/rules/awsrules/models/aws_backup_vault_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_backup_vault" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsBackupVaultInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_batch_compute_environment_invalid_state_test.go
+++ b/rules/awsrules/models/aws_batch_compute_environment_invalid_state_test.go
@@ -84,7 +84,10 @@ resource "aws_batch_compute_environment" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsBatchComputeEnvironmentInvalidStateRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_batch_compute_environment_invalid_type_test.go
+++ b/rules/awsrules/models/aws_batch_compute_environment_invalid_type_test.go
@@ -84,7 +84,10 @@ resource "aws_batch_compute_environment" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsBatchComputeEnvironmentInvalidTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_batch_job_definition_invalid_type_test.go
+++ b/rules/awsrules/models/aws_batch_job_definition_invalid_type_test.go
@@ -84,7 +84,10 @@ resource "aws_batch_job_definition" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsBatchJobDefinitionInvalidTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_batch_job_queue_invalid_state_test.go
+++ b/rules/awsrules/models/aws_batch_job_queue_invalid_state_test.go
@@ -84,7 +84,10 @@ resource "aws_batch_job_queue" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsBatchJobQueueInvalidStateRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_budgets_budget_invalid_account_id_test.go
+++ b/rules/awsrules/models/aws_budgets_budget_invalid_account_id_test.go
@@ -84,7 +84,10 @@ resource "aws_budgets_budget" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsBudgetsBudgetInvalidAccountIDRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_budgets_budget_invalid_budget_type_test.go
+++ b/rules/awsrules/models/aws_budgets_budget_invalid_budget_type_test.go
@@ -84,7 +84,10 @@ resource "aws_budgets_budget" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsBudgetsBudgetInvalidBudgetTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_budgets_budget_invalid_name_test.go
+++ b/rules/awsrules/models/aws_budgets_budget_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_budgets_budget" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsBudgetsBudgetInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_budgets_budget_invalid_time_unit_test.go
+++ b/rules/awsrules/models/aws_budgets_budget_invalid_time_unit_test.go
@@ -84,7 +84,10 @@ resource "aws_budgets_budget" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsBudgetsBudgetInvalidTimeUnitRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloud9_environment_ec2_invalid_instance_type_test.go
+++ b/rules/awsrules/models/aws_cloud9_environment_ec2_invalid_instance_type_test.go
@@ -84,7 +84,10 @@ resource "aws_cloud9_environment_ec2" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloud9EnvironmentEc2InvalidInstanceTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloud9_environment_ec2_invalid_owner_arn_test.go
+++ b/rules/awsrules/models/aws_cloud9_environment_ec2_invalid_owner_arn_test.go
@@ -84,7 +84,10 @@ resource "aws_cloud9_environment_ec2" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloud9EnvironmentEc2InvalidOwnerArnRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudformation_stack_invalid_on_failure_test.go
+++ b/rules/awsrules/models/aws_cloudformation_stack_invalid_on_failure_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudformation_stack" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudformationStackInvalidOnFailureRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudformation_stack_set_instance_invalid_account_id_test.go
+++ b/rules/awsrules/models/aws_cloudformation_stack_set_instance_invalid_account_id_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudformation_stack_set_instance" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudformationStackSetInstanceInvalidAccountIDRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudformation_stack_set_invalid_execution_role_name_test.go
+++ b/rules/awsrules/models/aws_cloudformation_stack_set_invalid_execution_role_name_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudformation_stack_set" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudformationStackSetInvalidExecutionRoleNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudfront_distribution_invalid_http_version_test.go
+++ b/rules/awsrules/models/aws_cloudfront_distribution_invalid_http_version_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudfront_distribution" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudfrontDistributionInvalidHTTPVersionRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudfront_distribution_invalid_price_class_test.go
+++ b/rules/awsrules/models/aws_cloudfront_distribution_invalid_price_class_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudfront_distribution" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudfrontDistributionInvalidPriceClassRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudhsm_v2_cluster_invalid_hsm_type_test.go
+++ b/rules/awsrules/models/aws_cloudhsm_v2_cluster_invalid_hsm_type_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudhsm_v2_cluster" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudhsmV2ClusterInvalidHsmTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudhsm_v2_cluster_invalid_source_backup_identifier_test.go
+++ b/rules/awsrules/models/aws_cloudhsm_v2_cluster_invalid_source_backup_identifier_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudhsm_v2_cluster" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudhsmV2ClusterInvalidSourceBackupIdentifierRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudhsm_v2_hsm_invalid_availability_zone_test.go
+++ b/rules/awsrules/models/aws_cloudhsm_v2_hsm_invalid_availability_zone_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudhsm_v2_hsm" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudhsmV2HsmInvalidAvailabilityZoneRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudhsm_v2_hsm_invalid_cluster_id_test.go
+++ b/rules/awsrules/models/aws_cloudhsm_v2_hsm_invalid_cluster_id_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudhsm_v2_hsm" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudhsmV2HsmInvalidClusterIDRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudhsm_v2_hsm_invalid_ip_address_test.go
+++ b/rules/awsrules/models/aws_cloudhsm_v2_hsm_invalid_ip_address_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudhsm_v2_hsm" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudhsmV2HsmInvalidIPAddressRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudhsm_v2_hsm_invalid_subnet_id_test.go
+++ b/rules/awsrules/models/aws_cloudhsm_v2_hsm_invalid_subnet_id_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudhsm_v2_hsm" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudhsmV2HsmInvalidSubnetIDRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudwatch_event_permission_invalid_action_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_event_permission_invalid_action_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudwatch_event_permission" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudwatchEventPermissionInvalidActionRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudwatch_event_permission_invalid_principal_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_event_permission_invalid_principal_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudwatch_event_permission" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudwatchEventPermissionInvalidPrincipalRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudwatch_event_permission_invalid_statement_id_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_event_permission_invalid_statement_id_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudwatch_event_permission" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudwatchEventPermissionInvalidStatementIDRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudwatch_event_rule_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_event_rule_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudwatch_event_rule" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudwatchEventRuleInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudwatch_event_target_invalid_target_id_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_event_target_invalid_target_id_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudwatch_event_target" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudwatchEventTargetInvalidTargetIDRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudwatch_log_destination_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_log_destination_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudwatch_log_destination" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudwatchLogDestinationInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudwatch_log_group_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_log_group_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudwatch_log_group" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudwatchLogGroupInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudwatch_log_metric_filter_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_log_metric_filter_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudwatch_log_metric_filter" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudwatchLogMetricFilterInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudwatch_log_stream_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_log_stream_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudwatch_log_stream" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudwatchLogStreamInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudwatch_log_subscription_filter_invalid_distribution_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_log_subscription_filter_invalid_distribution_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudwatch_log_subscription_filter" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudwatchLogSubscriptionFilterInvalidDistributionRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudwatch_log_subscription_filter_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_log_subscription_filter_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudwatch_log_subscription_filter" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudwatchLogSubscriptionFilterInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_comparison_operator_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_comparison_operator_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudwatch_metric_alarm" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudwatchMetricAlarmInvalidComparisonOperatorRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_extended_statistic_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_extended_statistic_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudwatch_metric_alarm" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudwatchMetricAlarmInvalidExtendedStatisticRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_namespace_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_namespace_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudwatch_metric_alarm" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudwatchMetricAlarmInvalidNamespaceRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_statistic_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_statistic_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudwatch_metric_alarm" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudwatchMetricAlarmInvalidStatisticRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_unit_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_unit_test.go
@@ -84,7 +84,10 @@ resource "aws_cloudwatch_metric_alarm" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCloudwatchMetricAlarmInvalidUnitRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_codecommit_repository_invalid_repository_name_test.go
+++ b/rules/awsrules/models/aws_codecommit_repository_invalid_repository_name_test.go
@@ -84,7 +84,10 @@ resource "aws_codecommit_repository" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCodecommitRepositoryInvalidRepositoryNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_codedeploy_app_invalid_compute_platform_test.go
+++ b/rules/awsrules/models/aws_codedeploy_app_invalid_compute_platform_test.go
@@ -84,7 +84,10 @@ resource "aws_codedeploy_app" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCodedeployAppInvalidComputePlatformRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_codepipeline_invalid_name_test.go
+++ b/rules/awsrules/models/aws_codepipeline_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_codepipeline" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCodepipelineInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_codepipeline_invalid_role_arn_test.go
+++ b/rules/awsrules/models/aws_codepipeline_invalid_role_arn_test.go
@@ -84,7 +84,10 @@ resource "aws_codepipeline" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCodepipelineInvalidRoleArnRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_codepipeline_webhook_invalid_authentication_test.go
+++ b/rules/awsrules/models/aws_codepipeline_webhook_invalid_authentication_test.go
@@ -84,7 +84,10 @@ resource "aws_codepipeline_webhook" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCodepipelineWebhookInvalidAuthenticationRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_codepipeline_webhook_invalid_name_test.go
+++ b/rules/awsrules/models/aws_codepipeline_webhook_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_codepipeline_webhook" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCodepipelineWebhookInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_codepipeline_webhook_invalid_target_action_test.go
+++ b/rules/awsrules/models/aws_codepipeline_webhook_invalid_target_action_test.go
@@ -84,7 +84,10 @@ resource "aws_codepipeline_webhook" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCodepipelineWebhookInvalidTargetActionRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cognito_identity_pool_invalid_identity_pool_name_test.go
+++ b/rules/awsrules/models/aws_cognito_identity_pool_invalid_identity_pool_name_test.go
@@ -84,7 +84,10 @@ resource "aws_cognito_identity_pool" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCognitoIdentityPoolInvalidIdentityPoolNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cognito_identity_pool_roles_attachment_invalid_identity_pool_id_test.go
+++ b/rules/awsrules/models/aws_cognito_identity_pool_roles_attachment_invalid_identity_pool_id_test.go
@@ -84,7 +84,10 @@ resource "aws_cognito_identity_pool_roles_attachment" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCognitoIdentityPoolRolesAttachmentInvalidIdentityPoolIDRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cognito_identity_provider_invalid_provider_name_test.go
+++ b/rules/awsrules/models/aws_cognito_identity_provider_invalid_provider_name_test.go
@@ -84,7 +84,10 @@ resource "aws_cognito_identity_provider" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCognitoIdentityProviderInvalidProviderNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cognito_identity_provider_invalid_provider_type_test.go
+++ b/rules/awsrules/models/aws_cognito_identity_provider_invalid_provider_type_test.go
@@ -84,7 +84,10 @@ resource "aws_cognito_identity_provider" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCognitoIdentityProviderInvalidProviderTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cognito_identity_provider_invalid_user_pool_id_test.go
+++ b/rules/awsrules/models/aws_cognito_identity_provider_invalid_user_pool_id_test.go
@@ -84,7 +84,10 @@ resource "aws_cognito_identity_provider" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCognitoIdentityProviderInvalidUserPoolIDRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cognito_resource_server_invalid_identifier_test.go
+++ b/rules/awsrules/models/aws_cognito_resource_server_invalid_identifier_test.go
@@ -84,7 +84,10 @@ resource "aws_cognito_resource_server" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCognitoResourceServerInvalidIdentifierRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cognito_resource_server_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cognito_resource_server_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_cognito_resource_server" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCognitoResourceServerInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cognito_user_group_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cognito_user_group_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_cognito_user_group" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCognitoUserGroupInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cognito_user_group_invalid_role_arn_test.go
+++ b/rules/awsrules/models/aws_cognito_user_group_invalid_role_arn_test.go
@@ -84,7 +84,10 @@ resource "aws_cognito_user_group" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCognitoUserGroupInvalidRoleArnRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cognito_user_pool_client_invalid_default_redirect_uri_test.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_client_invalid_default_redirect_uri_test.go
@@ -84,7 +84,10 @@ resource "aws_cognito_user_pool_client" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCognitoUserPoolClientInvalidDefaultRedirectURIRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cognito_user_pool_client_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_client_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_cognito_user_pool_client" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCognitoUserPoolClientInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cognito_user_pool_domain_invalid_domain_test.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_domain_invalid_domain_test.go
@@ -84,7 +84,10 @@ resource "aws_cognito_user_pool_domain" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCognitoUserPoolDomainInvalidDomainRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cognito_user_pool_invalid_email_verification_message_test.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_invalid_email_verification_message_test.go
@@ -84,7 +84,10 @@ resource "aws_cognito_user_pool" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCognitoUserPoolInvalidEmailVerificationMessageRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cognito_user_pool_invalid_mfa_configuration_test.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_invalid_mfa_configuration_test.go
@@ -84,7 +84,10 @@ resource "aws_cognito_user_pool" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCognitoUserPoolInvalidMfaConfigurationRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cognito_user_pool_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_cognito_user_pool" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCognitoUserPoolInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cognito_user_pool_invalid_sms_authentication_message_test.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_invalid_sms_authentication_message_test.go
@@ -84,7 +84,10 @@ resource "aws_cognito_user_pool" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCognitoUserPoolInvalidSmsAuthenticationMessageRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cognito_user_pool_invalid_sms_verification_message_test.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_invalid_sms_verification_message_test.go
@@ -84,7 +84,10 @@ resource "aws_cognito_user_pool" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCognitoUserPoolInvalidSmsVerificationMessageRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_config_aggregate_authorization_invalid_account_id_test.go
+++ b/rules/awsrules/models/aws_config_aggregate_authorization_invalid_account_id_test.go
@@ -84,7 +84,10 @@ resource "aws_config_aggregate_authorization" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsConfigAggregateAuthorizationInvalidAccountIDRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_config_config_rule_invalid_maximum_execution_frequency_test.go
+++ b/rules/awsrules/models/aws_config_config_rule_invalid_maximum_execution_frequency_test.go
@@ -84,7 +84,10 @@ resource "aws_config_config_rule" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsConfigConfigRuleInvalidMaximumExecutionFrequencyRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_config_configuration_aggregator_invalid_name_test.go
+++ b/rules/awsrules/models/aws_config_configuration_aggregator_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_config_configuration_aggregator" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsConfigConfigurationAggregatorInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cur_report_definition_invalid_compression_test.go
+++ b/rules/awsrules/models/aws_cur_report_definition_invalid_compression_test.go
@@ -84,7 +84,10 @@ resource "aws_cur_report_definition" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCurReportDefinitionInvalidCompressionRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cur_report_definition_invalid_format_test.go
+++ b/rules/awsrules/models/aws_cur_report_definition_invalid_format_test.go
@@ -84,7 +84,10 @@ resource "aws_cur_report_definition" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCurReportDefinitionInvalidFormatRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cur_report_definition_invalid_report_name_test.go
+++ b/rules/awsrules/models/aws_cur_report_definition_invalid_report_name_test.go
@@ -84,7 +84,10 @@ resource "aws_cur_report_definition" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCurReportDefinitionInvalidReportNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cur_report_definition_invalid_s3_prefix_test.go
+++ b/rules/awsrules/models/aws_cur_report_definition_invalid_s3_prefix_test.go
@@ -86,7 +86,10 @@ resource "aws_cur_report_definition" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCurReportDefinitionInvalidS3PrefixRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cur_report_definition_invalid_s3_region_test.go
+++ b/rules/awsrules/models/aws_cur_report_definition_invalid_s3_region_test.go
@@ -84,7 +84,10 @@ resource "aws_cur_report_definition" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCurReportDefinitionInvalidS3RegionRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_cur_report_definition_invalid_time_unit_test.go
+++ b/rules/awsrules/models/aws_cur_report_definition_invalid_time_unit_test.go
@@ -84,7 +84,10 @@ resource "aws_cur_report_definition" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsCurReportDefinitionInvalidTimeUnitRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_datasync_agent_invalid_activation_key_test.go
+++ b/rules/awsrules/models/aws_datasync_agent_invalid_activation_key_test.go
@@ -84,7 +84,10 @@ resource "aws_datasync_agent" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDatasyncAgentInvalidActivationKeyRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_datasync_agent_invalid_name_test.go
+++ b/rules/awsrules/models/aws_datasync_agent_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_datasync_agent" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDatasyncAgentInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_datasync_location_efs_invalid_efs_file_system_arn_test.go
+++ b/rules/awsrules/models/aws_datasync_location_efs_invalid_efs_file_system_arn_test.go
@@ -84,7 +84,10 @@ resource "aws_datasync_location_efs" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDatasyncLocationEfsInvalidEfsFileSystemArnRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_datasync_location_efs_invalid_subdirectory_test.go
+++ b/rules/awsrules/models/aws_datasync_location_efs_invalid_subdirectory_test.go
@@ -84,7 +84,10 @@ resource "aws_datasync_location_efs" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDatasyncLocationEfsInvalidSubdirectoryRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_datasync_location_nfs_invalid_server_hostname_test.go
+++ b/rules/awsrules/models/aws_datasync_location_nfs_invalid_server_hostname_test.go
@@ -84,7 +84,10 @@ resource "aws_datasync_location_nfs" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDatasyncLocationNfsInvalidServerHostnameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_datasync_location_nfs_invalid_subdirectory_test.go
+++ b/rules/awsrules/models/aws_datasync_location_nfs_invalid_subdirectory_test.go
@@ -84,7 +84,10 @@ resource "aws_datasync_location_nfs" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDatasyncLocationNfsInvalidSubdirectoryRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_datasync_location_s3_invalid_s3_bucket_arn_test.go
+++ b/rules/awsrules/models/aws_datasync_location_s3_invalid_s3_bucket_arn_test.go
@@ -84,7 +84,10 @@ resource "aws_datasync_location_s3" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDatasyncLocationS3InvalidS3BucketArnRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_datasync_task_invalid_cloudwatch_log_group_arn_test.go
+++ b/rules/awsrules/models/aws_datasync_task_invalid_cloudwatch_log_group_arn_test.go
@@ -84,7 +84,10 @@ resource "aws_datasync_task" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDatasyncTaskInvalidCloudwatchLogGroupArnRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_datasync_task_invalid_source_location_arn_test.go
+++ b/rules/awsrules/models/aws_datasync_task_invalid_source_location_arn_test.go
@@ -84,7 +84,10 @@ resource "aws_datasync_task" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDatasyncTaskInvalidSourceLocationArnRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_directory_service_conditional_forwarder_invalid_directory_id_test.go
+++ b/rules/awsrules/models/aws_directory_service_conditional_forwarder_invalid_directory_id_test.go
@@ -84,7 +84,10 @@ resource "aws_directory_service_conditional_forwarder" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDirectoryServiceConditionalForwarderInvalidDirectoryIDRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_directory_service_conditional_forwarder_invalid_remote_domain_name_test.go
+++ b/rules/awsrules/models/aws_directory_service_conditional_forwarder_invalid_remote_domain_name_test.go
@@ -84,7 +84,10 @@ resource "aws_directory_service_conditional_forwarder" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDirectoryServiceConditionalForwarderInvalidRemoteDomainNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_directory_service_directory_invalid_description_test.go
+++ b/rules/awsrules/models/aws_directory_service_directory_invalid_description_test.go
@@ -84,7 +84,10 @@ resource "aws_directory_service_directory" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDirectoryServiceDirectoryInvalidDescriptionRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_directory_service_directory_invalid_edition_test.go
+++ b/rules/awsrules/models/aws_directory_service_directory_invalid_edition_test.go
@@ -84,7 +84,10 @@ resource "aws_directory_service_directory" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDirectoryServiceDirectoryInvalidEditionRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_directory_service_directory_invalid_name_test.go
+++ b/rules/awsrules/models/aws_directory_service_directory_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_directory_service_directory" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDirectoryServiceDirectoryInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_directory_service_directory_invalid_short_name_test.go
+++ b/rules/awsrules/models/aws_directory_service_directory_invalid_short_name_test.go
@@ -84,7 +84,10 @@ resource "aws_directory_service_directory" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDirectoryServiceDirectoryInvalidShortNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_directory_service_directory_invalid_size_test.go
+++ b/rules/awsrules/models/aws_directory_service_directory_invalid_size_test.go
@@ -84,7 +84,10 @@ resource "aws_directory_service_directory" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDirectoryServiceDirectoryInvalidSizeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_directory_service_directory_invalid_type_test.go
+++ b/rules/awsrules/models/aws_directory_service_directory_invalid_type_test.go
@@ -84,7 +84,10 @@ resource "aws_directory_service_directory" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDirectoryServiceDirectoryInvalidTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_dlm_lifecycle_policy_invalid_state_test.go
+++ b/rules/awsrules/models/aws_dlm_lifecycle_policy_invalid_state_test.go
@@ -84,7 +84,10 @@ resource "aws_dlm_lifecycle_policy" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDlmLifecyclePolicyInvalidStateRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_dms_endpoint_invalid_endpoint_type_test.go
+++ b/rules/awsrules/models/aws_dms_endpoint_invalid_endpoint_type_test.go
@@ -84,7 +84,10 @@ resource "aws_dms_endpoint" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDmsEndpointInvalidEndpointTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_dms_endpoint_invalid_ssl_mode_test.go
+++ b/rules/awsrules/models/aws_dms_endpoint_invalid_ssl_mode_test.go
@@ -84,7 +84,10 @@ resource "aws_dms_endpoint" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDmsEndpointInvalidSslModeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_dms_replication_task_invalid_migration_type_test.go
+++ b/rules/awsrules/models/aws_dms_replication_task_invalid_migration_type_test.go
@@ -84,7 +84,10 @@ resource "aws_dms_replication_task" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDmsReplicationTaskInvalidMigrationTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_dx_bgp_peer_invalid_address_family_test.go
+++ b/rules/awsrules/models/aws_dx_bgp_peer_invalid_address_family_test.go
@@ -84,7 +84,10 @@ resource "aws_dx_bgp_peer" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDxBgpPeerInvalidAddressFamilyRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_dynamodb_global_table_invalid_name_test.go
+++ b/rules/awsrules/models/aws_dynamodb_global_table_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_dynamodb_global_table" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDynamoDBGlobalTableInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_dynamodb_table_invalid_billing_mode_test.go
+++ b/rules/awsrules/models/aws_dynamodb_table_invalid_billing_mode_test.go
@@ -84,7 +84,10 @@ resource "aws_dynamodb_table" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDynamoDBTableInvalidBillingModeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_dynamodb_table_invalid_stream_view_type_test.go
+++ b/rules/awsrules/models/aws_dynamodb_table_invalid_stream_view_type_test.go
@@ -84,7 +84,10 @@ resource "aws_dynamodb_table" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsDynamoDBTableInvalidStreamViewTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ebs_volume_invalid_type_test.go
+++ b/rules/awsrules/models/aws_ebs_volume_invalid_type_test.go
@@ -84,7 +84,10 @@ resource "aws_ebs_volume" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEbsVolumeInvalidTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ec2_capacity_reservation_invalid_end_date_type_test.go
+++ b/rules/awsrules/models/aws_ec2_capacity_reservation_invalid_end_date_type_test.go
@@ -84,7 +84,10 @@ resource "aws_ec2_capacity_reservation" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEc2CapacityReservationInvalidEndDateTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ec2_capacity_reservation_invalid_instance_match_criteria_test.go
+++ b/rules/awsrules/models/aws_ec2_capacity_reservation_invalid_instance_match_criteria_test.go
@@ -84,7 +84,10 @@ resource "aws_ec2_capacity_reservation" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEc2CapacityReservationInvalidInstanceMatchCriteriaRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ec2_capacity_reservation_invalid_instance_platform_test.go
+++ b/rules/awsrules/models/aws_ec2_capacity_reservation_invalid_instance_platform_test.go
@@ -84,7 +84,10 @@ resource "aws_ec2_capacity_reservation" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEc2CapacityReservationInvalidInstancePlatformRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ec2_capacity_reservation_invalid_tenancy_test.go
+++ b/rules/awsrules/models/aws_ec2_capacity_reservation_invalid_tenancy_test.go
@@ -84,7 +84,10 @@ resource "aws_ec2_capacity_reservation" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEc2CapacityReservationInvalidTenancyRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ec2_client_vpn_endpoint_invalid_transport_protocol_test.go
+++ b/rules/awsrules/models/aws_ec2_client_vpn_endpoint_invalid_transport_protocol_test.go
@@ -84,7 +84,10 @@ resource "aws_ec2_client_vpn_endpoint" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEc2ClientVpnEndpointInvalidTransportProtocolRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ec2_fleet_invalid_excess_capacity_termination_policy_test.go
+++ b/rules/awsrules/models/aws_ec2_fleet_invalid_excess_capacity_termination_policy_test.go
@@ -84,7 +84,10 @@ resource "aws_ec2_fleet" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEc2FleetInvalidExcessCapacityTerminationPolicyRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ec2_fleet_invalid_type_test.go
+++ b/rules/awsrules/models/aws_ec2_fleet_invalid_type_test.go
@@ -84,7 +84,10 @@ resource "aws_ec2_fleet" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEc2FleetInvalidTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ec2_transit_gateway_invalid_auto_accept_shared_attachments_test.go
+++ b/rules/awsrules/models/aws_ec2_transit_gateway_invalid_auto_accept_shared_attachments_test.go
@@ -84,7 +84,10 @@ resource "aws_ec2_transit_gateway" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEc2TransitGatewayInvalidAutoAcceptSharedAttachmentsRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ec2_transit_gateway_invalid_default_route_table_association_test.go
+++ b/rules/awsrules/models/aws_ec2_transit_gateway_invalid_default_route_table_association_test.go
@@ -84,7 +84,10 @@ resource "aws_ec2_transit_gateway" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEc2TransitGatewayInvalidDefaultRouteTableAssociationRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ec2_transit_gateway_invalid_default_route_table_propagation_test.go
+++ b/rules/awsrules/models/aws_ec2_transit_gateway_invalid_default_route_table_propagation_test.go
@@ -84,7 +84,10 @@ resource "aws_ec2_transit_gateway" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEc2TransitGatewayInvalidDefaultRouteTablePropagationRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ec2_transit_gateway_invalid_dns_support_test.go
+++ b/rules/awsrules/models/aws_ec2_transit_gateway_invalid_dns_support_test.go
@@ -84,7 +84,10 @@ resource "aws_ec2_transit_gateway" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEc2TransitGatewayInvalidDNSSupportRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ec2_transit_gateway_vpc_attachment_invalid_ipv6_support_test.go
+++ b/rules/awsrules/models/aws_ec2_transit_gateway_vpc_attachment_invalid_ipv6_support_test.go
@@ -84,7 +84,10 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEc2TransitGatewayVpcAttachmentInvalidIpv6SupportRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ecr_lifecycle_policy_invalid_repository_test.go
+++ b/rules/awsrules/models/aws_ecr_lifecycle_policy_invalid_repository_test.go
@@ -84,7 +84,10 @@ resource "aws_ecr_lifecycle_policy" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEcrLifecyclePolicyInvalidRepositoryRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ecs_service_invalid_launch_type_test.go
+++ b/rules/awsrules/models/aws_ecs_service_invalid_launch_type_test.go
@@ -84,7 +84,10 @@ resource "aws_ecs_service" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEcsServiceInvalidLaunchTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ecs_service_invalid_propagate_tags_test.go
+++ b/rules/awsrules/models/aws_ecs_service_invalid_propagate_tags_test.go
@@ -84,7 +84,10 @@ resource "aws_ecs_service" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEcsServiceInvalidPropagateTagsRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ecs_service_invalid_scheduling_strategy_test.go
+++ b/rules/awsrules/models/aws_ecs_service_invalid_scheduling_strategy_test.go
@@ -84,7 +84,10 @@ resource "aws_ecs_service" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEcsServiceInvalidSchedulingStrategyRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ecs_task_definition_invalid_ipc_mode_test.go
+++ b/rules/awsrules/models/aws_ecs_task_definition_invalid_ipc_mode_test.go
@@ -84,7 +84,10 @@ resource "aws_ecs_task_definition" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEcsTaskDefinitionInvalidIpcModeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ecs_task_definition_invalid_network_mode_test.go
+++ b/rules/awsrules/models/aws_ecs_task_definition_invalid_network_mode_test.go
@@ -84,7 +84,10 @@ resource "aws_ecs_task_definition" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEcsTaskDefinitionInvalidNetworkModeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_ecs_task_definition_invalid_pid_mode_test.go
+++ b/rules/awsrules/models/aws_ecs_task_definition_invalid_pid_mode_test.go
@@ -84,7 +84,10 @@ resource "aws_ecs_task_definition" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEcsTaskDefinitionInvalidPidModeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_efs_file_system_invalid_performance_mode_test.go
+++ b/rules/awsrules/models/aws_efs_file_system_invalid_performance_mode_test.go
@@ -84,7 +84,10 @@ resource "aws_efs_file_system" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEfsFileSystemInvalidPerformanceModeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_efs_file_system_invalid_throughput_mode_test.go
+++ b/rules/awsrules/models/aws_efs_file_system_invalid_throughput_mode_test.go
@@ -84,7 +84,10 @@ resource "aws_efs_file_system" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEfsFileSystemInvalidThroughputModeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_eks_cluster_invalid_name_test.go
+++ b/rules/awsrules/models/aws_eks_cluster_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_eks_cluster" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsEksClusterInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_elasticache_cluster_invalid_az_mode_test.go
+++ b/rules/awsrules/models/aws_elasticache_cluster_invalid_az_mode_test.go
@@ -84,7 +84,10 @@ resource "aws_elasticache_cluster" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsElastiCacheClusterInvalidAzModeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_elastictranscoder_preset_invalid_container_test.go
+++ b/rules/awsrules/models/aws_elastictranscoder_preset_invalid_container_test.go
@@ -84,7 +84,10 @@ resource "aws_elastictranscoder_preset" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsElastictranscoderPresetInvalidContainerRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_instance_invalid_instance_initiated_shutdown_behavior_test.go
+++ b/rules/awsrules/models/aws_instance_invalid_instance_initiated_shutdown_behavior_test.go
@@ -84,7 +84,10 @@ resource "aws_instance" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsInstanceInvalidInstanceInitiatedShutdownBehaviorRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_instance_invalid_tenancy_test.go
+++ b/rules/awsrules/models/aws_instance_invalid_tenancy_test.go
@@ -84,7 +84,10 @@ resource "aws_instance" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsInstanceInvalidTenancyRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_launch_template_invalid_instance_type_test.go
+++ b/rules/awsrules/models/aws_launch_template_invalid_instance_type_test.go
@@ -84,7 +84,10 @@ resource "aws_launch_template" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsLaunchTemplateInvalidInstanceTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_launch_template_invalid_name_test.go
+++ b/rules/awsrules/models/aws_launch_template_invalid_name_test.go
@@ -84,7 +84,10 @@ resource "aws_launch_template" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsLaunchTemplateInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_lb_invalid_ip_address_type_test.go
+++ b/rules/awsrules/models/aws_lb_invalid_ip_address_type_test.go
@@ -84,7 +84,10 @@ resource "aws_lb" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsLbInvalidIPAddressTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_lb_invalid_load_balancer_type_test.go
+++ b/rules/awsrules/models/aws_lb_invalid_load_balancer_type_test.go
@@ -84,7 +84,10 @@ resource "aws_lb" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsLbInvalidLoadBalancerTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_lb_listener_invalid_protocol_test.go
+++ b/rules/awsrules/models/aws_lb_listener_invalid_protocol_test.go
@@ -84,7 +84,10 @@ resource "aws_lb_listener" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsLbListenerInvalidProtocolRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_lb_target_group_invalid_target_type_test.go
+++ b/rules/awsrules/models/aws_lb_target_group_invalid_target_type_test.go
@@ -84,7 +84,10 @@ resource "aws_lb_target_group" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsLbTargetGroupInvalidTargetTypeRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_placement_group_invalid_strategy_test.go
+++ b/rules/awsrules/models/aws_placement_group_invalid_strategy_test.go
@@ -84,7 +84,10 @@ resource "aws_placement_group" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsPlacementGroupInvalidStrategyRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_spot_fleet_request_invalid_allocation_strategy_test.go
+++ b/rules/awsrules/models/aws_spot_fleet_request_invalid_allocation_strategy_test.go
@@ -84,7 +84,10 @@ resource "aws_spot_fleet_request" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsSpotFleetRequestInvalidAllocationStrategyRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/aws_spot_fleet_request_invalid_instance_interruption_behaviour_test.go
+++ b/rules/awsrules/models/aws_spot_fleet_request_invalid_instance_interruption_behaviour_test.go
@@ -84,7 +84,10 @@ resource "aws_spot_fleet_request" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsSpotFleetRequestInvalidInstanceInterruptionBehaviourRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/models_test.go
+++ b/rules/awsrules/models/models_test.go
@@ -106,7 +106,10 @@ resource "aws_launch_template" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewAwsLaunchTemplateInvalidNameRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/awsrules/models/pattern_rule_test.go.tmpl
+++ b/rules/awsrules/models/pattern_rule_test.go.tmpl
@@ -89,7 +89,10 @@ resource "{{ .ResourceType }}" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := New{{ .RuleNameCC }}Rule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/rule_test.go.tmpl
+++ b/rules/rule_test.go.tmpl
@@ -76,7 +76,10 @@ resource "null_resource" "null" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := New{{ .RuleNameCC }}Rule()
 
 		mock := mock.NewMockAPI(ctrl)

--- a/rules/terraformrules/terraform_documented_outputs_test.go
+++ b/rules/terraformrules/terraform_documented_outputs_test.go
@@ -103,7 +103,10 @@ output "endpoint" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewTerraformDocumentedOutputsRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/terraformrules/terraform_documented_variables_test.go
+++ b/rules/terraformrules/terraform_documented_variables_test.go
@@ -101,7 +101,10 @@ variable "with_description" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewTerraformDocumentedVariablesRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/rules/terraformrules/terraform_module_pinned_source_test.go
+++ b/rules/terraformrules/terraform_module_pinned_source_test.go
@@ -321,7 +321,10 @@ module "pinned_mercurial" {
 			t.Fatal(tfdiags)
 		}
 
-		runner := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatal(err)
+		}
 		rule := NewTerraformModulePinnedSourceRule()
 
 		if err = rule.Check(runner); err != nil {

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -128,6 +128,9 @@ func (c *Config) Merge(other *Config) *Config {
 	if other.AwsCredentials.Profile != "" {
 		ret.AwsCredentials.Profile = other.AwsCredentials.Profile
 	}
+	if other.AwsCredentials.CredsFile != "" {
+		ret.AwsCredentials.CredsFile = other.AwsCredentials.CredsFile
+	}
 	if other.AwsCredentials.Region != "" {
 		ret.AwsCredentials.Region = other.AwsCredentials.Region
 	}
@@ -251,6 +254,7 @@ func (raw *rawConfig) toConfig() *Config {
 			ret.AwsCredentials.AccessKey = credentials["access_key"]
 			ret.AwsCredentials.SecretKey = credentials["secret_key"]
 			ret.AwsCredentials.Profile = credentials["profile"]
+			ret.AwsCredentials.CredsFile = credentials["shared_credentials_file"]
 			ret.AwsCredentials.Region = credentials["region"]
 		}
 		if rc.IgnoreModule != nil {

--- a/tflint/config_test.go
+++ b/tflint/config_test.go
@@ -33,6 +33,8 @@ func Test_LoadConfig(t *testing.T) {
 					AccessKey: "AWS_ACCESS_KEY",
 					SecretKey: "AWS_SECRET_KEY",
 					Region:    "us-east-1",
+					Profile:   "production",
+					CredsFile: "~/.aws/myapp",
 				},
 				IgnoreRule: map[string]bool{
 					"aws_instance_invalid_type":  true,
@@ -259,6 +261,7 @@ func Test_Merge(t *testing.T) {
 					AccessKey: "ACCESS_KEY",
 					SecretKey: "SECRET_KEY",
 					Region:    "ap-northeast-1",
+					CredsFile: "~/.aws/myapp",
 				},
 				IgnoreModule: map[string]bool{
 					"github.com/wata727/example-2": true,
@@ -290,6 +293,7 @@ func Test_Merge(t *testing.T) {
 					SecretKey: "SECRET_KEY",
 					Profile:   "production",
 					Region:    "ap-northeast-1",
+					CredsFile: "~/.aws/myapp",
 				},
 				IgnoreModule: map[string]bool{
 					"github.com/wata727/example-1": true,

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -167,7 +167,10 @@ resource "null_resource" "test" {
 			t.Fatal(err)
 		}
 
-		runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
+		}
 
 		var ret string
 		err = runner.EvaluateExpr(attribute.Expr, &ret)
@@ -234,7 +237,10 @@ resource "null_resource" "test" {
 			t.Fatal(err)
 		}
 
-		runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
+		}
 
 		var ret int
 		err = runner.EvaluateExpr(attribute.Expr, &ret)
@@ -285,7 +291,10 @@ resource "null_resource" "test" {
 			t.Fatal(err)
 		}
 
-		runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
+		}
 
 		ret := []string{}
 		err = runner.EvaluateExpr(attribute.Expr, &ret)
@@ -336,7 +345,10 @@ resource "null_resource" "test" {
 			t.Fatal(err)
 		}
 
-		runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
+		}
 
 		ret := []int{}
 		err = runner.EvaluateExpr(attribute.Expr, &ret)
@@ -390,7 +402,10 @@ resource "null_resource" "test" {
 			t.Fatal(err)
 		}
 
-		runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
+		}
 
 		ret := map[string]string{}
 		err = runner.EvaluateExpr(attribute.Expr, &ret)
@@ -444,7 +459,10 @@ resource "null_resource" "test" {
 			t.Fatal(err)
 		}
 
-		runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
+		}
 
 		ret := map[string]int{}
 		err = runner.EvaluateExpr(attribute.Expr, &ret)
@@ -556,7 +574,10 @@ resource "null_resource" "test" {
 			t.Fatal(err)
 		}
 
-		runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
+		}
 
 		expectedText := fmt.Sprintf(tc.ErrorText, filepath.Join(dir, "resource.tf"))
 
@@ -667,7 +688,10 @@ resource "null_resource" "test" {
 			t.Fatal(err)
 		}
 
-		runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
+		}
 
 		expectedText := fmt.Sprintf(tc.ErrorText, filepath.Join(dir, "resource.tf"))
 
@@ -933,7 +957,10 @@ resource "null_resource" "test" {
 			t.Fatal(err)
 		}
 
-		runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, tc.InputValues...)
+		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, tc.InputValues...)
+		if err != nil {
+			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
+		}
 
 		var ret string
 		err = runner.EvaluateExpr(attribute.Expr, &ret)
@@ -975,7 +1002,7 @@ func Test_NewModuleRunners_noModules(t *testing.T) {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
 
-	runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+	runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
 	runners, err := NewModuleRunners(runner)
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
@@ -1007,7 +1034,7 @@ func Test_NewModuleRunners_nestedModules(t *testing.T) {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
 
-	runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+	runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
 	runners, err := NewModuleRunners(runner)
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
@@ -1138,7 +1165,7 @@ func Test_NewModuleRunners_ignoreModules(t *testing.T) {
 	conf := EmptyConfig()
 	conf.IgnoreModule["./module"] = true
 
-	runner := NewRunner(conf, map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+	runner, err := NewRunner(conf, map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
 	runners, err := NewModuleRunners(runner)
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
@@ -1170,7 +1197,11 @@ func Test_NewModuleRunners_withInvalidExpression(t *testing.T) {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
 
-	runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+	runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
 	_, err = NewModuleRunners(runner)
 
 	errText := "Failed to eval an expression in module.tf:4; Invalid \"terraform\" attribute: The terraform.env attribute was deprecated in v0.10 and removed in v0.12. The \"state environment\" concept was rename to \"workspace\" in v0.12, and so the workspace name can now be accessed using the terraform.workspace attribute."
@@ -1216,7 +1247,11 @@ func Test_NewModuleRunners_withNotAllowedAttributes(t *testing.T) {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
 
-	runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+	runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
 	_, err = NewModuleRunners(runner)
 
 	errText := "Attribute of module not allowed was found in module.tf:1; module.tf:4,3-10: Unexpected \"invalid\" block; Blocks are not allowed here."
@@ -1278,7 +1313,11 @@ resource "aws_route" "r" {
 		t.Fatal(err)
 	}
 
-	runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+	runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
 	resources := runner.LookupResourcesByType("aws_instance")
 
 	if len(resources) != 1 {
@@ -1290,7 +1329,11 @@ resource "aws_route" "r" {
 }
 
 func Test_LookupIssues(t *testing.T) {
-	runner := NewRunner(EmptyConfig(), map[string]Annotations{}, configs.NewEmptyConfig(), map[string]*terraform.InputValue{})
+	runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, configs.NewEmptyConfig(), map[string]*terraform.InputValue{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
 	runner.Issues = issue.Issues{
 		{
 			Detector: "test rule",
@@ -1379,7 +1422,10 @@ resource "aws_instance" "test" {
 		if err != nil {
 			t.Fatal(err)
 		}
-		runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
+		}
 
 		err = runner.WalkResourceAttributes("aws_instance", "instance_type", func(attribute *hcl.Attribute) error {
 			return fmt.Errorf("Walk %s", attribute.Name)
@@ -1480,7 +1526,10 @@ resource "aws_instance" "test" {
 		if err != nil {
 			t.Fatal(err)
 		}
-		runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
+		}
 
 		err = runner.WalkResourceBlocks("aws_instance", "instance_type", func(block *hcl.Block) error {
 			return fmt.Errorf("Walk %s", block.Type)
@@ -1537,7 +1586,10 @@ func Test_EnsureNoError(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	for _, tc := range cases {
-		runner := NewRunner(EmptyConfig(), map[string]Annotations{}, configs.NewEmptyConfig(), map[string]*terraform.InputValue{})
+		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, configs.NewEmptyConfig(), map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
+		}
 
 		err = runner.EnsureNoError(tc.Error, func() error {
 			return errors.New("function called")
@@ -1647,7 +1699,10 @@ resource "null_resource" "test" {
 			t.Fatal(err)
 		}
 
-		runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
+		}
 		ret := runner.IsNullExpr(attribute.Expr)
 
 		if tc.Expected != ret {
@@ -1726,7 +1781,10 @@ resource "null_resource" "test" {
 		if err != nil {
 			t.Fatal(err)
 		}
-		runner := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
+		}
 
 		vals := []string{}
 		lines := []int{}
@@ -1822,7 +1880,10 @@ func Test_EmitIssue(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	for _, tc := range cases {
-		runner := NewRunner(EmptyConfig(), tc.Annotations, configs.NewEmptyConfig(), map[string]*terraform.InputValue{})
+		runner, err := NewRunner(EmptyConfig(), tc.Annotations, configs.NewEmptyConfig(), map[string]*terraform.InputValue{})
+		if err != nil {
+			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
+		}
 
 		runner.EmitIssue(tc.Rule, tc.Message, tc.Location)
 

--- a/tflint/test-fixtures/config/config.hcl
+++ b/tflint/test-fixtures/config/config.hcl
@@ -4,9 +4,11 @@ config {
   force = true
 
   aws_credentials = {
-    access_key = "AWS_ACCESS_KEY"
-    secret_key = "AWS_SECRET_KEY"
-    region     = "us-east-1"
+    access_key              = "AWS_ACCESS_KEY"
+    secret_key              = "AWS_SECRET_KEY"
+    region                  = "us-east-1"
+    profile                 = "production"
+    shared_credentials_file = "~/.aws/myapp"
   }
 
   ignore_rule = {


### PR DESCRIPTION
Fixes #85 

This PR allows passing a credentials file path as an option. There are two ways:

## CLI flags

Added `--aws-creds-file` in CLI flags.

```
$ tflint --deep --aws-region us-east-1 --aws-profile default --aws-creds-file ~/.aws/creds
```

References to home directories are expanded automatically. Note that you need to specify the region and profile name. If not specified, the option is ignored. This issue is fixed by other pull requests.

## Config file

Added `shared_credentials_file` attribute.

```hcl
config {
  aws_credentials = {
    region                  = "us-east-1"
    profile                 = "default"
    shared_credentials_file = "~/.aws/creds"
  }
}
```