### PR TITLE
Eval provider attributes

### DIFF
--- a/client/aws_test.go
+++ b/client/aws_test.go
@@ -1,23 +1,92 @@
 package client
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	awsbase "github.com/hashicorp/aws-sdk-go-base"
-	"github.com/hashicorp/hcl2/hcl"
-	"github.com/hashicorp/hcl2/hclparse"
-	"github.com/hashicorp/terraform/configs"
 	homedir "github.com/mitchellh/go-homedir"
 )
 
-func Test_getBaseConfig(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
+func Test_Merge(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Self     AwsCredentials
+		Other    AwsCredentials
+		Expected AwsCredentials
+	}{
+		{
+			Name: "self is empty",
+			Self: AwsCredentials{},
+			Other: AwsCredentials{
+				AccessKey: "AWS_ACCESS_KEY",
+				SecretKey: "AWS_SECRET_KEY",
+				Profile:   "default",
+				CredsFile: "~/.aws/creds",
+				Region:    "us-east-1",
+			},
+			Expected: AwsCredentials{
+				AccessKey: "AWS_ACCESS_KEY",
+				SecretKey: "AWS_SECRET_KEY",
+				Profile:   "default",
+				CredsFile: "~/.aws/creds",
+				Region:    "us-east-1",
+			},
+		},
+		{
+			Name: "other is empty",
+			Self: AwsCredentials{
+				AccessKey: "AWS_ACCESS_KEY_2",
+				SecretKey: "AWS_SECRET_KEY_2",
+				Profile:   "staging",
+				CredsFile: "~/.aws/creds_stg",
+				Region:    "ap-northeast-1",
+			},
+			Other: AwsCredentials{},
+			Expected: AwsCredentials{
+				AccessKey: "AWS_ACCESS_KEY_2",
+				SecretKey: "AWS_SECRET_KEY_2",
+				Profile:   "staging",
+				CredsFile: "~/.aws/creds_stg",
+				Region:    "ap-northeast-1",
+			},
+		},
+		{
+			Name: "merged",
+			Self: AwsCredentials{
+				AccessKey: "AWS_ACCESS_KEY_2",
+				SecretKey: "AWS_SECRET_KEY_2",
+				Profile:   "staging",
+				CredsFile: "~/.aws/creds_stg",
+				Region:    "ap-northeast-1",
+			},
+			Other: AwsCredentials{
+				AccessKey: "AWS_ACCESS_KEY",
+				SecretKey: "AWS_SECRET_KEY",
+				Profile:   "default",
+				CredsFile: "~/.aws/creds",
+				Region:    "us-east-1",
+			},
+			Expected: AwsCredentials{
+				AccessKey: "AWS_ACCESS_KEY",
+				SecretKey: "AWS_SECRET_KEY",
+				Profile:   "default",
+				CredsFile: "~/.aws/creds",
+				Region:    "us-east-1",
+			},
+		},
 	}
+
+	for _, tc := range cases {
+		ret := tc.Self.Merge(tc.Other)
+		if !cmp.Equal(tc.Expected, ret) {
+			t.Fatalf("Failed `%s` test: Diff=%s", tc.Name, cmp.Diff(tc.Expected, ret))
+		}
+	}
+}
+
+func Test_getBaseConfig(t *testing.T) {
 	home, err := homedir.Expand("~/")
 	if err != nil {
 		t.Fatal(err)
@@ -26,7 +95,6 @@ func Test_getBaseConfig(t *testing.T) {
 	cases := []struct {
 		Name     string
 		Creds    AwsCredentials
-		File     string
 		Expected *awsbase.Config
 	}{
 		{
@@ -55,86 +123,10 @@ func Test_getBaseConfig(t *testing.T) {
 				Region:        "us-east-1",
 			},
 		},
-		{
-			Name: "static credentials provider",
-			File: "static-creds.tf",
-			Expected: &awsbase.Config{
-				AccessKey: "AWS_ACCESS_KEY",
-				SecretKey: "AWS_SECRET_KEY",
-				Region:    "us-east-1",
-			},
-		},
-		{
-			Name: "shared credentials provider",
-			File: "shared-creds.tf",
-			Expected: &awsbase.Config{
-				Profile:       "default",
-				CredsFilename: filepath.Join(home, ".aws", "creds"),
-				Region:        "us-east-1",
-			},
-		},
-		{
-			Name:     "assume role provider",
-			File:     "assume-role.tf",
-			Expected: &awsbase.Config{},
-		},
-		{
-			Name: "prefer tflint static credentials over provider",
-			File: "static-creds.tf",
-			Creds: AwsCredentials{
-				AccessKey: "TFLINT_AWS_ACCESS_KEY",
-				SecretKey: "TFLINT_AWS_SECRET_KEY",
-				Region:    "us-east-2",
-			},
-			Expected: &awsbase.Config{
-				AccessKey: "TFLINT_AWS_ACCESS_KEY",
-				SecretKey: "TFLINT_AWS_SECRET_KEY",
-				Region:    "us-east-2",
-			},
-		},
-		{
-			Name: "prefer tflint shared credentials over provider",
-			File: "shared-creds.tf",
-			Creds: AwsCredentials{
-				Profile:   "terraform",
-				CredsFile: "~/.aws/tf_credentials",
-				Region:    "us-east-2",
-			},
-			Expected: &awsbase.Config{
-				Profile:       "terraform",
-				CredsFilename: filepath.Join(home, ".aws", "tf_credentials"),
-				Region:        "us-east-2",
-			},
-		},
 	}
 
 	for _, tc := range cases {
-		var pc *configs.Provider
-		if tc.File != "" {
-			parser := hclparse.NewParser()
-			f, diags := parser.ParseHCLFile(filepath.Join(currentDir, "test-fixtures", tc.File))
-			if diags.HasErrors() {
-				t.Fatal(diags)
-			}
-
-			body, _, diags := f.Body.PartialContent(&hcl.BodySchema{
-				Blocks: []hcl.BlockHeaderSchema{
-					{
-						Type:       "provider",
-						LabelNames: []string{"name"},
-					},
-				},
-			})
-			if diags.HasErrors() {
-				t.Fatal(diags)
-			}
-
-			pc = &configs.Provider{
-				Config: body.Blocks[0].Body,
-			}
-		}
-
-		base, err := getBaseConfig(pc, tc.Creds)
+		base, err := getBaseConfig(tc.Creds)
 		if err != nil {
 			t.Fatalf("Failed `%s` test: Unexpected error occurred: %s", tc.Name, err)
 		}

--- a/client/test-fixtures/assume-role.tf
+++ b/client/test-fixtures/assume-role.tf
@@ -1,7 +1,0 @@
-provider "aws" {
-  assume_role {
-    role_arn     = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
-    session_name = "SESSION_NAME"
-    external_id  = "EXTERNAL_ID"
-  }
-}

--- a/client/test-fixtures/shared-creds.tf
+++ b/client/test-fixtures/shared-creds.tf
@@ -1,5 +1,0 @@
-provider "aws" {
-    profile                 = "default"
-    shared_credentials_file = "~/.aws/creds"
-    region                  = "us-east-1"
-}

--- a/client/test-fixtures/static-creds.tf
+++ b/client/test-fixtures/static-creds.tf
@@ -1,5 +1,0 @@
-provider "aws" {
-    access_key = "AWS_ACCESS_KEY"
-    secret_key = "AWS_SECRET_KEY"
-    region     = "us-east-1"
-}

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -119,22 +119,7 @@ func (c *Config) Merge(other *Config) *Config {
 		ret.Force = true
 	}
 
-	if other.AwsCredentials.AccessKey != "" {
-		ret.AwsCredentials.AccessKey = other.AwsCredentials.AccessKey
-	}
-	if other.AwsCredentials.SecretKey != "" {
-		ret.AwsCredentials.SecretKey = other.AwsCredentials.SecretKey
-	}
-	if other.AwsCredentials.Profile != "" {
-		ret.AwsCredentials.Profile = other.AwsCredentials.Profile
-	}
-	if other.AwsCredentials.CredsFile != "" {
-		ret.AwsCredentials.CredsFile = other.AwsCredentials.CredsFile
-	}
-	if other.AwsCredentials.Region != "" {
-		ret.AwsCredentials.Region = other.AwsCredentials.Region
-	}
-
+	ret.AwsCredentials = ret.AwsCredentials.Merge(other.AwsCredentials)
 	ret.IgnoreModule = mergeBoolMap(ret.IgnoreModule, other.IgnoreModule)
 	ret.IgnoreRule = mergeBoolMap(ret.IgnoreRule, other.IgnoreRule)
 	ret.Varfile = append(ret.Varfile, other.Varfile...)

--- a/tflint/provider.go
+++ b/tflint/provider.go
@@ -1,0 +1,59 @@
+package tflint
+
+import (
+	"log"
+
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/terraform/configs"
+)
+
+// ProviderConfig represents a provider block with an eval context (runner)
+type ProviderConfig struct {
+	tfProvider *configs.Provider
+	runner     *Runner
+	attributes hcl.Attributes
+	blocks     hcl.Blocks
+}
+
+// NewProviderConfig returns a provider config from the given `configs.Provider` and runner
+func NewProviderConfig(tfProvider *configs.Provider, runner *Runner, schema *hcl.BodySchema) (*ProviderConfig, error) {
+	providerConfig := &ProviderConfig{
+		tfProvider: tfProvider,
+		runner:     runner,
+		attributes: map[string]*hcl.Attribute{},
+		blocks:     []*hcl.Block{},
+	}
+
+	if tfProvider != nil {
+		content, _, diags := tfProvider.Config.PartialContent(schema)
+		if diags.HasErrors() {
+			return nil, diags
+		}
+
+		providerConfig.attributes = content.Attributes
+		providerConfig.blocks = content.Blocks
+	}
+
+	return providerConfig, nil
+}
+
+// Get returns a value corresponding to the given key
+// It should be noted that the value is evaluated if it is evaluable
+// The second return value is a flag that determines whether a value exists
+// We assume the provider has only simple attributes, so it just returns string
+func (p *ProviderConfig) Get(key string) (string, bool, error) {
+	attribute, exists := p.attributes[key]
+	if !exists {
+		log.Printf("[INFO] `%s` is not found in the provider block.", key)
+		return "", false, nil
+	}
+
+	var val string
+	err := p.runner.EvaluateExpr(attribute.Expr, &val)
+
+	err = p.runner.EnsureNoError(err, func() error { return nil })
+	if err != nil {
+		return "", true, err
+	}
+	return val, true, nil
+}

--- a/tflint/provider_test.go
+++ b/tflint/provider_test.go
@@ -1,0 +1,150 @@
+package tflint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/wata727/tflint/client"
+)
+
+func Test_Get(t *testing.T) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "provider_config"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loader, err := NewLoader(EmptyConfig())
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+	cfg, err := loader.LoadConfig(".")
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+
+	runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+	if err != nil {
+		t.Fatalf("Unexpected error occrred: %s", err)
+	}
+
+	providerConfig, err := NewProviderConfig(
+		runner.TFConfig.Module.ProviderConfigs["aws"],
+		runner,
+		client.AwsProviderBlockSchema,
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error occrred: %s", err)
+	}
+
+	cases := []struct {
+		Key    string
+		Value  string
+		Exists bool
+		Err    error
+	}{
+		{
+			Key:    "access_key",
+			Value:  "AWS_ACCESS_KEY",
+			Exists: true,
+			Err:    nil,
+		},
+		{
+			Key:    "secret_key",
+			Value:  "",
+			Exists: true,
+			Err:    nil,
+		},
+		{
+			Key:    "region",
+			Value:  "us-east-1",
+			Exists: true,
+			Err:    nil,
+		},
+		{
+			Key:    "profile",
+			Value:  "",
+			Exists: true,
+			Err:    nil,
+		},
+		{
+			Key:    "shared_credentials_file",
+			Value:  "",
+			Exists: true,
+			Err:    nil,
+		},
+		{
+			Key:    "undefined",
+			Value:  "",
+			Exists: false,
+			Err:    nil,
+		},
+	}
+
+	for _, tc := range cases {
+		val, exists, err := providerConfig.Get(tc.Key)
+		if val != tc.Value {
+			t.Fatalf("Expected `%s` as the key value of `%s`, but got `%s`", tc.Value, tc.Key, val)
+		}
+		if exists != tc.Exists {
+			t.Fatalf("Expected `%t` as the exists, but got `%t`", tc.Exists, exists)
+		}
+		if err != tc.Err {
+			t.Fatalf("Expected `%s` as the error, but got `%s`", tc.Err, err)
+		}
+	}
+}
+
+func Test_Get_withEmptyProvider(t *testing.T) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir)
+
+	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "provider_config"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loader, err := NewLoader(EmptyConfig())
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+	cfg, err := loader.LoadConfig(".")
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+
+	runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+	if err != nil {
+		t.Fatalf("Unexpected error occrred: %s", err)
+	}
+
+	providerConfig, err := NewProviderConfig(
+		nil,
+		runner,
+		client.AwsProviderBlockSchema,
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error occrred: %s", err)
+	}
+
+	val, exists, err := providerConfig.Get("key")
+	if val != "" {
+		t.Fatalf("Expected empty string, but got `%s`", val)
+	}
+	if exists {
+		t.Fatal("Expected not exists, but exists")
+	}
+	if err != nil {
+		t.Fatalf("Expected to return nil, but got `%s`", err)
+	}
+}

--- a/tflint/test-fixtures/provider_config/main.tf
+++ b/tflint/test-fixtures/provider_config/main.tf
@@ -1,0 +1,15 @@
+variable "secret_key" {}
+
+variable "region" {
+    default = "us-east-1"
+}
+
+provider "aws" {
+    access_key = "AWS_ACCESS_KEY"
+    secret_key = var.secret_key
+    region     = var.region
+    profile    = null
+    shared_credentials_file = null_resource.foo.bar
+}
+
+resource "null_resource" "foo" {}


### PR DESCRIPTION
Fixes #392 
See also #361 

There is a bug that returned an error when using a variable in the `provider` block attributes.

This pull request introduces `ProviderConfig` that contains the evaluation context. the `ProviderConfig` can be converted into `AwsCredentials` and initializes the client based on the credentials merged with TFLint's config.
