### PR TITLE
Bump terraform-provider-aws from v2.20.0 to v2.22.0

### DIFF
--- a/rules/awsrules/models/aws_secretsmanager_secret_invalid_policy.go
+++ b/rules/awsrules/models/aws_secretsmanager_secret_invalid_policy.go
@@ -23,7 +23,7 @@ func NewAwsSecretsmanagerSecretInvalidPolicyRule() *AwsSecretsmanagerSecretInval
 	return &AwsSecretsmanagerSecretInvalidPolicyRule{
 		resourceType:  "aws_secretsmanager_secret",
 		attributeName: "policy",
-		max:           4096,
+		max:           20480,
 		min:           1,
 	}
 }
@@ -60,7 +60,7 @@ func (r *AwsSecretsmanagerSecretInvalidPolicyRule) Check(runner *tflint.Runner) 
 			if len(val) > r.max {
 				runner.EmitIssue(
 					r,
-					"policy must be 4096 characters or less",
+					"policy must be 20480 characters or less",
 					attribute.Expr.Range(),
 				)
 			}

--- a/rules/awsrules/models/aws_secretsmanager_secret_version_invalid_secret_string.go
+++ b/rules/awsrules/models/aws_secretsmanager_secret_version_invalid_secret_string.go
@@ -22,7 +22,7 @@ func NewAwsSecretsmanagerSecretVersionInvalidSecretStringRule() *AwsSecretsmanag
 	return &AwsSecretsmanagerSecretVersionInvalidSecretStringRule{
 		resourceType:  "aws_secretsmanager_secret_version",
 		attributeName: "secret_string",
-		max:           7168,
+		max:           10240,
 	}
 }
 
@@ -58,7 +58,7 @@ func (r *AwsSecretsmanagerSecretVersionInvalidSecretStringRule) Check(runner *tf
 			if len(val) > r.max {
 				runner.EmitIssue(
 					r,
-					"secret_string must be 7168 characters or less",
+					"secret_string must be 10240 characters or less",
 					attribute.Expr.Range(),
 				)
 			}

--- a/rules/awsrules/models/aws_ssm_maintenance_window_target_invalid_resource_type.go
+++ b/rules/awsrules/models/aws_ssm_maintenance_window_target_invalid_resource_type.go
@@ -24,6 +24,7 @@ func NewAwsSsmMaintenanceWindowTargetInvalidResourceTypeRule() *AwsSsmMaintenanc
 		attributeName: "resource_type",
 		enum: []string{
 			"INSTANCE",
+			"RESOURCE_GROUP",
 		},
 	}
 }

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -3,8 +3,8 @@ module github.com/wata727/tflint/tools
 go 1.12
 
 require (
-	github.com/hashicorp/hcl2 v0.0.0-20190702185634-5b39d9ff3a9a
+	github.com/hashicorp/hcl2 v0.0.0-20190725010614-0c3fe388e450
 	github.com/hashicorp/terraform v0.12.6
 	github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516
-	github.com/terraform-providers/terraform-provider-aws v2.20.0+incompatible
+	github.com/terraform-providers/terraform-provider-aws v2.22.0+incompatible
 )

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -53,11 +53,8 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
 github.com/aws/aws-sdk-go v1.16.36/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.19.18/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.20.4/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.20.19 h1:RQDLGGlcffQzAceEXGdMu+uGGPGhNu+vNG3BrUZAMPI=
 github.com/aws/aws-sdk-go v1.20.19/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.20.21 h1:22vHWL9rur+SRTYPHAXlxJMFIA9OSYsYDIAHFDhQ7Z0=
-github.com/aws/aws-sdk-go v1.20.21/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.21.7 h1:ml+k7szyVaq4YD+3LhqOGl9tgMTqgMbpnuUSkB6UJvQ=
 github.com/aws/aws-sdk-go v1.21.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
