### PR TITLE
Remove `--quiet` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ Application Options:
       --aws-creds-file=FILE                 AWS shared credentials file path used in deep checking
       --aws-region=REGION                   AWS region used in deep check mode
       --force                               Return zero exit status even if issues found
-  -q, --quiet                               Do not output any message when no issues are found (default format only)
 
 Help Options:
   -h, --help                                Show this help message

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -55,6 +55,9 @@ func (cli *CLI) Run(args []string) int {
 		if option == "error-with-issues" {
 			return []string{}, errors.New("`error-with-issues` option was removed in v0.9.0. The behavior is now default")
 		}
+		if option == "quiet" || option == "q" {
+			return []string{}, errors.New("`quiet` option was removed in v0.11.0. The behavior is now default")
+		}
 		return []string{}, fmt.Errorf("`%s` is unknown option. Please run `tflint --help`", option)
 	}
 	// Parse commandline flag
@@ -64,7 +67,6 @@ func (cli *CLI) Run(args []string) int {
 		Stdout: cli.outStream,
 		Stderr: cli.errStream,
 		Format: opts.Format,
-		Quiet:  opts.Quiet,
 	}
 	if err != nil {
 		if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -59,12 +59,6 @@ func TestCLIRun__noIssuesFound(t *testing.T) {
 			Stdout:  "",
 		},
 		{
-			Name:    "`--quiet` option",
-			Command: "./tflint --quiet",
-			Status:  ExitCodeOK,
-			Stdout:  "", // TODO: Remove this option
-		},
-		{
 			Name:    "loading errors are occurred",
 			Command: "./tflint",
 			LoadErr: errors.New("Load error occurred"),
@@ -88,6 +82,12 @@ func TestCLIRun__noIssuesFound(t *testing.T) {
 			Command: "./tflint --error-with-issues",
 			Status:  ExitCodeError,
 			Stderr:  "`error-with-issues` option was removed in v0.9.0. The behavior is now default",
+		},
+		{
+			Name:    "removed `--quiet` option",
+			Command: "./tflint --quiet",
+			Status:  ExitCodeError,
+			Stderr:  "`quiet` option was removed in v0.11.0. The behavior is now default",
 		},
 		{
 			Name:    "invalid options",
@@ -215,13 +215,6 @@ func TestCLIRun__issuesFound(t *testing.T) {
 			Command: "./tflint --force",
 			Rule:    &testRule{},
 			Status:  ExitCodeOK,
-			Stdout:  fmt.Sprintf("%s (test_rule)", color.New(color.Bold).Sprint("This is test error")),
-		},
-		{
-			Name:    "`--quiet` option",
-			Command: "./tflint --quiet",
-			Rule:    &testRule{},
-			Status:  ExitCodeIssuesFound,
 			Stdout:  fmt.Sprintf("%s (test_rule)", color.New(color.Bold).Sprint("This is test error")),
 		},
 		{

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -25,7 +25,6 @@ type Options struct {
 	AwsCredsFile string   `long:"aws-creds-file" description:"AWS shared credentials file path used in deep checking" value-name:"FILE"`
 	AwsRegion    string   `long:"aws-region" description:"AWS region used in deep check mode" value-name:"REGION"`
 	Force        bool     `long:"force" description:"Return zero exit status even if issues found"`
-	Quiet        bool     `short:"q" long:"quiet" description:"Do not output any message when no issues are found (default format only)"`
 }
 
 func (opts *Options) toConfig() *tflint.Config {

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -12,7 +12,6 @@ type Formatter struct {
 	Stdout io.Writer
 	Stderr io.Writer
 	Format string
-	Quiet  bool
 }
 
 // Print outputs the given issues and errors according to configured format


### PR DESCRIPTION
See #407 

This behavior is the default for new output formats.