### PR TITLE
Bump terraform-provider-aws from v2.24.0 to v2.25.0

### DIFF
--- a/docs/guides/compatibility.md
+++ b/docs/guides/compatibility.md
@@ -3,7 +3,7 @@
 Some inspections implicitly assume the behavior of a specific version of provider plugins or Terraform. This always assumes the latest version and is as follows:
 
 - Terraform v0.12.6
-- AWS Provider v2.24.0
+- AWS Provider v2.25.0
 
 Of course, TFLint may work correctly if you run it on other versions. But, false positives/negatives can occur based on this assumption.
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -3,8 +3,8 @@ module github.com/wata727/tflint/tools
 go 1.12
 
 require (
-	github.com/hashicorp/hcl2 v0.0.0-20190725010614-0c3fe388e450
+	github.com/hashicorp/hcl2 v0.0.0-20190821123243-0c888d1241f6
 	github.com/hashicorp/terraform v0.12.7
 	github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516
-	github.com/terraform-providers/terraform-provider-aws v2.24.0+incompatible
+	github.com/terraform-providers/terraform-provider-aws v2.25.0+incompatible
 )

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -123,6 +123,7 @@ github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dT
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-toolsmith/astcast v1.0.0/go.mod h1:mt2OdQTeAQcY4DQgPSArJjHCcOwlX+Wl/kwN+LbLGQ4=
 github.com/go-toolsmith/astcopy v1.0.0/go.mod h1:vrgyG+5Bxrnz4MZWPF+pI4R8h3qKRjjyvV/DSez4WVQ=
@@ -337,6 +338,7 @@ github.com/kubernetes-sigs/aws-iam-authenticator v0.3.1-0.20181019024009-82544ec
 github.com/kubernetes-sigs/aws-iam-authenticator v0.3.1-0.20181019024009-82544ec86140/go.mod h1:ItxiN33Ho7Di8wiC4S4XqbH1NLF0DNdDWOd/5MI9gJU=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -509,14 +511,14 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d h1:Z4EH+5EffvBEhh37F0C0DnpklTMh00JOkjW5zK3ofBI=
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BSTlc8jOjh0niykqEGVXOLXdi9o0r0kR8tCYiMvjFgw=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/terraform-providers/terraform-provider-aws v2.24.0+incompatible h1:huJmrQ5Tqnqxvnp1ETZEkLpliZT6w+9AhiOgT0AJ1SM=
-github.com/terraform-providers/terraform-provider-aws v2.24.0+incompatible/go.mod h1:X0CYCk8+8mp3JkPFKCW2AVH7qgomVoOTDI1CProJ494=
+github.com/terraform-providers/terraform-provider-aws v2.25.0+incompatible h1:/ImYAqN3vkmo2byaAezwTt5dW+9jKaFk8183ad7lcG8=
+github.com/terraform-providers/terraform-provider-aws v2.25.0+incompatible/go.mod h1:Yc+SQyXHUSQkxM3hi7lzaOnD5uu21v0xNyVMcOGsj9Y=
 github.com/terraform-providers/terraform-provider-openstack v1.15.0 h1:adpjqej+F8BAX9dHmuPF47sUIkgifeqBu6p7iCsyj0Y=
 github.com/terraform-providers/terraform-provider-openstack v1.15.0/go.mod h1:2aQ6n/BtChAl1y2S60vebhyJyZXBsuAI5G4+lHrT1Ew=
 github.com/terraform-providers/terraform-provider-template v2.1.2+incompatible h1:imLvtj+kEr7z3xsHlHed+CAw4Z/mnlLYXfynKLv12SI=
 github.com/terraform-providers/terraform-provider-template v2.1.2+incompatible/go.mod h1:Y+/1GV1sOgHNxzYdkkGb9Cz/FNk8W4/Gb5+Phf1CNU8=
-github.com/terraform-providers/terraform-provider-tls v2.0.1+incompatible h1:LzJFW5XFadz/4K/lUSTjN2/TrQM5QZtJxrzz50z4yLY=
-github.com/terraform-providers/terraform-provider-tls v2.0.1+incompatible/go.mod h1:L5wzhvGcKGSSnpY/Oq9zKRk8cwgrvurqiJu00Eu50cA=
+github.com/terraform-providers/terraform-provider-tls v2.1.0+incompatible h1:/6+8oPw6h3gNs9FhaWCtAP3rzpFrOuxoCD4tBfr9p2g=
+github.com/terraform-providers/terraform-provider-tls v2.1.0+incompatible/go.mod h1:kurQaP6D5IY4ig4K7EhQchbY/0Q1jZBeOGi4IrWDdJc=
 github.com/timakin/bodyclose v0.0.0-20190407043127-4a873e97b2bb/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v0.0.0-20180813092308-00b869d2f4a5 h1:cMjKdf4PxEBN9K5HaD9UMW8gkTbM0kMzkTa9SJe0WNQ=


### PR DESCRIPTION
No changes because the version of aws-sdk on which the provider depends does not change