### PR TITLE
Fix values for excess_capacity_termination_policy

### DIFF
--- a/rules/awsrules/models/aws_spot_fleet_request_invalid_excess_capacity_termination_policy.go
+++ b/rules/awsrules/models/aws_spot_fleet_request_invalid_excess_capacity_termination_policy.go
@@ -23,8 +23,8 @@ func NewAwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule() *AwsSpot
 		resourceType:  "aws_spot_fleet_request",
 		attributeName: "excess_capacity_termination_policy",
 		enum: []string{
-			"no-termination",
-			"termination",
+			"Default",
+			"NoTermination",
 		},
 	}
 }


### PR DESCRIPTION
The values the Terraform provider accepts are ["Default" and
"NoTermination"][spot_fleet_request_code].

[spot_fleet_request_code]: https://github.com/terraform-providers/terraform-provider-aws/blob/3f4ae7f126a63642e443d5e9ff09e8cec47823f9/aws/resource_aws_spot_fleet_request.go#L319-L320