### PR TITLE
Add `--no-color` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Application Options:
       --aws-creds-file=FILE                 AWS shared credentials file path used in deep checking
       --aws-region=REGION                   AWS region used in deep check mode
       --force                               Return zero exit status even if issues found
+      --no-color                            Disable colorized output
 
 Help Options:
   -h, --help                                Show this help message

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/fatih/color"
 	flags "github.com/jessevdk/go-flags"
 	"github.com/spf13/afero"
 
@@ -69,6 +70,11 @@ func (cli *CLI) Run(args []string) int {
 		Stderr: cli.errStream,
 		Format: opts.Format,
 	}
+	if opts.NoColor {
+		color.NoColor = true
+		formatter.NoColor = true
+	}
+
 	if err != nil {
 		if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {
 			fmt.Fprintln(cli.outStream, err)

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -218,6 +218,13 @@ func TestCLIRun__issuesFound(t *testing.T) {
 			Stdout:  fmt.Sprintf("%s (test_rule)", color.New(color.Bold).Sprint("This is test error")),
 		},
 		{
+			Name:    "`--no-color` option",
+			Command: "./tflint --no-color",
+			Rule:    &testRule{},
+			Status:  ExitCodeIssuesFound,
+			Stdout:  "This is test error (test_rule)",
+		},
+		{
 			Name:    "checking errors are occurred",
 			Command: "./tflint",
 			Rule:    &errorRule{},

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -25,6 +25,7 @@ type Options struct {
 	AwsCredsFile string   `long:"aws-creds-file" description:"AWS shared credentials file path used in deep checking" value-name:"FILE"`
 	AwsRegion    string   `long:"aws-region" description:"AWS region used in deep check mode" value-name:"REGION"`
 	Force        bool     `long:"force" description:"Return zero exit status even if issues found"`
+	NoColor      bool     `long:"no-color" description:"Disable colorized output"`
 }
 
 func (opts *Options) toConfig() *tflint.Config {

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -9,9 +9,10 @@ import (
 
 // Formatter outputs appropriate results to stdout and stderr depending on the format
 type Formatter struct {
-	Stdout io.Writer
-	Stderr io.Writer
-	Format string
+	Stdout  io.Writer
+	Stderr  io.Writer
+	Format  string
+	NoColor bool
 }
 
 // Print outputs the given issues and errors according to configured format

--- a/formatter/pretty.go
+++ b/formatter/pretty.go
@@ -90,7 +90,7 @@ func (f *Formatter) printErrors(err *tflint.Error, sources map[string][]byte) {
 	if diags, ok := err.Cause.(hcl.Diagnostics); ok {
 		fmt.Fprintf(f.Stderr, "%s. %d error(s) occurred:\n\n", err.Message, len(diags.Errs()))
 
-		writer := hcl.NewDiagnosticTextWriter(f.Stderr, parseSources(sources), 0, true)
+		writer := hcl.NewDiagnosticTextWriter(f.Stderr, parseSources(sources), 0, !f.NoColor)
 		writer.WriteDiagnostics(diags)
 	} else {
 		fmt.Fprintf(f.Stderr, "%s. An error occurred:\n\n", err.Message)


### PR DESCRIPTION
The new output format includes a lot of colors, so it provides a `--no-color` option for users who cannot use it.