### PR TITLE
Get an AWS session in the same way as Terraform

### DIFF
--- a/client/test-fixtures/assume-role.tf
+++ b/client/test-fixtures/assume-role.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  assume_role {
+    role_arn     = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
+    session_name = "SESSION_NAME"
+    external_id  = "EXTERNAL_ID"
+  }
+}

--- a/client/test-fixtures/shared-creds.tf
+++ b/client/test-fixtures/shared-creds.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+    profile                 = "default"
+    shared_credentials_file = "~/.aws/creds"
+    region                  = "us-east-1"
+}

--- a/client/test-fixtures/static-creds.tf
+++ b/client/test-fixtures/static-creds.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+    access_key = "AWS_ACCESS_KEY"
+    secret_key = "AWS_SECRET_KEY"
+    region     = "us-east-1"
+}

--- a/docs/guides/credentials.md
+++ b/docs/guides/credentials.md
@@ -5,11 +5,14 @@ In [Deep checking](advanced.md#deep-checking), it is necessary to set provider's
 Credentials are used with the following priority:
 
 - Static credentials
+- Static credentials (Terraform)
+- Environment variables
 - Shared credentials
-- Environment credentials
-- Default shared credentials
+- Shared credentials (Terraform)
+- ECS and CodeBuild task roles
+- EC2 role
 
-## Static Credentials
+## Static credentials
 
 If you have an access key and a secret key, you can pass these keys like the following:
 
@@ -27,7 +30,17 @@ config {
 }
 ```
 
-## Shared Credentials
+Although there is not recommended, if an access key is hard-coded in a provider definition, they will also be taken into account. However, aliases are not supported. The priority is higher than the environment variable and lower than the above way.
+
+```hcl
+provider "aws" {
+  region     = "us-west-2"
+  access_key = "my-access-key"
+  secret_key = "my-secret-key"
+}
+```
+
+## Shared credentials
 
 If you have [shared credentials](https://aws.amazon.com/jp/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/), you can pass a profile name and credentials file path. If omitted, these will be `default` and `~/.aws/credentials`.
 
@@ -45,7 +58,17 @@ config {
 }
 ```
 
-## Environment Credentials
+If these configurations are defined in the provider block, they will also be taken into account. But the priority is lower than the above way.
+
+```hcl
+provider "aws" {
+  region                  = "us-west-2"
+  shared_credentials_file = "/Users/tf_user/.aws/creds"
+  profile                 = "customprofile"
+}
+```
+
+## Environment variables
 
 TFLint looks up `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` environment variables. This is useful when you don't want to explicitly pass credentials.
 
@@ -53,3 +76,7 @@ TFLint looks up `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` en
 $ export AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY
 $ export AWS_SECRET_ACCESS_KEY=AWS_SECRET_KEY
 ```
+
+## Role-based authentication
+
+TFLint fetches AWS credentials in the same way as Terraform. See [this documentation](https://www.terraform.io/docs/providers/aws/index.html#ecs-and-codebuild-task-roles) for role-based authentication. However, Assume role is not supported.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/fatih/color v1.7.0
 	github.com/golang/mock v1.3.1
 	github.com/google/go-cmp v0.3.0
+	github.com/hashicorp/aws-sdk-go-base v0.3.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce // indirect
 	github.com/hashicorp/hcl2 v0.0.0-20190702185634-5b39d9ff3a9a

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpg
 github.com/grpc-ecosystem/grpc-gateway v1.5.1/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/hashicorp/aws-sdk-go-base v0.2.0 h1:5bjZnWCvQg9Im5CHZr9t90IaFC4uvVlMl2fTh23IoCk=
 github.com/hashicorp/aws-sdk-go-base v0.2.0/go.mod h1:ZIWACGGi0N7a4DZbf15yuE1JQORmWLtBcVM6F5SXNFU=
+github.com/hashicorp/aws-sdk-go-base v0.3.0 h1:CPWKWCuOwpIFNsy8FUI9IT2QI7mGwgVPc4hrXW9I4L4=
+github.com/hashicorp/aws-sdk-go-base v0.3.0/go.mod h1:ZIWACGGi0N7a4DZbf15yuE1JQORmWLtBcVM6F5SXNFU=
 github.com/hashicorp/consul v0.0.0-20171026175957-610f3c86a089 h1:1eDpXAxTh0iPv+1kc9/gfSI2pxRERDsTk/lNGolwHn8=
 github.com/hashicorp/consul v0.0.0-20171026175957-610f3c86a089/go.mod h1:mFrjN1mfidgJfYP1xrJCF+AfRhr6Eaqhb2+sfyn/OOI=
 github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -50,9 +50,14 @@ func NewRunner(c *Config, ants map[string]Annotations, cfg *configs.Config, vari
 	}
 	log.Printf("[INFO] Initialize new runner for %s", path)
 
-	awsClient, err := client.NewAwsClient(c.AwsCredentials)
-	if err != nil {
-		return nil, err
+	awsClient := &client.AwsClient{}
+	var err error
+	if c.DeepCheck {
+		// FIXME: Alias providers are not considered
+		awsClient, err = client.NewAwsClient(cfg.Module.ProviderConfigs["aws"], c.AwsCredentials)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &Runner{
@@ -148,6 +153,8 @@ func NewModuleRunners(parent *Runner) ([]*Runner, error) {
 		if err != nil {
 			return runners, err
 		}
+		// Inherit parent's AwsClient
+		runner.AwsClient = parent.AwsClient
 		runners = append(runners, runner)
 		moudleRunners, err := NewModuleRunners(runner)
 		if err != nil {


### PR DESCRIPTION
Fixes #134 

This pull request introduces [`github.com/hashicorp/aws-sdk-go-base`](https://github.com/hashicorp/aws-sdk-go-base) and gets an AWS session in the same way as Terraform.

Also, it will take provider blocks in configuration files into account. For example, the following region settings are also propagated to TFLint, and redundant region settings are not required:

```hcl
provider "aws" {
  region = "us-east-1"
}
```

However, this results in changing the priority of the credentials. This is an incompatible change. For example, regions and static credentials in the configuration file have higher priority than environment variables, so you need to set static credentials as a TFLint configuration. See the changed documentation for the new priorities.

In addition, ECS (CodeBuild) task roles and EC2 roles were supported. Please note that Assume role is not supported.