@@ -266,7 +263,6 @@ github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb h1:ZbgmOQt8DOg796fi
 github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb/go.mod h1:h/Ru6tmZazX7WO/GDmwdpS975F019L4t5ng5IgwbNrE=
 github.com/hashicorp/terraform v0.12.0-alpha4.0.20190424121927-9327eedb0417/go.mod h1:A3NsI7WT87OMgpcD15cu6dK2YNpihchZp5fxUf8EHBg=
 github.com/hashicorp/terraform v0.12.0/go.mod h1:Ke0ig9gGZ8rhV6OddAhBYt5nXmpvXsuNQQ8w9qYBZfU=
-github.com/hashicorp/terraform v0.12.4/go.mod h1:R3nGcJpajl/k9hfg6Q/Mvj/mO9Zg4N2CuqXyGBFhjX0=
 github.com/hashicorp/terraform v0.12.5 h1:Z2FichOU9kUKWa8RBzwMXzPR1+vhAIstvdsrT8NgYwE=
 github.com/hashicorp/terraform v0.12.5/go.mod h1:79gUmnwZ6qMgdCF2RVlVjmIDnqrVROxsczBbmRirIQE=
 github.com/hashicorp/terraform v0.12.6 h1:mWItQdLZQ7f3kBYBu2Kgdg+E5iZb1KtCq73V10Hmu48=
@@ -473,8 +469,6 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d h1:Z4EH+5EffvBEhh37F0C0DnpklTMh00JOkjW5zK3ofBI=
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BSTlc8jOjh0niykqEGVXOLXdi9o0r0kR8tCYiMvjFgw=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/terraform-providers/terraform-provider-aws v2.20.0+incompatible h1:2lcY95v8QwTr0zU05t6Odqo6oCjtBdJpU0FnO2NlagM=
-github.com/terraform-providers/terraform-provider-aws v2.20.0+incompatible/go.mod h1:xsjWNY1dACAD8z7DLra9168ll7ggCrWG5MKSzEdR4dk=
 github.com/terraform-providers/terraform-provider-aws v2.22.0+incompatible h1:ixebL89WXMqiNhYGB7XJGAWqIBt/v6FGYedSt9GcaTY=
 github.com/terraform-providers/terraform-provider-aws v2.22.0+incompatible/go.mod h1:JdKn1ERRnxg9xUtGlSR7RgKDqE/8/3kSq6kBe//Cbao=
 github.com/terraform-providers/terraform-provider-openstack v1.15.0 h1:adpjqej+F8BAX9dHmuPF47sUIkgifeqBu6p7iCsyj0Y=

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -475,6 +475,8 @@ github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BST
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/terraform-providers/terraform-provider-aws v2.20.0+incompatible h1:2lcY95v8QwTr0zU05t6Odqo6oCjtBdJpU0FnO2NlagM=
 github.com/terraform-providers/terraform-provider-aws v2.20.0+incompatible/go.mod h1:xsjWNY1dACAD8z7DLra9168ll7ggCrWG5MKSzEdR4dk=
+github.com/terraform-providers/terraform-provider-aws v2.22.0+incompatible h1:ixebL89WXMqiNhYGB7XJGAWqIBt/v6FGYedSt9GcaTY=
+github.com/terraform-providers/terraform-provider-aws v2.22.0+incompatible/go.mod h1:JdKn1ERRnxg9xUtGlSR7RgKDqE/8/3kSq6kBe//Cbao=
 github.com/terraform-providers/terraform-provider-openstack v1.15.0 h1:adpjqej+F8BAX9dHmuPF47sUIkgifeqBu6p7iCsyj0Y=
 github.com/terraform-providers/terraform-provider-openstack v1.15.0/go.mod h1:2aQ6n/BtChAl1y2S60vebhyJyZXBsuAI5G4+lHrT1Ew=
 github.com/terraform-providers/terraform-provider-template v2.1.2+incompatible h1:imLvtj+kEr7z3xsHlHed+CAw4Z/mnlLYXfynKLv12SI=


### PR DESCRIPTION
- `aws_secretsmanager_secret_invalid_policy` rule
  - Increase the upper limit from 4096 to 20480
- `aws_secretsmanager_secret_version_invalid_secret_string ` rule
  - Increase the upper limit from 7168 to 10240
- `aws_ssm_maintenance_window_target_invalid_resource_type ` rule
  - Allow `RESOURCE_GROUP` as a valid type