### PR TITLE
Refactoring tests

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	flags "github.com/jessevdk/go-flags"
+	"github.com/spf13/afero"
 
 	"github.com/wata727/tflint/formatter"
 	"github.com/wata727/tflint/project"
@@ -96,7 +97,7 @@ func (cli *CLI) Run(args []string) int {
 
 	// Load Terraform's configurations
 	if !cli.testMode {
-		cli.loader, err = tflint.NewLoader(cfg)
+		cli.loader, err = tflint.NewLoader(afero.Afero{Fs: afero.NewOsFs()}, cfg)
 		if err != nil {
 			formatter.Print(tflint.Issues{}, tflint.NewContextError("Failed to prepare loading", err), map[string][]byte{})
 			return ExitCodeError

--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,6 @@ require (
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/mattn/go-colorable v0.1.2
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/spf13/afero v1.2.1
 	github.com/zclconf/go-cty v1.0.1-0.20190708163926-19588f92a98f
 )

--- a/go.mod
+++ b/go.mod
@@ -19,3 +19,6 @@ require (
 	github.com/spf13/afero v1.2.1
 	github.com/zclconf/go-cty v1.0.1-0.20190708163926-19588f92a98f
 )
+
+// Override since git.apache.org is down
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999

--- a/go.sum
+++ b/go.sum
@@ -7,7 +7,6 @@ dmitri.shuralyov.com/app/changes v0.0.0-20180602232624-0a106ad413e3/go.mod h1:Yl
 dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBrvjyP0v+ecvNYvCpyZgu5/xkfAUhi6wJj28eUfSU=
 dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1:a1inKt/atXimZ4Mv927x+r7UpyzRUf4emIoiiSC2TN4=
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
-git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/Azure/azure-sdk-for-go v21.3.0+incompatible h1:YFvAka2WKAl2xnJkYV1e1b7E2z88AgFszDzWU18ejMY=
 github.com/Azure/azure-sdk-for-go v21.3.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v10.15.4+incompatible h1:q+DRrRdbCnkY7f2WxQBx58TwCGkEdMAK/hkZ10g0Pzk=
@@ -37,6 +36,7 @@ github.com/aliyun/aliyun-tablestore-go-sdk v4.1.2+incompatible/go.mod h1:LDQHRZy
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antchfx/xpath v0.0.0-20190129040759-c8489ed3251e/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
 github.com/antchfx/xquery v0.0.0-20180515051857-ad5b8c7a47b0/go.mod h1:LzD22aAzDP8/dyiCKFp31He4m2GPjl0AFyzDtZzUu9M=
+github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apparentlymart/go-cidr v1.0.0 h1:lGDvXx8Lv9QHjrAVP7jyzleG4F9+FkRhJcEsDFxeb8w=
 github.com/apparentlymart/go-cidr v1.0.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=

--- a/rules/awsrules/aws_db_instance_default_parameter_group_test.go
+++ b/rules/awsrules/aws_db_instance_default_parameter_group_test.go
@@ -1,16 +1,9 @@
 package awsrules
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl2/hcl"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -48,59 +41,15 @@ resource "aws_db_instance" "db" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDBInstanceDefaultParameterGroup")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDBInstanceDefaultParameterGroupRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDBInstanceDefaultParameterGroupRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDBInstanceDefaultParameterGroupRule{}),
-			cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/aws_db_instance_invalid_type_test.go
+++ b/rules/awsrules/aws_db_instance_invalid_type_test.go
@@ -1,16 +1,9 @@
 package awsrules
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl2/hcl"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -48,59 +41,15 @@ resource "aws_db_instance" "mysql" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDBInstanceInvalidType")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDBInstanceInvalidTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDBInstanceInvalidTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDBInstanceInvalidTypeRule{}),
-			cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/aws_db_instance_previous_type_test.go
+++ b/rules/awsrules/aws_db_instance_previous_type_test.go
@@ -1,16 +1,9 @@
 package awsrules
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl2/hcl"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -48,59 +41,15 @@ resource "aws_db_instance" "mysql" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDBInstancePreviousType")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDBInstancePreviousTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDBInstancePreviousTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDBInstancePreviousTypeRule{}),
-			cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/aws_elasticache_cluster_default_parameter_group_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_default_parameter_group_test.go
@@ -1,16 +1,9 @@
 package awsrules
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl2/hcl"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -48,59 +41,15 @@ resource "aws_elasticache_cluster" "cache" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsElasticacheClusterDefaultParameterGroup")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsElastiCacheClusterDefaultParameterGroupRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsElastiCacheClusterDefaultParameterGroupRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsElastiCacheClusterDefaultParameterGroupRule{}),
-			cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/aws_elasticache_cluster_invalid_type_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_invalid_type_test.go
@@ -1,16 +1,9 @@
 package awsrules
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl2/hcl"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -48,59 +41,15 @@ resource "aws_elasticache_cluster" "redis" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsElastiCacheClusterInvalidType")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsElastiCacheClusterInvalidTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsElastiCacheClusterInvalidTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsElastiCacheClusterInvalidTypeRule{}),
-			cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/aws_elasticache_cluster_previous_type_test.go
+++ b/rules/awsrules/aws_elasticache_cluster_previous_type_test.go
@@ -1,16 +1,9 @@
 package awsrules
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl2/hcl"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -48,59 +41,15 @@ resource "aws_elasticache_cluster" "redis" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsElastiCacheClusterPreviousType")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsElastiCacheClusterPreviousTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsElastiCacheClusterPreviousTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsElastiCacheClusterPreviousTypeRule{}),
-			cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/aws_instance_invalid_ami_test.go
+++ b/rules/awsrules/aws_instance_invalid_ami_test.go
@@ -2,73 +2,26 @@ package awsrules
 
 import (
 	"errors"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl2/hcl"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/client"
 	"github.com/wata727/tflint/tflint"
 )
 
 func Test_AwsInstanceInvalidAMI_invalid(t *testing.T) {
-	dir, err := ioutil.TempDir("", "AwsInstanceInvalidAMI_invalid")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	loader, err := configload.NewLoader(&configload.Config{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	content := `
 resource "aws_instance" "invalid" {
 	ami = "ami-1234abcd"
 }`
-	err = ioutil.WriteFile(dir+"/instances.tf", []byte(content), os.ModePerm)
-	if err != nil {
-		t.Fatal(err)
-	}
+	runner := tflint.TestRunner(t, map[string]string{"instances.tf": content})
 
-	mod, diags := loader.Parser().LoadConfigDir(".")
-	if diags.HasErrors() {
-		t.Fatal(diags)
-	}
-	cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-	if tfdiags.HasErrors() {
-		t.Fatal(tfdiags)
-	}
-
-	runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	rule := NewAwsInstanceInvalidAMIRule()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
 	ec2mock := client.NewMockEC2API(ctrl)
 	ec2mock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{
@@ -78,7 +31,8 @@ resource "aws_instance" "invalid" {
 	}, nil)
 	runner.AwsClient.EC2 = ec2mock
 
-	if err = rule.Check(runner); err != nil {
+	rule := NewAwsInstanceInvalidAMIRule()
+	if err := rule.Check(runner); err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
 
@@ -93,64 +47,18 @@ resource "aws_instance" "invalid" {
 			},
 		},
 	}
-	opts := []cmp.Option{
-		cmpopts.IgnoreUnexported(AwsInstanceInvalidAMIRule{}),
-		cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
-	}
-	if !cmp.Equal(expected, runner.Issues, opts...) {
-		t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(expected, runner.Issues, opts...))
-	}
+	tflint.AssertIssues(t, expected, runner.Issues)
 }
 
 func Test_AwsInstanceInvalidAMI_valid(t *testing.T) {
-	dir, err := ioutil.TempDir("", "AwsInstanceInvalidAMI_invalid")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	loader, err := configload.NewLoader(&configload.Config{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	content := `
 resource "aws_instance" "valid" {
 	ami = "ami-9ad76sd1"
 }`
-	err = ioutil.WriteFile(dir+"/instances.tf", []byte(content), os.ModePerm)
-	if err != nil {
-		t.Fatal(err)
-	}
+	runner := tflint.TestRunner(t, map[string]string{"instances.tf": content})
 
-	mod, diags := loader.Parser().LoadConfigDir(".")
-	if diags.HasErrors() {
-		t.Fatal(diags)
-	}
-	cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-	if tfdiags.HasErrors() {
-		t.Fatal(tfdiags)
-	}
-
-	runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	rule := NewAwsInstanceInvalidAMIRule()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
 	ec2mock := client.NewMockEC2API(ctrl)
 	ec2mock.EXPECT().DescribeImages(&ec2.DescribeImagesInput{
@@ -164,25 +72,22 @@ resource "aws_instance" "valid" {
 	}, nil)
 	runner.AwsClient.EC2 = ec2mock
 
-	if err = rule.Check(runner); err != nil {
+	rule := NewAwsInstanceInvalidAMIRule()
+	if err := rule.Check(runner); err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
 
 	expected := tflint.Issues{}
-	if !cmp.Equal(expected, runner.Issues) {
-		t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(expected, runner.Issues))
-	}
+	tflint.AssertIssues(t, expected, runner.Issues)
 }
 
 func Test_AwsInstanceInvalidAMI_error(t *testing.T) {
 	cases := []struct {
-		Name       string
-		Content    string
-		Request    *ec2.DescribeImagesInput
-		Response   error
-		ErrorCode  int
-		ErrorLevel int
-		ErrorText  string
+		Name     string
+		Content  string
+		Request  *ec2.DescribeImagesInput
+		Response error
+		Error    tflint.Error
 	}{
 		{
 			Name: "AWS API error",
@@ -198,9 +103,11 @@ resource "aws_instance" "valid" {
 				"could not find region configuration",
 				nil,
 			),
-			ErrorCode:  tflint.ExternalAPIError,
-			ErrorLevel: tflint.ErrorLevel,
-			ErrorText:  "An error occurred while describing images; MissingRegion: could not find region configuration",
+			Error: tflint.Error{
+				Code:    tflint.ExternalAPIError,
+				Level:   tflint.ErrorLevel,
+				Message: "An error occurred while describing images; MissingRegion: could not find region configuration",
+			},
 		},
 		{
 			Name: "Unexpected error",
@@ -211,80 +118,29 @@ resource "aws_instance" "valid" {
 			Request: &ec2.DescribeImagesInput{
 				ImageIds: aws.StringSlice([]string{"ami-9ad76sd1"}),
 			},
-			Response:   errors.New("Unexpected"),
-			ErrorCode:  tflint.ExternalAPIError,
-			ErrorLevel: tflint.ErrorLevel,
-			ErrorText:  "An error occurred while describing images; Unexpected",
+			Response: errors.New("Unexpected"),
+			Error: tflint.Error{
+				Code:    tflint.ExternalAPIError,
+				Level:   tflint.ErrorLevel,
+				Message: "An error occurred while describing images; Unexpected",
+			},
 		},
-	}
-
-	dir, err := ioutil.TempDir("", "AwsInstanceInvalidAMI_error")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
 	}
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	rule := NewAwsInstanceInvalidAMIRule()
+
 	for _, tc := range cases {
-		err := ioutil.WriteFile(dir+"/instances.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsInstanceInvalidAMIRule()
+		runner := tflint.TestRunner(t, map[string]string{"instances.tf": tc.Content})
 
 		ec2mock := client.NewMockEC2API(ctrl)
 		ec2mock.EXPECT().DescribeImages(tc.Request).Return(nil, tc.Response)
 		runner.AwsClient.EC2 = ec2mock
 
-		err = rule.Check(runner)
-		if appErr, ok := err.(*tflint.Error); ok {
-			if appErr == nil {
-				t.Fatalf("Failed `%s` test: expected err is `%s`, but nothing occurred", tc.Name, tc.ErrorText)
-			}
-			if appErr.Code != tc.ErrorCode {
-				t.Fatalf("Failed `%s` test: expected error code is `%d`, but get `%d`", tc.Name, tc.ErrorCode, appErr.Code)
-			}
-			if appErr.Level != tc.ErrorLevel {
-				t.Fatalf("Failed `%s` test: expected error level is `%d`, but get `%d`", tc.Name, tc.ErrorLevel, appErr.Level)
-			}
-			if appErr.Error() != tc.ErrorText {
-				t.Fatalf("Failed `%s` test: expected error is `%s`, but get `%s`", tc.Name, tc.ErrorText, appErr.Error())
-			}
-		} else {
-			t.Fatalf("Failed `%s` test: unexpected error occurred: %s", tc.Name, err)
-		}
+		err := rule.Check(runner)
+		tflint.AssertAppError(t, tc.Error, err)
 	}
 }
 
@@ -380,57 +236,19 @@ resource "aws_instance" "unavailable" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsInstanceInvalidAMI_AMIError")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	rule := NewAwsInstanceInvalidAMIRule()
+
 	for _, tc := range cases {
-		err := ioutil.WriteFile(dir+"/instances.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsInstanceInvalidAMIRule()
+		runner := tflint.TestRunner(t, map[string]string{"instances.tf": tc.Content})
 
 		ec2mock := client.NewMockEC2API(ctrl)
 		ec2mock.EXPECT().DescribeImages(tc.Request).Return(nil, tc.Response)
 		runner.AwsClient.EC2 = ec2mock
 
-		err = rule.Check(runner)
+		err := rule.Check(runner)
 		if err != nil && !tc.Error {
 			t.Fatalf("Failed `%s` test: unexpected error occurred: %s", tc.Name, err)
 		}
@@ -438,12 +256,6 @@ resource "aws_instance" "unavailable" {
 			t.Fatalf("Failed `%s` test: expected to return an error, but nothing occurred", tc.Name)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsInstanceInvalidAMIRule{}),
-			cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
-		}
-		if !cmp.Equal(tc.Issues, runner.Issues, opts...) {
-			t.Fatalf("Failed `%s` test: expected issues are not matched:\n %s\n", tc.Name, cmp.Diff(tc.Issues, runner.Issues, opts...))
-		}
+		tflint.AssertIssues(t, tc.Issues, runner.Issues)
 	}
 }

--- a/rules/awsrules/aws_instance_previous_type_test.go
+++ b/rules/awsrules/aws_instance_previous_type_test.go
@@ -1,16 +1,9 @@
 package awsrules
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl2/hcl"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -48,59 +41,15 @@ resource "aws_instance" "web" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsInstancePreviousType")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsInstancePreviousTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsInstancePreviousTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsInstancePreviousTypeRule{}),
-			cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/aws_route_not_specified_target_test.go
+++ b/rules/awsrules/aws_route_not_specified_target_test.go
@@ -1,16 +1,9 @@
 package awsrules
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl2/hcl"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -127,59 +120,15 @@ resource "aws_route" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsRouteNotSpecifiedTarget")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsRouteNotSpecifiedTargetRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsRouteNotSpecifiedTargetRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsRouteNotSpecifiedTargetRule{}),
-			cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/aws_route_specified_multiple_targets_test.go
+++ b/rules/awsrules/aws_route_specified_multiple_targets_test.go
@@ -1,16 +1,9 @@
 package awsrules
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl2/hcl"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -66,59 +59,15 @@ resource "aws_route" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsRouteSpecifiedMultipleTargets")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsRouteSpecifiedMultipleTargetsRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsRouteSpecifiedMultipleTargetsRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsRouteSpecifiedMultipleTargetsRule{}),
-			cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_acm_certificate_invalid_certificate_body_test.go
+++ b/rules/awsrules/models/aws_acm_certificate_invalid_certificate_body_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -81,59 +74,15 @@ TEXT
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAcmCertificateInvalidCertificateBodyRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAcmCertificateInvalidCertificateBodyRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAcmCertificateInvalidCertificateBodyRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAcmCertificateInvalidCertificateBodyRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_acm_certificate_invalid_certificate_chain_test.go
+++ b/rules/awsrules/models/aws_acm_certificate_invalid_certificate_chain_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -99,59 +92,15 @@ TEXT
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAcmCertificateInvalidCertificateChainRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAcmCertificateInvalidCertificateChainRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAcmCertificateInvalidCertificateChainRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAcmCertificateInvalidCertificateChainRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_acm_certificate_invalid_private_key_test.go
+++ b/rules/awsrules/models/aws_acm_certificate_invalid_private_key_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -92,59 +85,15 @@ TEXT
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAcmCertificateInvalidPrivateKeyRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAcmCertificateInvalidPrivateKeyRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAcmCertificateInvalidPrivateKeyRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAcmCertificateInvalidPrivateKeyRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_acmpca_certificate_authority_invalid_type_test.go
+++ b/rules/awsrules/models/aws_acmpca_certificate_authority_invalid_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_acmpca_certificate_authority" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAcmpcaCertificateAuthorityInvalidTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAcmpcaCertificateAuthorityInvalidTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAcmpcaCertificateAuthorityInvalidTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAcmpcaCertificateAuthorityInvalidTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ami_invalid_architecture_test.go
+++ b/rules/awsrules/models/aws_ami_invalid_architecture_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ami" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAMIInvalidArchitectureRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAMIInvalidArchitectureRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAMIInvalidArchitectureRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAMIInvalidArchitectureRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_api_gateway_authorizer_invalid_type_test.go
+++ b/rules/awsrules/models/aws_api_gateway_authorizer_invalid_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_api_gateway_authorizer" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAPIGatewayAuthorizerInvalidTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAPIGatewayAuthorizerInvalidTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAPIGatewayAuthorizerInvalidTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAPIGatewayAuthorizerInvalidTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_api_gateway_gateway_response_invalid_response_type_test.go
+++ b/rules/awsrules/models/aws_api_gateway_gateway_response_invalid_response_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_api_gateway_gateway_response" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAPIGatewayGatewayResponseInvalidResponseTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAPIGatewayGatewayResponseInvalidResponseTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAPIGatewayGatewayResponseInvalidResponseTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAPIGatewayGatewayResponseInvalidResponseTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_api_gateway_gateway_response_invalid_status_code_test.go
+++ b/rules/awsrules/models/aws_api_gateway_gateway_response_invalid_status_code_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_api_gateway_gateway_response" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAPIGatewayGatewayResponseInvalidStatusCodeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAPIGatewayGatewayResponseInvalidStatusCodeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAPIGatewayGatewayResponseInvalidStatusCodeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAPIGatewayGatewayResponseInvalidStatusCodeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_api_gateway_integration_invalid_connection_type_test.go
+++ b/rules/awsrules/models/aws_api_gateway_integration_invalid_connection_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_api_gateway_integration" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAPIGatewayIntegrationInvalidConnectionTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAPIGatewayIntegrationInvalidConnectionTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAPIGatewayIntegrationInvalidConnectionTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAPIGatewayIntegrationInvalidConnectionTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_api_gateway_integration_invalid_content_handling_test.go
+++ b/rules/awsrules/models/aws_api_gateway_integration_invalid_content_handling_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_api_gateway_integration" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAPIGatewayIntegrationInvalidContentHandlingRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAPIGatewayIntegrationInvalidContentHandlingRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAPIGatewayIntegrationInvalidContentHandlingRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAPIGatewayIntegrationInvalidContentHandlingRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_api_gateway_integration_invalid_type_test.go
+++ b/rules/awsrules/models/aws_api_gateway_integration_invalid_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_api_gateway_integration" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAPIGatewayIntegrationInvalidTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAPIGatewayIntegrationInvalidTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAPIGatewayIntegrationInvalidTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAPIGatewayIntegrationInvalidTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_api_gateway_rest_api_invalid_api_key_source_test.go
+++ b/rules/awsrules/models/aws_api_gateway_rest_api_invalid_api_key_source_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_api_gateway_rest_api" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAPIGatewayRestAPIInvalidAPIKeySourceRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAPIGatewayRestAPIInvalidAPIKeySourceRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAPIGatewayRestAPIInvalidAPIKeySourceRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAPIGatewayRestAPIInvalidAPIKeySourceRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_api_gateway_stage_invalid_cache_cluster_size_test.go
+++ b/rules/awsrules/models/aws_api_gateway_stage_invalid_cache_cluster_size_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_api_gateway_stage" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAPIGatewayStageInvalidCacheClusterSizeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAPIGatewayStageInvalidCacheClusterSizeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAPIGatewayStageInvalidCacheClusterSizeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAPIGatewayStageInvalidCacheClusterSizeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_appautoscaling_policy_invalid_policy_type_test.go
+++ b/rules/awsrules/models/aws_appautoscaling_policy_invalid_policy_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_appautoscaling_policy" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAppautoscalingPolicyInvalidPolicyTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAppautoscalingPolicyInvalidPolicyTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAppautoscalingPolicyInvalidPolicyTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAppautoscalingPolicyInvalidPolicyTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_appautoscaling_policy_invalid_scalable_dimension_test.go
+++ b/rules/awsrules/models/aws_appautoscaling_policy_invalid_scalable_dimension_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_appautoscaling_policy" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAppautoscalingPolicyInvalidScalableDimensionRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAppautoscalingPolicyInvalidScalableDimensionRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAppautoscalingPolicyInvalidScalableDimensionRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAppautoscalingPolicyInvalidScalableDimensionRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_appautoscaling_policy_invalid_service_namespace_test.go
+++ b/rules/awsrules/models/aws_appautoscaling_policy_invalid_service_namespace_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_appautoscaling_policy" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAppautoscalingPolicyInvalidServiceNamespaceRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAppautoscalingPolicyInvalidServiceNamespaceRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAppautoscalingPolicyInvalidServiceNamespaceRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAppautoscalingPolicyInvalidServiceNamespaceRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_appsync_datasource_invalid_name_test.go
+++ b/rules/awsrules/models/aws_appsync_datasource_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_appsync_datasource" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAppsyncDatasourceInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAppsyncDatasourceInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAppsyncDatasourceInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAppsyncDatasourceInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_appsync_datasource_invalid_type_test.go
+++ b/rules/awsrules/models/aws_appsync_datasource_invalid_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_appsync_datasource" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAppsyncDatasourceInvalidTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAppsyncDatasourceInvalidTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAppsyncDatasourceInvalidTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAppsyncDatasourceInvalidTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_appsync_graphql_api_invalid_authentication_type_test.go
+++ b/rules/awsrules/models/aws_appsync_graphql_api_invalid_authentication_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_appsync_graphql_api" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsAppsyncGraphqlAPIInvalidAuthenticationTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsAppsyncGraphqlAPIInvalidAuthenticationTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsAppsyncGraphqlAPIInvalidAuthenticationTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsAppsyncGraphqlAPIInvalidAuthenticationTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_backup_selection_invalid_name_test.go
+++ b/rules/awsrules/models/aws_backup_selection_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_backup_selection" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsBackupSelectionInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsBackupSelectionInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsBackupSelectionInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsBackupSelectionInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_backup_vault_invalid_name_test.go
+++ b/rules/awsrules/models/aws_backup_vault_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_backup_vault" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsBackupVaultInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsBackupVaultInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsBackupVaultInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsBackupVaultInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_batch_compute_environment_invalid_state_test.go
+++ b/rules/awsrules/models/aws_batch_compute_environment_invalid_state_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_batch_compute_environment" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsBatchComputeEnvironmentInvalidStateRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsBatchComputeEnvironmentInvalidStateRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsBatchComputeEnvironmentInvalidStateRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsBatchComputeEnvironmentInvalidStateRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_batch_compute_environment_invalid_type_test.go
+++ b/rules/awsrules/models/aws_batch_compute_environment_invalid_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_batch_compute_environment" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsBatchComputeEnvironmentInvalidTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsBatchComputeEnvironmentInvalidTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsBatchComputeEnvironmentInvalidTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsBatchComputeEnvironmentInvalidTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_batch_job_definition_invalid_type_test.go
+++ b/rules/awsrules/models/aws_batch_job_definition_invalid_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_batch_job_definition" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsBatchJobDefinitionInvalidTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsBatchJobDefinitionInvalidTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsBatchJobDefinitionInvalidTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsBatchJobDefinitionInvalidTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_batch_job_queue_invalid_state_test.go
+++ b/rules/awsrules/models/aws_batch_job_queue_invalid_state_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_batch_job_queue" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsBatchJobQueueInvalidStateRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsBatchJobQueueInvalidStateRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsBatchJobQueueInvalidStateRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsBatchJobQueueInvalidStateRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_budgets_budget_invalid_account_id_test.go
+++ b/rules/awsrules/models/aws_budgets_budget_invalid_account_id_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_budgets_budget" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsBudgetsBudgetInvalidAccountIDRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsBudgetsBudgetInvalidAccountIDRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsBudgetsBudgetInvalidAccountIDRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsBudgetsBudgetInvalidAccountIDRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_budgets_budget_invalid_budget_type_test.go
+++ b/rules/awsrules/models/aws_budgets_budget_invalid_budget_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_budgets_budget" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsBudgetsBudgetInvalidBudgetTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsBudgetsBudgetInvalidBudgetTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsBudgetsBudgetInvalidBudgetTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsBudgetsBudgetInvalidBudgetTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_budgets_budget_invalid_name_test.go
+++ b/rules/awsrules/models/aws_budgets_budget_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_budgets_budget" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsBudgetsBudgetInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsBudgetsBudgetInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsBudgetsBudgetInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsBudgetsBudgetInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_budgets_budget_invalid_time_unit_test.go
+++ b/rules/awsrules/models/aws_budgets_budget_invalid_time_unit_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_budgets_budget" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsBudgetsBudgetInvalidTimeUnitRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsBudgetsBudgetInvalidTimeUnitRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsBudgetsBudgetInvalidTimeUnitRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsBudgetsBudgetInvalidTimeUnitRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloud9_environment_ec2_invalid_instance_type_test.go
+++ b/rules/awsrules/models/aws_cloud9_environment_ec2_invalid_instance_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloud9_environment_ec2" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloud9EnvironmentEc2InvalidInstanceTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloud9EnvironmentEc2InvalidInstanceTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloud9EnvironmentEc2InvalidInstanceTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloud9EnvironmentEc2InvalidInstanceTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloud9_environment_ec2_invalid_owner_arn_test.go
+++ b/rules/awsrules/models/aws_cloud9_environment_ec2_invalid_owner_arn_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloud9_environment_ec2" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloud9EnvironmentEc2InvalidOwnerArnRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloud9EnvironmentEc2InvalidOwnerArnRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloud9EnvironmentEc2InvalidOwnerArnRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloud9EnvironmentEc2InvalidOwnerArnRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudformation_stack_invalid_on_failure_test.go
+++ b/rules/awsrules/models/aws_cloudformation_stack_invalid_on_failure_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudformation_stack" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudformationStackInvalidOnFailureRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudformationStackInvalidOnFailureRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudformationStackInvalidOnFailureRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudformationStackInvalidOnFailureRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudformation_stack_set_instance_invalid_account_id_test.go
+++ b/rules/awsrules/models/aws_cloudformation_stack_set_instance_invalid_account_id_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudformation_stack_set_instance" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudformationStackSetInstanceInvalidAccountIDRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudformationStackSetInstanceInvalidAccountIDRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudformationStackSetInstanceInvalidAccountIDRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudformationStackSetInstanceInvalidAccountIDRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudformation_stack_set_invalid_execution_role_name_test.go
+++ b/rules/awsrules/models/aws_cloudformation_stack_set_invalid_execution_role_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudformation_stack_set" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudformationStackSetInvalidExecutionRoleNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudformationStackSetInvalidExecutionRoleNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudformationStackSetInvalidExecutionRoleNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudformationStackSetInvalidExecutionRoleNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudfront_distribution_invalid_http_version_test.go
+++ b/rules/awsrules/models/aws_cloudfront_distribution_invalid_http_version_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudfront_distribution" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudfrontDistributionInvalidHTTPVersionRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudfrontDistributionInvalidHTTPVersionRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudfrontDistributionInvalidHTTPVersionRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudfrontDistributionInvalidHTTPVersionRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudfront_distribution_invalid_price_class_test.go
+++ b/rules/awsrules/models/aws_cloudfront_distribution_invalid_price_class_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudfront_distribution" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudfrontDistributionInvalidPriceClassRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudfrontDistributionInvalidPriceClassRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudfrontDistributionInvalidPriceClassRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudfrontDistributionInvalidPriceClassRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudhsm_v2_cluster_invalid_hsm_type_test.go
+++ b/rules/awsrules/models/aws_cloudhsm_v2_cluster_invalid_hsm_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudhsm_v2_cluster" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudhsmV2ClusterInvalidHsmTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudhsmV2ClusterInvalidHsmTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudhsmV2ClusterInvalidHsmTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudhsmV2ClusterInvalidHsmTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudhsm_v2_cluster_invalid_source_backup_identifier_test.go
+++ b/rules/awsrules/models/aws_cloudhsm_v2_cluster_invalid_source_backup_identifier_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudhsm_v2_cluster" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudhsmV2ClusterInvalidSourceBackupIdentifierRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudhsmV2ClusterInvalidSourceBackupIdentifierRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudhsmV2ClusterInvalidSourceBackupIdentifierRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudhsmV2ClusterInvalidSourceBackupIdentifierRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudhsm_v2_hsm_invalid_availability_zone_test.go
+++ b/rules/awsrules/models/aws_cloudhsm_v2_hsm_invalid_availability_zone_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudhsm_v2_hsm" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudhsmV2HsmInvalidAvailabilityZoneRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudhsmV2HsmInvalidAvailabilityZoneRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudhsmV2HsmInvalidAvailabilityZoneRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudhsmV2HsmInvalidAvailabilityZoneRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudhsm_v2_hsm_invalid_cluster_id_test.go
+++ b/rules/awsrules/models/aws_cloudhsm_v2_hsm_invalid_cluster_id_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudhsm_v2_hsm" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudhsmV2HsmInvalidClusterIDRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudhsmV2HsmInvalidClusterIDRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudhsmV2HsmInvalidClusterIDRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudhsmV2HsmInvalidClusterIDRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudhsm_v2_hsm_invalid_ip_address_test.go
+++ b/rules/awsrules/models/aws_cloudhsm_v2_hsm_invalid_ip_address_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudhsm_v2_hsm" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudhsmV2HsmInvalidIPAddressRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudhsmV2HsmInvalidIPAddressRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudhsmV2HsmInvalidIPAddressRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudhsmV2HsmInvalidIPAddressRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudhsm_v2_hsm_invalid_subnet_id_test.go
+++ b/rules/awsrules/models/aws_cloudhsm_v2_hsm_invalid_subnet_id_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudhsm_v2_hsm" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudhsmV2HsmInvalidSubnetIDRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudhsmV2HsmInvalidSubnetIDRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudhsmV2HsmInvalidSubnetIDRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudhsmV2HsmInvalidSubnetIDRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudwatch_event_permission_invalid_action_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_event_permission_invalid_action_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudwatch_event_permission" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudwatchEventPermissionInvalidActionRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudwatchEventPermissionInvalidActionRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudwatchEventPermissionInvalidActionRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudwatchEventPermissionInvalidActionRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudwatch_event_permission_invalid_principal_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_event_permission_invalid_principal_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudwatch_event_permission" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudwatchEventPermissionInvalidPrincipalRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudwatchEventPermissionInvalidPrincipalRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudwatchEventPermissionInvalidPrincipalRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudwatchEventPermissionInvalidPrincipalRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudwatch_event_permission_invalid_statement_id_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_event_permission_invalid_statement_id_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudwatch_event_permission" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudwatchEventPermissionInvalidStatementIDRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudwatchEventPermissionInvalidStatementIDRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudwatchEventPermissionInvalidStatementIDRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudwatchEventPermissionInvalidStatementIDRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudwatch_event_rule_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_event_rule_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudwatch_event_rule" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudwatchEventRuleInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudwatchEventRuleInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudwatchEventRuleInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudwatchEventRuleInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudwatch_event_target_invalid_target_id_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_event_target_invalid_target_id_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudwatch_event_target" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudwatchEventTargetInvalidTargetIDRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudwatchEventTargetInvalidTargetIDRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudwatchEventTargetInvalidTargetIDRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudwatchEventTargetInvalidTargetIDRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudwatch_log_destination_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_log_destination_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudwatch_log_destination" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudwatchLogDestinationInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudwatchLogDestinationInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudwatchLogDestinationInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudwatchLogDestinationInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudwatch_log_group_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_log_group_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudwatch_log_group" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudwatchLogGroupInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudwatchLogGroupInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudwatchLogGroupInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudwatchLogGroupInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudwatch_log_metric_filter_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_log_metric_filter_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudwatch_log_metric_filter" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudwatchLogMetricFilterInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudwatchLogMetricFilterInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudwatchLogMetricFilterInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudwatchLogMetricFilterInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudwatch_log_stream_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_log_stream_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudwatch_log_stream" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudwatchLogStreamInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudwatchLogStreamInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudwatchLogStreamInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudwatchLogStreamInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudwatch_log_subscription_filter_invalid_distribution_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_log_subscription_filter_invalid_distribution_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudwatch_log_subscription_filter" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudwatchLogSubscriptionFilterInvalidDistributionRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudwatchLogSubscriptionFilterInvalidDistributionRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudwatchLogSubscriptionFilterInvalidDistributionRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudwatchLogSubscriptionFilterInvalidDistributionRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudwatch_log_subscription_filter_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_log_subscription_filter_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudwatch_log_subscription_filter" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudwatchLogSubscriptionFilterInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudwatchLogSubscriptionFilterInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudwatchLogSubscriptionFilterInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudwatchLogSubscriptionFilterInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_comparison_operator_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_comparison_operator_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudwatch_metric_alarm" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudwatchMetricAlarmInvalidComparisonOperatorRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudwatchMetricAlarmInvalidComparisonOperatorRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudwatchMetricAlarmInvalidComparisonOperatorRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudwatchMetricAlarmInvalidComparisonOperatorRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_extended_statistic_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_extended_statistic_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudwatch_metric_alarm" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudwatchMetricAlarmInvalidExtendedStatisticRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudwatchMetricAlarmInvalidExtendedStatisticRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudwatchMetricAlarmInvalidExtendedStatisticRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudwatchMetricAlarmInvalidExtendedStatisticRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_namespace_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_namespace_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudwatch_metric_alarm" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudwatchMetricAlarmInvalidNamespaceRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudwatchMetricAlarmInvalidNamespaceRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudwatchMetricAlarmInvalidNamespaceRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudwatchMetricAlarmInvalidNamespaceRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_statistic_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_statistic_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudwatch_metric_alarm" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudwatchMetricAlarmInvalidStatisticRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudwatchMetricAlarmInvalidStatisticRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudwatchMetricAlarmInvalidStatisticRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudwatchMetricAlarmInvalidStatisticRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_unit_test.go
+++ b/rules/awsrules/models/aws_cloudwatch_metric_alarm_invalid_unit_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cloudwatch_metric_alarm" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCloudwatchMetricAlarmInvalidUnitRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCloudwatchMetricAlarmInvalidUnitRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCloudwatchMetricAlarmInvalidUnitRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCloudwatchMetricAlarmInvalidUnitRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_codecommit_repository_invalid_repository_name_test.go
+++ b/rules/awsrules/models/aws_codecommit_repository_invalid_repository_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_codecommit_repository" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCodecommitRepositoryInvalidRepositoryNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCodecommitRepositoryInvalidRepositoryNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCodecommitRepositoryInvalidRepositoryNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCodecommitRepositoryInvalidRepositoryNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_codedeploy_app_invalid_compute_platform_test.go
+++ b/rules/awsrules/models/aws_codedeploy_app_invalid_compute_platform_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_codedeploy_app" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCodedeployAppInvalidComputePlatformRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCodedeployAppInvalidComputePlatformRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCodedeployAppInvalidComputePlatformRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCodedeployAppInvalidComputePlatformRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_codepipeline_invalid_name_test.go
+++ b/rules/awsrules/models/aws_codepipeline_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_codepipeline" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCodepipelineInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCodepipelineInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCodepipelineInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCodepipelineInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_codepipeline_invalid_role_arn_test.go
+++ b/rules/awsrules/models/aws_codepipeline_invalid_role_arn_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_codepipeline" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCodepipelineInvalidRoleArnRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCodepipelineInvalidRoleArnRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCodepipelineInvalidRoleArnRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCodepipelineInvalidRoleArnRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_codepipeline_webhook_invalid_authentication_test.go
+++ b/rules/awsrules/models/aws_codepipeline_webhook_invalid_authentication_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_codepipeline_webhook" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCodepipelineWebhookInvalidAuthenticationRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCodepipelineWebhookInvalidAuthenticationRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCodepipelineWebhookInvalidAuthenticationRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCodepipelineWebhookInvalidAuthenticationRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_codepipeline_webhook_invalid_name_test.go
+++ b/rules/awsrules/models/aws_codepipeline_webhook_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_codepipeline_webhook" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCodepipelineWebhookInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCodepipelineWebhookInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCodepipelineWebhookInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCodepipelineWebhookInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_codepipeline_webhook_invalid_target_action_test.go
+++ b/rules/awsrules/models/aws_codepipeline_webhook_invalid_target_action_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_codepipeline_webhook" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCodepipelineWebhookInvalidTargetActionRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCodepipelineWebhookInvalidTargetActionRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCodepipelineWebhookInvalidTargetActionRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCodepipelineWebhookInvalidTargetActionRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cognito_identity_pool_invalid_identity_pool_name_test.go
+++ b/rules/awsrules/models/aws_cognito_identity_pool_invalid_identity_pool_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cognito_identity_pool" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCognitoIdentityPoolInvalidIdentityPoolNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCognitoIdentityPoolInvalidIdentityPoolNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCognitoIdentityPoolInvalidIdentityPoolNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCognitoIdentityPoolInvalidIdentityPoolNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cognito_identity_pool_roles_attachment_invalid_identity_pool_id_test.go
+++ b/rules/awsrules/models/aws_cognito_identity_pool_roles_attachment_invalid_identity_pool_id_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cognito_identity_pool_roles_attachment" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCognitoIdentityPoolRolesAttachmentInvalidIdentityPoolIDRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCognitoIdentityPoolRolesAttachmentInvalidIdentityPoolIDRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCognitoIdentityPoolRolesAttachmentInvalidIdentityPoolIDRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCognitoIdentityPoolRolesAttachmentInvalidIdentityPoolIDRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cognito_identity_provider_invalid_provider_name_test.go
+++ b/rules/awsrules/models/aws_cognito_identity_provider_invalid_provider_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cognito_identity_provider" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCognitoIdentityProviderInvalidProviderNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCognitoIdentityProviderInvalidProviderNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCognitoIdentityProviderInvalidProviderNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCognitoIdentityProviderInvalidProviderNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cognito_identity_provider_invalid_provider_type_test.go
+++ b/rules/awsrules/models/aws_cognito_identity_provider_invalid_provider_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cognito_identity_provider" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCognitoIdentityProviderInvalidProviderTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCognitoIdentityProviderInvalidProviderTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCognitoIdentityProviderInvalidProviderTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCognitoIdentityProviderInvalidProviderTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cognito_identity_provider_invalid_user_pool_id_test.go
+++ b/rules/awsrules/models/aws_cognito_identity_provider_invalid_user_pool_id_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cognito_identity_provider" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCognitoIdentityProviderInvalidUserPoolIDRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCognitoIdentityProviderInvalidUserPoolIDRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCognitoIdentityProviderInvalidUserPoolIDRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCognitoIdentityProviderInvalidUserPoolIDRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cognito_resource_server_invalid_identifier_test.go
+++ b/rules/awsrules/models/aws_cognito_resource_server_invalid_identifier_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cognito_resource_server" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCognitoResourceServerInvalidIdentifierRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCognitoResourceServerInvalidIdentifierRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCognitoResourceServerInvalidIdentifierRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCognitoResourceServerInvalidIdentifierRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cognito_resource_server_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cognito_resource_server_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cognito_resource_server" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCognitoResourceServerInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCognitoResourceServerInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCognitoResourceServerInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCognitoResourceServerInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cognito_user_group_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cognito_user_group_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cognito_user_group" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCognitoUserGroupInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCognitoUserGroupInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCognitoUserGroupInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCognitoUserGroupInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cognito_user_group_invalid_role_arn_test.go
+++ b/rules/awsrules/models/aws_cognito_user_group_invalid_role_arn_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cognito_user_group" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCognitoUserGroupInvalidRoleArnRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCognitoUserGroupInvalidRoleArnRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCognitoUserGroupInvalidRoleArnRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCognitoUserGroupInvalidRoleArnRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cognito_user_pool_client_invalid_default_redirect_uri_test.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_client_invalid_default_redirect_uri_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cognito_user_pool_client" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCognitoUserPoolClientInvalidDefaultRedirectURIRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCognitoUserPoolClientInvalidDefaultRedirectURIRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCognitoUserPoolClientInvalidDefaultRedirectURIRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCognitoUserPoolClientInvalidDefaultRedirectURIRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cognito_user_pool_client_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_client_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cognito_user_pool_client" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCognitoUserPoolClientInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCognitoUserPoolClientInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCognitoUserPoolClientInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCognitoUserPoolClientInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cognito_user_pool_domain_invalid_domain_test.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_domain_invalid_domain_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cognito_user_pool_domain" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCognitoUserPoolDomainInvalidDomainRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCognitoUserPoolDomainInvalidDomainRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCognitoUserPoolDomainInvalidDomainRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCognitoUserPoolDomainInvalidDomainRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cognito_user_pool_invalid_email_verification_message_test.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_invalid_email_verification_message_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cognito_user_pool" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCognitoUserPoolInvalidEmailVerificationMessageRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCognitoUserPoolInvalidEmailVerificationMessageRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCognitoUserPoolInvalidEmailVerificationMessageRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCognitoUserPoolInvalidEmailVerificationMessageRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cognito_user_pool_invalid_mfa_configuration_test.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_invalid_mfa_configuration_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cognito_user_pool" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCognitoUserPoolInvalidMfaConfigurationRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCognitoUserPoolInvalidMfaConfigurationRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCognitoUserPoolInvalidMfaConfigurationRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCognitoUserPoolInvalidMfaConfigurationRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cognito_user_pool_invalid_name_test.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cognito_user_pool" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCognitoUserPoolInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCognitoUserPoolInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCognitoUserPoolInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCognitoUserPoolInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cognito_user_pool_invalid_sms_authentication_message_test.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_invalid_sms_authentication_message_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cognito_user_pool" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCognitoUserPoolInvalidSmsAuthenticationMessageRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCognitoUserPoolInvalidSmsAuthenticationMessageRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCognitoUserPoolInvalidSmsAuthenticationMessageRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCognitoUserPoolInvalidSmsAuthenticationMessageRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cognito_user_pool_invalid_sms_verification_message_test.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_invalid_sms_verification_message_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cognito_user_pool" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCognitoUserPoolInvalidSmsVerificationMessageRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCognitoUserPoolInvalidSmsVerificationMessageRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCognitoUserPoolInvalidSmsVerificationMessageRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCognitoUserPoolInvalidSmsVerificationMessageRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_config_aggregate_authorization_invalid_account_id_test.go
+++ b/rules/awsrules/models/aws_config_aggregate_authorization_invalid_account_id_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_config_aggregate_authorization" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsConfigAggregateAuthorizationInvalidAccountIDRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsConfigAggregateAuthorizationInvalidAccountIDRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsConfigAggregateAuthorizationInvalidAccountIDRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsConfigAggregateAuthorizationInvalidAccountIDRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_config_config_rule_invalid_maximum_execution_frequency_test.go
+++ b/rules/awsrules/models/aws_config_config_rule_invalid_maximum_execution_frequency_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_config_config_rule" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsConfigConfigRuleInvalidMaximumExecutionFrequencyRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsConfigConfigRuleInvalidMaximumExecutionFrequencyRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsConfigConfigRuleInvalidMaximumExecutionFrequencyRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsConfigConfigRuleInvalidMaximumExecutionFrequencyRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_config_configuration_aggregator_invalid_name_test.go
+++ b/rules/awsrules/models/aws_config_configuration_aggregator_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_config_configuration_aggregator" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsConfigConfigurationAggregatorInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsConfigConfigurationAggregatorInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsConfigConfigurationAggregatorInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsConfigConfigurationAggregatorInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cur_report_definition_invalid_compression_test.go
+++ b/rules/awsrules/models/aws_cur_report_definition_invalid_compression_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cur_report_definition" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCurReportDefinitionInvalidCompressionRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCurReportDefinitionInvalidCompressionRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCurReportDefinitionInvalidCompressionRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCurReportDefinitionInvalidCompressionRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cur_report_definition_invalid_format_test.go
+++ b/rules/awsrules/models/aws_cur_report_definition_invalid_format_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cur_report_definition" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCurReportDefinitionInvalidFormatRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCurReportDefinitionInvalidFormatRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCurReportDefinitionInvalidFormatRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCurReportDefinitionInvalidFormatRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cur_report_definition_invalid_report_name_test.go
+++ b/rules/awsrules/models/aws_cur_report_definition_invalid_report_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cur_report_definition" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCurReportDefinitionInvalidReportNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCurReportDefinitionInvalidReportNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCurReportDefinitionInvalidReportNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCurReportDefinitionInvalidReportNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cur_report_definition_invalid_s3_prefix_test.go
+++ b/rules/awsrules/models/aws_cur_report_definition_invalid_s3_prefix_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -46,59 +39,15 @@ resource "aws_cur_report_definition" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCurReportDefinitionInvalidS3PrefixRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCurReportDefinitionInvalidS3PrefixRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCurReportDefinitionInvalidS3PrefixRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCurReportDefinitionInvalidS3PrefixRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cur_report_definition_invalid_s3_region_test.go
+++ b/rules/awsrules/models/aws_cur_report_definition_invalid_s3_region_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cur_report_definition" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCurReportDefinitionInvalidS3RegionRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCurReportDefinitionInvalidS3RegionRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCurReportDefinitionInvalidS3RegionRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCurReportDefinitionInvalidS3RegionRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_cur_report_definition_invalid_time_unit_test.go
+++ b/rules/awsrules/models/aws_cur_report_definition_invalid_time_unit_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_cur_report_definition" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsCurReportDefinitionInvalidTimeUnitRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsCurReportDefinitionInvalidTimeUnitRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsCurReportDefinitionInvalidTimeUnitRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsCurReportDefinitionInvalidTimeUnitRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_datasync_agent_invalid_activation_key_test.go
+++ b/rules/awsrules/models/aws_datasync_agent_invalid_activation_key_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_datasync_agent" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDatasyncAgentInvalidActivationKeyRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDatasyncAgentInvalidActivationKeyRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDatasyncAgentInvalidActivationKeyRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDatasyncAgentInvalidActivationKeyRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_datasync_agent_invalid_name_test.go
+++ b/rules/awsrules/models/aws_datasync_agent_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_datasync_agent" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDatasyncAgentInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDatasyncAgentInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDatasyncAgentInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDatasyncAgentInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_datasync_location_efs_invalid_efs_file_system_arn_test.go
+++ b/rules/awsrules/models/aws_datasync_location_efs_invalid_efs_file_system_arn_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_datasync_location_efs" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDatasyncLocationEfsInvalidEfsFileSystemArnRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDatasyncLocationEfsInvalidEfsFileSystemArnRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDatasyncLocationEfsInvalidEfsFileSystemArnRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDatasyncLocationEfsInvalidEfsFileSystemArnRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_datasync_location_efs_invalid_subdirectory_test.go
+++ b/rules/awsrules/models/aws_datasync_location_efs_invalid_subdirectory_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_datasync_location_efs" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDatasyncLocationEfsInvalidSubdirectoryRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDatasyncLocationEfsInvalidSubdirectoryRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDatasyncLocationEfsInvalidSubdirectoryRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDatasyncLocationEfsInvalidSubdirectoryRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_datasync_location_nfs_invalid_server_hostname_test.go
+++ b/rules/awsrules/models/aws_datasync_location_nfs_invalid_server_hostname_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_datasync_location_nfs" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDatasyncLocationNfsInvalidServerHostnameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDatasyncLocationNfsInvalidServerHostnameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDatasyncLocationNfsInvalidServerHostnameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDatasyncLocationNfsInvalidServerHostnameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_datasync_location_nfs_invalid_subdirectory_test.go
+++ b/rules/awsrules/models/aws_datasync_location_nfs_invalid_subdirectory_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_datasync_location_nfs" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDatasyncLocationNfsInvalidSubdirectoryRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDatasyncLocationNfsInvalidSubdirectoryRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDatasyncLocationNfsInvalidSubdirectoryRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDatasyncLocationNfsInvalidSubdirectoryRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_datasync_location_s3_invalid_s3_bucket_arn_test.go
+++ b/rules/awsrules/models/aws_datasync_location_s3_invalid_s3_bucket_arn_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_datasync_location_s3" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDatasyncLocationS3InvalidS3BucketArnRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDatasyncLocationS3InvalidS3BucketArnRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDatasyncLocationS3InvalidS3BucketArnRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDatasyncLocationS3InvalidS3BucketArnRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_datasync_task_invalid_cloudwatch_log_group_arn_test.go
+++ b/rules/awsrules/models/aws_datasync_task_invalid_cloudwatch_log_group_arn_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_datasync_task" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDatasyncTaskInvalidCloudwatchLogGroupArnRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDatasyncTaskInvalidCloudwatchLogGroupArnRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDatasyncTaskInvalidCloudwatchLogGroupArnRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDatasyncTaskInvalidCloudwatchLogGroupArnRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_datasync_task_invalid_source_location_arn_test.go
+++ b/rules/awsrules/models/aws_datasync_task_invalid_source_location_arn_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_datasync_task" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDatasyncTaskInvalidSourceLocationArnRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDatasyncTaskInvalidSourceLocationArnRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDatasyncTaskInvalidSourceLocationArnRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDatasyncTaskInvalidSourceLocationArnRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_directory_service_conditional_forwarder_invalid_directory_id_test.go
+++ b/rules/awsrules/models/aws_directory_service_conditional_forwarder_invalid_directory_id_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_directory_service_conditional_forwarder" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDirectoryServiceConditionalForwarderInvalidDirectoryIDRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDirectoryServiceConditionalForwarderInvalidDirectoryIDRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDirectoryServiceConditionalForwarderInvalidDirectoryIDRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDirectoryServiceConditionalForwarderInvalidDirectoryIDRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_directory_service_conditional_forwarder_invalid_remote_domain_name_test.go
+++ b/rules/awsrules/models/aws_directory_service_conditional_forwarder_invalid_remote_domain_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_directory_service_conditional_forwarder" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDirectoryServiceConditionalForwarderInvalidRemoteDomainNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDirectoryServiceConditionalForwarderInvalidRemoteDomainNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDirectoryServiceConditionalForwarderInvalidRemoteDomainNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDirectoryServiceConditionalForwarderInvalidRemoteDomainNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_directory_service_directory_invalid_description_test.go
+++ b/rules/awsrules/models/aws_directory_service_directory_invalid_description_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_directory_service_directory" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDirectoryServiceDirectoryInvalidDescriptionRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDirectoryServiceDirectoryInvalidDescriptionRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDirectoryServiceDirectoryInvalidDescriptionRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDirectoryServiceDirectoryInvalidDescriptionRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_directory_service_directory_invalid_edition_test.go
+++ b/rules/awsrules/models/aws_directory_service_directory_invalid_edition_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_directory_service_directory" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDirectoryServiceDirectoryInvalidEditionRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDirectoryServiceDirectoryInvalidEditionRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDirectoryServiceDirectoryInvalidEditionRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDirectoryServiceDirectoryInvalidEditionRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_directory_service_directory_invalid_name_test.go
+++ b/rules/awsrules/models/aws_directory_service_directory_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_directory_service_directory" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDirectoryServiceDirectoryInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDirectoryServiceDirectoryInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDirectoryServiceDirectoryInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDirectoryServiceDirectoryInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_directory_service_directory_invalid_short_name_test.go
+++ b/rules/awsrules/models/aws_directory_service_directory_invalid_short_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_directory_service_directory" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDirectoryServiceDirectoryInvalidShortNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDirectoryServiceDirectoryInvalidShortNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDirectoryServiceDirectoryInvalidShortNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDirectoryServiceDirectoryInvalidShortNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_directory_service_directory_invalid_size_test.go
+++ b/rules/awsrules/models/aws_directory_service_directory_invalid_size_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_directory_service_directory" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDirectoryServiceDirectoryInvalidSizeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDirectoryServiceDirectoryInvalidSizeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDirectoryServiceDirectoryInvalidSizeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDirectoryServiceDirectoryInvalidSizeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_directory_service_directory_invalid_type_test.go
+++ b/rules/awsrules/models/aws_directory_service_directory_invalid_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_directory_service_directory" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDirectoryServiceDirectoryInvalidTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDirectoryServiceDirectoryInvalidTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDirectoryServiceDirectoryInvalidTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDirectoryServiceDirectoryInvalidTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_dlm_lifecycle_policy_invalid_state_test.go
+++ b/rules/awsrules/models/aws_dlm_lifecycle_policy_invalid_state_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_dlm_lifecycle_policy" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDlmLifecyclePolicyInvalidStateRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDlmLifecyclePolicyInvalidStateRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDlmLifecyclePolicyInvalidStateRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDlmLifecyclePolicyInvalidStateRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_dms_endpoint_invalid_endpoint_type_test.go
+++ b/rules/awsrules/models/aws_dms_endpoint_invalid_endpoint_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_dms_endpoint" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDmsEndpointInvalidEndpointTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDmsEndpointInvalidEndpointTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDmsEndpointInvalidEndpointTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDmsEndpointInvalidEndpointTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_dms_endpoint_invalid_ssl_mode_test.go
+++ b/rules/awsrules/models/aws_dms_endpoint_invalid_ssl_mode_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_dms_endpoint" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDmsEndpointInvalidSslModeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDmsEndpointInvalidSslModeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDmsEndpointInvalidSslModeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDmsEndpointInvalidSslModeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_dms_replication_task_invalid_migration_type_test.go
+++ b/rules/awsrules/models/aws_dms_replication_task_invalid_migration_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_dms_replication_task" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDmsReplicationTaskInvalidMigrationTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDmsReplicationTaskInvalidMigrationTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDmsReplicationTaskInvalidMigrationTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDmsReplicationTaskInvalidMigrationTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_dx_bgp_peer_invalid_address_family_test.go
+++ b/rules/awsrules/models/aws_dx_bgp_peer_invalid_address_family_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_dx_bgp_peer" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDxBgpPeerInvalidAddressFamilyRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDxBgpPeerInvalidAddressFamilyRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDxBgpPeerInvalidAddressFamilyRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDxBgpPeerInvalidAddressFamilyRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_dynamodb_global_table_invalid_name_test.go
+++ b/rules/awsrules/models/aws_dynamodb_global_table_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_dynamodb_global_table" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDynamoDBGlobalTableInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDynamoDBGlobalTableInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDynamoDBGlobalTableInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDynamoDBGlobalTableInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_dynamodb_table_invalid_billing_mode_test.go
+++ b/rules/awsrules/models/aws_dynamodb_table_invalid_billing_mode_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_dynamodb_table" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDynamoDBTableInvalidBillingModeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDynamoDBTableInvalidBillingModeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDynamoDBTableInvalidBillingModeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDynamoDBTableInvalidBillingModeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_dynamodb_table_invalid_stream_view_type_test.go
+++ b/rules/awsrules/models/aws_dynamodb_table_invalid_stream_view_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_dynamodb_table" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsDynamoDBTableInvalidStreamViewTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsDynamoDBTableInvalidStreamViewTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsDynamoDBTableInvalidStreamViewTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsDynamoDBTableInvalidStreamViewTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ebs_volume_invalid_type_test.go
+++ b/rules/awsrules/models/aws_ebs_volume_invalid_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ebs_volume" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEbsVolumeInvalidTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEbsVolumeInvalidTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEbsVolumeInvalidTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEbsVolumeInvalidTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ec2_capacity_reservation_invalid_end_date_type_test.go
+++ b/rules/awsrules/models/aws_ec2_capacity_reservation_invalid_end_date_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ec2_capacity_reservation" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEc2CapacityReservationInvalidEndDateTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEc2CapacityReservationInvalidEndDateTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEc2CapacityReservationInvalidEndDateTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEc2CapacityReservationInvalidEndDateTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ec2_capacity_reservation_invalid_instance_match_criteria_test.go
+++ b/rules/awsrules/models/aws_ec2_capacity_reservation_invalid_instance_match_criteria_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ec2_capacity_reservation" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEc2CapacityReservationInvalidInstanceMatchCriteriaRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEc2CapacityReservationInvalidInstanceMatchCriteriaRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEc2CapacityReservationInvalidInstanceMatchCriteriaRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEc2CapacityReservationInvalidInstanceMatchCriteriaRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ec2_capacity_reservation_invalid_instance_platform_test.go
+++ b/rules/awsrules/models/aws_ec2_capacity_reservation_invalid_instance_platform_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ec2_capacity_reservation" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEc2CapacityReservationInvalidInstancePlatformRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEc2CapacityReservationInvalidInstancePlatformRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEc2CapacityReservationInvalidInstancePlatformRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEc2CapacityReservationInvalidInstancePlatformRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ec2_capacity_reservation_invalid_tenancy_test.go
+++ b/rules/awsrules/models/aws_ec2_capacity_reservation_invalid_tenancy_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ec2_capacity_reservation" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEc2CapacityReservationInvalidTenancyRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEc2CapacityReservationInvalidTenancyRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEc2CapacityReservationInvalidTenancyRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEc2CapacityReservationInvalidTenancyRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ec2_client_vpn_endpoint_invalid_transport_protocol_test.go
+++ b/rules/awsrules/models/aws_ec2_client_vpn_endpoint_invalid_transport_protocol_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ec2_client_vpn_endpoint" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEc2ClientVpnEndpointInvalidTransportProtocolRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEc2ClientVpnEndpointInvalidTransportProtocolRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEc2ClientVpnEndpointInvalidTransportProtocolRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEc2ClientVpnEndpointInvalidTransportProtocolRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ec2_fleet_invalid_excess_capacity_termination_policy_test.go
+++ b/rules/awsrules/models/aws_ec2_fleet_invalid_excess_capacity_termination_policy_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ec2_fleet" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEc2FleetInvalidExcessCapacityTerminationPolicyRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEc2FleetInvalidExcessCapacityTerminationPolicyRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEc2FleetInvalidExcessCapacityTerminationPolicyRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEc2FleetInvalidExcessCapacityTerminationPolicyRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ec2_fleet_invalid_type_test.go
+++ b/rules/awsrules/models/aws_ec2_fleet_invalid_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ec2_fleet" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEc2FleetInvalidTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEc2FleetInvalidTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEc2FleetInvalidTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEc2FleetInvalidTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ec2_transit_gateway_invalid_auto_accept_shared_attachments_test.go
+++ b/rules/awsrules/models/aws_ec2_transit_gateway_invalid_auto_accept_shared_attachments_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ec2_transit_gateway" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEc2TransitGatewayInvalidAutoAcceptSharedAttachmentsRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEc2TransitGatewayInvalidAutoAcceptSharedAttachmentsRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEc2TransitGatewayInvalidAutoAcceptSharedAttachmentsRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEc2TransitGatewayInvalidAutoAcceptSharedAttachmentsRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ec2_transit_gateway_invalid_default_route_table_association_test.go
+++ b/rules/awsrules/models/aws_ec2_transit_gateway_invalid_default_route_table_association_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ec2_transit_gateway" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEc2TransitGatewayInvalidDefaultRouteTableAssociationRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEc2TransitGatewayInvalidDefaultRouteTableAssociationRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEc2TransitGatewayInvalidDefaultRouteTableAssociationRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEc2TransitGatewayInvalidDefaultRouteTableAssociationRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ec2_transit_gateway_invalid_default_route_table_propagation_test.go
+++ b/rules/awsrules/models/aws_ec2_transit_gateway_invalid_default_route_table_propagation_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ec2_transit_gateway" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEc2TransitGatewayInvalidDefaultRouteTablePropagationRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEc2TransitGatewayInvalidDefaultRouteTablePropagationRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEc2TransitGatewayInvalidDefaultRouteTablePropagationRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEc2TransitGatewayInvalidDefaultRouteTablePropagationRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ec2_transit_gateway_invalid_dns_support_test.go
+++ b/rules/awsrules/models/aws_ec2_transit_gateway_invalid_dns_support_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ec2_transit_gateway" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEc2TransitGatewayInvalidDNSSupportRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEc2TransitGatewayInvalidDNSSupportRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEc2TransitGatewayInvalidDNSSupportRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEc2TransitGatewayInvalidDNSSupportRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ec2_transit_gateway_vpc_attachment_invalid_ipv6_support_test.go
+++ b/rules/awsrules/models/aws_ec2_transit_gateway_vpc_attachment_invalid_ipv6_support_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEc2TransitGatewayVpcAttachmentInvalidIpv6SupportRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEc2TransitGatewayVpcAttachmentInvalidIpv6SupportRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEc2TransitGatewayVpcAttachmentInvalidIpv6SupportRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEc2TransitGatewayVpcAttachmentInvalidIpv6SupportRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ecr_lifecycle_policy_invalid_repository_test.go
+++ b/rules/awsrules/models/aws_ecr_lifecycle_policy_invalid_repository_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ecr_lifecycle_policy" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEcrLifecyclePolicyInvalidRepositoryRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEcrLifecyclePolicyInvalidRepositoryRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEcrLifecyclePolicyInvalidRepositoryRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEcrLifecyclePolicyInvalidRepositoryRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ecs_service_invalid_launch_type_test.go
+++ b/rules/awsrules/models/aws_ecs_service_invalid_launch_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ecs_service" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEcsServiceInvalidLaunchTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEcsServiceInvalidLaunchTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEcsServiceInvalidLaunchTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEcsServiceInvalidLaunchTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ecs_service_invalid_propagate_tags_test.go
+++ b/rules/awsrules/models/aws_ecs_service_invalid_propagate_tags_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ecs_service" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEcsServiceInvalidPropagateTagsRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEcsServiceInvalidPropagateTagsRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEcsServiceInvalidPropagateTagsRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEcsServiceInvalidPropagateTagsRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ecs_service_invalid_scheduling_strategy_test.go
+++ b/rules/awsrules/models/aws_ecs_service_invalid_scheduling_strategy_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ecs_service" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEcsServiceInvalidSchedulingStrategyRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEcsServiceInvalidSchedulingStrategyRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEcsServiceInvalidSchedulingStrategyRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEcsServiceInvalidSchedulingStrategyRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ecs_task_definition_invalid_ipc_mode_test.go
+++ b/rules/awsrules/models/aws_ecs_task_definition_invalid_ipc_mode_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ecs_task_definition" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEcsTaskDefinitionInvalidIpcModeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEcsTaskDefinitionInvalidIpcModeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEcsTaskDefinitionInvalidIpcModeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEcsTaskDefinitionInvalidIpcModeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ecs_task_definition_invalid_network_mode_test.go
+++ b/rules/awsrules/models/aws_ecs_task_definition_invalid_network_mode_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ecs_task_definition" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEcsTaskDefinitionInvalidNetworkModeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEcsTaskDefinitionInvalidNetworkModeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEcsTaskDefinitionInvalidNetworkModeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEcsTaskDefinitionInvalidNetworkModeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_ecs_task_definition_invalid_pid_mode_test.go
+++ b/rules/awsrules/models/aws_ecs_task_definition_invalid_pid_mode_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_ecs_task_definition" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEcsTaskDefinitionInvalidPidModeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEcsTaskDefinitionInvalidPidModeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEcsTaskDefinitionInvalidPidModeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEcsTaskDefinitionInvalidPidModeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_efs_file_system_invalid_performance_mode_test.go
+++ b/rules/awsrules/models/aws_efs_file_system_invalid_performance_mode_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_efs_file_system" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEfsFileSystemInvalidPerformanceModeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEfsFileSystemInvalidPerformanceModeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEfsFileSystemInvalidPerformanceModeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEfsFileSystemInvalidPerformanceModeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_efs_file_system_invalid_throughput_mode_test.go
+++ b/rules/awsrules/models/aws_efs_file_system_invalid_throughput_mode_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_efs_file_system" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEfsFileSystemInvalidThroughputModeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEfsFileSystemInvalidThroughputModeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEfsFileSystemInvalidThroughputModeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEfsFileSystemInvalidThroughputModeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_eks_cluster_invalid_name_test.go
+++ b/rules/awsrules/models/aws_eks_cluster_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_eks_cluster" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsEksClusterInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsEksClusterInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsEksClusterInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsEksClusterInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_elasticache_cluster_invalid_az_mode_test.go
+++ b/rules/awsrules/models/aws_elasticache_cluster_invalid_az_mode_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_elasticache_cluster" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsElastiCacheClusterInvalidAzModeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsElastiCacheClusterInvalidAzModeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsElastiCacheClusterInvalidAzModeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsElastiCacheClusterInvalidAzModeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_elastictranscoder_preset_invalid_container_test.go
+++ b/rules/awsrules/models/aws_elastictranscoder_preset_invalid_container_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_elastictranscoder_preset" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsElastictranscoderPresetInvalidContainerRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsElastictranscoderPresetInvalidContainerRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsElastictranscoderPresetInvalidContainerRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsElastictranscoderPresetInvalidContainerRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_instance_invalid_instance_initiated_shutdown_behavior_test.go
+++ b/rules/awsrules/models/aws_instance_invalid_instance_initiated_shutdown_behavior_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_instance" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsInstanceInvalidInstanceInitiatedShutdownBehaviorRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsInstanceInvalidInstanceInitiatedShutdownBehaviorRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsInstanceInvalidInstanceInitiatedShutdownBehaviorRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsInstanceInvalidInstanceInitiatedShutdownBehaviorRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_instance_invalid_tenancy_test.go
+++ b/rules/awsrules/models/aws_instance_invalid_tenancy_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_instance" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsInstanceInvalidTenancyRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsInstanceInvalidTenancyRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsInstanceInvalidTenancyRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsInstanceInvalidTenancyRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_launch_template_invalid_instance_type_test.go
+++ b/rules/awsrules/models/aws_launch_template_invalid_instance_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_launch_template" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsLaunchTemplateInvalidInstanceTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsLaunchTemplateInvalidInstanceTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsLaunchTemplateInvalidInstanceTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsLaunchTemplateInvalidInstanceTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_launch_template_invalid_name_test.go
+++ b/rules/awsrules/models/aws_launch_template_invalid_name_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_launch_template" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsLaunchTemplateInvalidNameRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsLaunchTemplateInvalidNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsLaunchTemplateInvalidNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsLaunchTemplateInvalidNameRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_lb_invalid_ip_address_type_test.go
+++ b/rules/awsrules/models/aws_lb_invalid_ip_address_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_lb" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsLbInvalidIPAddressTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsLbInvalidIPAddressTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsLbInvalidIPAddressTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsLbInvalidIPAddressTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_lb_invalid_load_balancer_type_test.go
+++ b/rules/awsrules/models/aws_lb_invalid_load_balancer_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_lb" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsLbInvalidLoadBalancerTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsLbInvalidLoadBalancerTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsLbInvalidLoadBalancerTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsLbInvalidLoadBalancerTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_lb_listener_invalid_protocol_test.go
+++ b/rules/awsrules/models/aws_lb_listener_invalid_protocol_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_lb_listener" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsLbListenerInvalidProtocolRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsLbListenerInvalidProtocolRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsLbListenerInvalidProtocolRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsLbListenerInvalidProtocolRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_lb_target_group_invalid_target_type_test.go
+++ b/rules/awsrules/models/aws_lb_target_group_invalid_target_type_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_lb_target_group" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsLbTargetGroupInvalidTargetTypeRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsLbTargetGroupInvalidTargetTypeRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsLbTargetGroupInvalidTargetTypeRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsLbTargetGroupInvalidTargetTypeRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_placement_group_invalid_strategy_test.go
+++ b/rules/awsrules/models/aws_placement_group_invalid_strategy_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_placement_group" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsPlacementGroupInvalidStrategyRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsPlacementGroupInvalidStrategyRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsPlacementGroupInvalidStrategyRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsPlacementGroupInvalidStrategyRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_spot_fleet_request_invalid_allocation_strategy_test.go
+++ b/rules/awsrules/models/aws_spot_fleet_request_invalid_allocation_strategy_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_spot_fleet_request" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsSpotFleetRequestInvalidAllocationStrategyRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsSpotFleetRequestInvalidAllocationStrategyRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsSpotFleetRequestInvalidAllocationStrategyRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsSpotFleetRequestInvalidAllocationStrategyRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/aws_spot_fleet_request_invalid_instance_interruption_behaviour_test.go
+++ b/rules/awsrules/models/aws_spot_fleet_request_invalid_instance_interruption_behaviour_test.go
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -44,59 +37,15 @@ resource "aws_spot_fleet_request" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "AwsSpotFleetRequestInvalidInstanceInterruptionBehaviourRule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewAwsSpotFleetRequestInvalidInstanceInterruptionBehaviourRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewAwsSpotFleetRequestInvalidInstanceInterruptionBehaviourRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(AwsSpotFleetRequestInvalidInstanceInterruptionBehaviourRule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/awsrules/models/pattern_rule_test.go.tmpl
+++ b/rules/awsrules/models/pattern_rule_test.go.tmpl
@@ -3,15 +3,8 @@
 package models
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -49,59 +42,15 @@ resource "{{ .ResourceType }}" "foo" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "{{ .RuleNameCC }}Rule")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := New{{ .RuleNameCC }}Rule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := New{{ .RuleNameCC }}Rule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported({{ .RuleNameCC }}Rule{}),
-			cmpopts.IgnoreFields(tflint.Issue{}, "Range"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssuesWithoutRange(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/rule_test.go.tmpl
+++ b/rules/rule_test.go.tmpl
@@ -2,18 +2,11 @@ package awsrules
 
 import (
 	"errors"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl2/hcl"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
-	"github.com/wata727/tflint/mock"
+	"github.com/wata727/tflint/client"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -45,137 +38,58 @@ resource "null_resource" "null" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "{{ .RuleNameCC }}")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := New{{ .RuleNameCC }}Rule()
-
-		mock := mock.NewMockAPI(ctrl)
+		mock := client.NewMockAPI(ctrl)
 		mock.EXPECT().CallAPI().Return(tc.Response, nil)
 		runner.AwsClient.Service = mock
 
-		if err = rule.Check(runner); err != nil {
+		rule := New{{ .RuleNameCC }}Rule()
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported({{ .RuleNameCC }}Rule{}),
-			cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
-		}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
 	}
 }
 
 func Test_{{ .RuleNameCC }}_error(t *testing.T) {
 	cases := []struct {
-		Name       string
-		Content    string
-		Response   error
-		ErrorCode  int
-		ErrorLevel int
-		ErrorText  string
+		Name     string
+		Content  string
+		Response error
+		Error    tflint.Error
 	}{
 		{
 			Name: "API error",
 			Content: `
 resource "null_resource" "null" {
 }`,
-			Response:   errors.New("Some error"),
-			ErrorCode:  tflint.ExternalAPIError,
-			ErrorLevel: tflint.ErrorLevel,
-			ErrorText:  "Some error",
+			Response: errors.New("Some error"),
+			Error: tflint.Error{
+				Code:    tflint.ExternalAPIError,
+				Level:   tflint.ErrorLevel,
+				Message: "Some error",
+			},
 		},
 	}
-
-	dir, err := ioutil.TempDir("", "{{ .RuleNameCC }}_error")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		err = ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(dir)
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner := tflint.NewRunner(tflint.EmptyConfig(), cfg, map[string]*terraform.InputValue{})
-		rule := New{{ .RuleNameCC }}Rule()
+		runner := tflint.TestRunner(t, map[string]string{"resource.tf": tc.Content})
 
 		mock := mock.NewMockAPI(ctrl)
 		mock.EXPECT().CallAPI().Return(nil, tc.Response)
 		runner.AwsClient.Service = mock
 
-		err = rule.Check(runner)
-		if appErr, ok := err.(*tflint.Error); ok {
-			if appErr == nil {
-				t.Fatalf("Failed `%s` test: expected err is `%s`, but nothing occurred", tc.Name, tc.ErrorText)
-			}
-			if appErr.Code != tc.ErrorCode {
-				t.Fatalf("Failed `%s` test: expected error code is `%d`, but get `%d`", tc.Name, tc.ErrorCode, appErr.Code)
-			}
-			if appErr.Level != tc.ErrorLevel {
-				t.Fatalf("Failed `%s` test: expected error level is `%d`, but get `%d`", tc.Name, tc.ErrorLevel, appErr.Level)
-			}
-			if appErr.Error() != tc.ErrorText {
-				t.Fatalf("Failed `%s` test: expected error is `%s`, but get `%s`", tc.Name, tc.ErrorText, appErr.Error())
-			}
-		} else {
-			t.Fatalf("Failed `%s` test: unexpected error occurred: %s", tc.Name, err)
-		}
+		rule := New{{ .RuleNameCC }}Rule()
+		err := rule.Check(runner)
+		tflint.AssertAppError(t, tc.Error, err)
 	}
 }

--- a/rules/terraformrules/terraform_dash_in_resource_name_test.go
+++ b/rules/terraformrules/terraform_dash_in_resource_name_test.go
@@ -1,16 +1,9 @@
 package terraformrules
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl2/hcl"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -46,56 +39,15 @@ resource "aws_eip" "no_dash_name" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "TerraformDashInResourceName")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewTerraformDashInResourceNameRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"resources.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/resources.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewTerraformDashInResourceNameRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{cmpopts.IgnoreFields(hcl.Pos{}, "Byte")}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/terraformrules/terraform_documented_outputs_test.go
+++ b/rules/terraformrules/terraform_documented_outputs_test.go
@@ -1,16 +1,9 @@
 package terraformrules
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl2/hcl"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -68,56 +61,15 @@ output "endpoint" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "TerraformDocumentedOutputs")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewTerraformDocumentedOutputsRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"outputs.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/outputs.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewTerraformDocumentedOutputsRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{cmpopts.IgnoreFields(hcl.Pos{}, "Byte")}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
 	}
 }

--- a/rules/terraformrules/terraform_documented_variables_test.go
+++ b/rules/terraformrules/terraform_documented_variables_test.go
@@ -1,16 +1,9 @@
 package terraformrules
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/hcl2/hcl"
-	"github.com/hashicorp/terraform/configs"
-	"github.com/hashicorp/terraform/configs/configload"
-	"github.com/hashicorp/terraform/terraform"
 	"github.com/wata727/tflint/tflint"
 )
 
@@ -66,56 +59,15 @@ variable "with_description" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "TerraformDocumentedVariables")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rule := NewTerraformDocumentedVariablesRule()
 
 	for _, tc := range cases {
-		loader, err := configload.NewLoader(&configload.Config{})
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := tflint.TestRunner(t, map[string]string{"variables.tf": tc.Content})
 
-		err = ioutil.WriteFile(dir+"/variables.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		mod, diags := loader.Parser().LoadConfigDir(".")
-		if diags.HasErrors() {
-			t.Fatal(diags)
-		}
-		cfg, tfdiags := configs.BuildConfig(mod, configs.DisabledModuleWalker)
-		if tfdiags.HasErrors() {
-			t.Fatal(tfdiags)
-		}
-
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		rule := NewTerraformDocumentedVariablesRule()
-
-		if err = rule.Check(runner); err != nil {
+		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
 
-		opts := []cmp.Option{cmpopts.IgnoreFields(hcl.Pos{}, "Byte")}
-		if !cmp.Equal(tc.Expected, runner.Issues, opts...) {
-			t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(tc.Expected, runner.Issues, opts...))
-		}
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
 	}
 }

--- a/tflint/loader_test.go
+++ b/tflint/loader_test.go
@@ -2,8 +2,6 @@ package tflint
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -17,301 +15,241 @@ import (
 )
 
 func Test_LoadConfig_v0_12_0(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
+	withinFixtureDir(t, "v0.12.0_module", func() {
+		loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, moduleConfig())
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+		config, err := loader.LoadConfig(".")
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
 
-	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "v0.12.0_module"))
-	if err != nil {
-		t.Fatal(err)
-	}
+		if _, exists := config.Children["ecs_on_spotfleet"]; !exists {
+			t.Fatalf("`ecs_on_spotfleet` module is not loaded: %#v", config.Children)
+		}
 
-	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, moduleConfig())
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-	config, err := loader.LoadConfig(".")
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
+		if _, exists := config.Children["ecs_on_spotfleet"].Module.ManagedResources["aws_ecs_cluster.main"]; !exists {
+			t.Fatalf("`ecs_on_spotfleet` module resource `aws_ecs_cluster.main` is not loaded: %#v", config.Children["ecs_on_spotfleet"].Module.ManagedResources)
+		}
 
-	if _, exists := config.Children["ecs_on_spotfleet"]; !exists {
-		t.Fatalf("`ecs_on_spotfleet` module is not loaded: %#v", config.Children)
-	}
+		if _, exists := config.Children["instance"]; !exists {
+			t.Fatalf("`instance` module is not loaded: %#v", config.Children)
+		}
 
-	if _, exists := config.Children["ecs_on_spotfleet"].Module.ManagedResources["aws_ecs_cluster.main"]; !exists {
-		t.Fatalf("`ecs_on_spotfleet` module resource `aws_ecs_cluster.main` is not loaded: %#v", config.Children["ecs_on_spotfleet"].Module.ManagedResources)
-	}
+		if _, exists := config.Children["consul"]; !exists {
+			t.Fatalf("`consul` module is not loaded: %#v", config.Children)
+		}
 
-	if _, exists := config.Children["instance"]; !exists {
-		t.Fatalf("`instance` module is not loaded: %#v", config.Children)
-	}
+		if _, exists := config.Children["consul"].Children["consul_clients"]; !exists {
+			t.Fatalf("`consul.consul_clients` module is not loaded: %#v", config.Children["consul"].Children)
+		}
 
-	if _, exists := config.Children["consul"]; !exists {
-		t.Fatalf("`consul` module is not loaded: %#v", config.Children)
-	}
+		if _, exists := config.Children["consul"].Children["consul_clients"].Children["iam_policies"]; !exists {
+			t.Fatalf("`consule.consul_clients.iam_policies` module is not loaded: %#v", config.Children["consul"].Children["consul_clients"].Children)
+		}
 
-	if _, exists := config.Children["consul"].Children["consul_clients"]; !exists {
-		t.Fatalf("`consul.consul_clients` module is not loaded: %#v", config.Children["consul"].Children)
-	}
+		if _, exists := config.Children["consul"].Children["consul_clients"].Children["iam_policies"].Module.ManagedResources["aws_iam_role_policy.auto_discover_cluster"]; !exists {
+			t.Fatalf("`consule.consul_clients.iam_policies` module resource `aws_iam_role_policy.auto_discover_cluster` is not loaded: %#v", config.Children["consul"].Children["consul_clients"].Children["iam_policies"].Module.ManagedResources)
+		}
 
-	if _, exists := config.Children["consul"].Children["consul_clients"].Children["iam_policies"]; !exists {
-		t.Fatalf("`consule.consul_clients.iam_policies` module is not loaded: %#v", config.Children["consul"].Children["consul_clients"].Children)
-	}
+		if _, exists := config.Children["consul"].Children["consul_clients"].Children["security_group_rules"]; !exists {
+			t.Fatalf("`consule.consul_clients.security_group_rules` module is not loaded: %#v", config.Children["consul"].Children["consul_clients"].Children)
+		}
 
-	if _, exists := config.Children["consul"].Children["consul_clients"].Children["iam_policies"].Module.ManagedResources["aws_iam_role_policy.auto_discover_cluster"]; !exists {
-		t.Fatalf("`consule.consul_clients.iam_policies` module resource `aws_iam_role_policy.auto_discover_cluster` is not loaded: %#v", config.Children["consul"].Children["consul_clients"].Children["iam_policies"].Module.ManagedResources)
-	}
+		if _, exists := config.Children["consul"].Children["consul_clients"].Children["security_group_rules"].Module.ManagedResources["aws_security_group_rule.allow_server_rpc_inbound"]; !exists {
+			t.Fatalf("`consule.consul_clients.security_group_rules` module resource `aws_security_group_rule.allow_server_rpc_inbound` is not loaded: %#v", config.Children["consul"].Children["consul_clients"].Children["security_group_rules"].Module.ManagedResources)
+		}
 
-	if _, exists := config.Children["consul"].Children["consul_clients"].Children["security_group_rules"]; !exists {
-		t.Fatalf("`consule.consul_clients.security_group_rules` module is not loaded: %#v", config.Children["consul"].Children["consul_clients"].Children)
-	}
+		if _, exists := config.Children["consul"].Children["consul_servers"]; !exists {
+			t.Fatalf("`consul.consul_servers` module is not loaded: %#v", config.Children["consul"].Children)
+		}
 
-	if _, exists := config.Children["consul"].Children["consul_clients"].Children["security_group_rules"].Module.ManagedResources["aws_security_group_rule.allow_server_rpc_inbound"]; !exists {
-		t.Fatalf("`consule.consul_clients.security_group_rules` module resource `aws_security_group_rule.allow_server_rpc_inbound` is not loaded: %#v", config.Children["consul"].Children["consul_clients"].Children["security_group_rules"].Module.ManagedResources)
-	}
+		if _, exists := config.Children["consul"].Children["consul_servers"].Children["iam_policies"]; !exists {
+			t.Fatalf("`consule.consul_servers.iam_policies` module is not loaded: %#v", config.Children["consul"].Children["consul_servers"].Children)
+		}
 
-	if _, exists := config.Children["consul"].Children["consul_servers"]; !exists {
-		t.Fatalf("`consul.consul_servers` module is not loaded: %#v", config.Children["consul"].Children)
-	}
+		if _, exists := config.Children["consul"].Children["consul_servers"].Children["iam_policies"].Module.ManagedResources["aws_iam_role_policy.auto_discover_cluster"]; !exists {
+			t.Fatalf("`consule.consul_servers.iam_policies` module resource `aws_iam_role_policy.auto_discover_cluster` is not loaded: %#v", config.Children["consul"].Children["consul_servers"].Children["iam_policies"].Module.ManagedResources)
+		}
 
-	if _, exists := config.Children["consul"].Children["consul_servers"].Children["iam_policies"]; !exists {
-		t.Fatalf("`consule.consul_servers.iam_policies` module is not loaded: %#v", config.Children["consul"].Children["consul_servers"].Children)
-	}
+		if _, exists := config.Children["consul"].Children["consul_servers"].Children["security_group_rules"]; !exists {
+			t.Fatalf("`consule.consul_servers.security_group_rules` module is not loaded: %#v", config.Children["consul"].Children["consul_servers"].Children)
+		}
 
-	if _, exists := config.Children["consul"].Children["consul_servers"].Children["iam_policies"].Module.ManagedResources["aws_iam_role_policy.auto_discover_cluster"]; !exists {
-		t.Fatalf("`consule.consul_servers.iam_policies` module resource `aws_iam_role_policy.auto_discover_cluster` is not loaded: %#v", config.Children["consul"].Children["consul_servers"].Children["iam_policies"].Module.ManagedResources)
-	}
-
-	if _, exists := config.Children["consul"].Children["consul_servers"].Children["security_group_rules"]; !exists {
-		t.Fatalf("`consule.consul_servers.security_group_rules` module is not loaded: %#v", config.Children["consul"].Children["consul_servers"].Children)
-	}
-
-	if _, exists := config.Children["consul"].Children["consul_servers"].Children["security_group_rules"].Module.ManagedResources["aws_security_group_rule.allow_server_rpc_inbound"]; !exists {
-		t.Fatalf("`consule.consul_servers.security_group_rules` module resource `aws_security_group_rule.allow_server_rpc_inbound` is not loaded: %#v", config.Children["consul"].Children["consul_servers"].Children["security_group_rules"].Module.ManagedResources)
-	}
+		if _, exists := config.Children["consul"].Children["consul_servers"].Children["security_group_rules"].Module.ManagedResources["aws_security_group_rule.allow_server_rpc_inbound"]; !exists {
+			t.Fatalf("`consule.consul_servers.security_group_rules` module resource `aws_security_group_rule.allow_server_rpc_inbound` is not loaded: %#v", config.Children["consul"].Children["consul_servers"].Children["security_group_rules"].Module.ManagedResources)
+		}
+	})
 }
 
 func Test_LoadConfig_moduleNotFound(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
+	withinFixtureDir(t, "before_terraform_init", func() {
+		loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, moduleConfig())
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+		_, err = loader.LoadConfig(".")
+		if err == nil {
+			t.Fatal("Expected error is not occurred")
+		}
 
-	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "before_terraform_init"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, moduleConfig())
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-	_, err = loader.LoadConfig(".")
-	if err == nil {
-		t.Fatal("Expected error is not occurred")
-	}
-
-	expected := "module.tf:1,1-22: `ec2_instance` module is not found. Did you run `terraform init`?; "
-	if err.Error() != expected {
-		t.Fatalf("Expected error is `%s`, but get `%s`", expected, err.Error())
-	}
+		expected := "module.tf:1,1-22: `ec2_instance` module is not found. Did you run `terraform init`?; "
+		if err.Error() != expected {
+			t.Fatalf("Expected error is `%s`, but get `%s`", expected, err.Error())
+		}
+	})
 }
 
 func Test_LoadConfig_disableModules(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
+	withinFixtureDir(t, "before_terraform_init", func() {
+		loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+		config, err := loader.LoadConfig(".")
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
 
-	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "before_terraform_init"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-	config, err := loader.LoadConfig(".")
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-
-	if len(config.Children) != 0 {
-		t.Fatalf("Root module has children unexpectedly: %#v", config.Children)
-	}
+		if len(config.Children) != 0 {
+			t.Fatalf("Root module has children unexpectedly: %#v", config.Children)
+		}
+	})
 }
 
 func Test_LoadConfig_invalidConfiguration(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
+	withinFixtureDir(t, "invalid_configuration", func() {
+		loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+		_, err = loader.LoadConfig(".")
+		if err == nil {
+			t.Fatal("Expected error is not occurred")
+		}
 
-	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "invalid_configuration"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-	_, err = loader.LoadConfig(".")
-	if err == nil {
-		t.Fatal("Expected error is not occurred")
-	}
-
-	expected := "resource.tf:1,1-10: Unsupported block type; Blocks of type \"resources\" are not expected here. Did you mean \"resource\"?"
-	if err.Error() != expected {
-		t.Fatalf("Expected error is `%s`, but get `%s`", expected, err.Error())
-	}
+		expected := "resource.tf:1,1-10: Unsupported block type; Blocks of type \"resources\" are not expected here. Did you mean \"resource\"?"
+		if err.Error() != expected {
+			t.Fatalf("Expected error is `%s`, but get `%s`", expected, err.Error())
+		}
+	})
 }
 
 func Test_LoadAnnotations(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
+	withinFixtureDir(t, "annotation_files", func() {
+		loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+		ret, err := loader.LoadAnnotations(".")
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
 
-	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "annotation_files"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-	ret, err := loader.LoadAnnotations(".")
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-
-	expected := map[string]Annotations{
-		"file1.tf": {
-			{
-				Content: "aws_instance_invalid_type",
-				Token: hclsyntax.Token{
-					Type:  hclsyntax.TokenComment,
-					Bytes: []byte(fmt.Sprintf("// tflint-ignore: aws_instance_invalid_type%s", newLine())),
-					Range: hcl.Range{
-						Filename: "file1.tf",
-						Start:    hcl.Pos{Line: 2, Column: 5},
-						End:      hcl.Pos{Line: 3, Column: 1},
+		expected := map[string]Annotations{
+			"file1.tf": {
+				{
+					Content: "aws_instance_invalid_type",
+					Token: hclsyntax.Token{
+						Type:  hclsyntax.TokenComment,
+						Bytes: []byte(fmt.Sprintf("// tflint-ignore: aws_instance_invalid_type%s", newLine())),
+						Range: hcl.Range{
+							Filename: "file1.tf",
+							Start:    hcl.Pos{Line: 2, Column: 5},
+							End:      hcl.Pos{Line: 3, Column: 1},
+						},
 					},
 				},
 			},
-		},
-		"file2.tf": {
-			{
-				Content: "aws_instance_invalid_type",
-				Token: hclsyntax.Token{
-					Type:  hclsyntax.TokenComment,
-					Bytes: []byte(fmt.Sprintf("// tflint-ignore: aws_instance_invalid_type%s", newLine())),
-					Range: hcl.Range{
-						Filename: "file2.tf",
-						Start:    hcl.Pos{Line: 2, Column: 32},
-						End:      hcl.Pos{Line: 3, Column: 1},
+			"file2.tf": {
+				{
+					Content: "aws_instance_invalid_type",
+					Token: hclsyntax.Token{
+						Type:  hclsyntax.TokenComment,
+						Bytes: []byte(fmt.Sprintf("// tflint-ignore: aws_instance_invalid_type%s", newLine())),
+						Range: hcl.Range{
+							Filename: "file2.tf",
+							Start:    hcl.Pos{Line: 2, Column: 32},
+							End:      hcl.Pos{Line: 3, Column: 1},
+						},
 					},
 				},
 			},
-		},
-		"file3.tf": {},
-	}
+			"file3.tf": {},
+		}
 
-	opts := cmpopts.IgnoreFields(hcl.Pos{}, "Byte")
-	if !cmp.Equal(expected, ret, opts) {
-		t.Fatalf("Test failed. Diff: %s", cmp.Diff(expected, ret, opts))
-	}
+		opts := cmpopts.IgnoreFields(hcl.Pos{}, "Byte")
+		if !cmp.Equal(expected, ret, opts) {
+			t.Fatalf("Test failed. Diff: %s", cmp.Diff(expected, ret, opts))
+		}
+	})
 }
 
 func Test_LoadValuesFiles(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
+	withinFixtureDir(t, "values_files", func() {
+		loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+		ret, err := loader.LoadValuesFiles("cli1.tfvars", "cli2.tfvars")
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
 
-	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "values_files"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-	ret, err := loader.LoadValuesFiles("cli1.tfvars", "cli2.tfvars")
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
+		expected := []terraform.InputValues{
+			{
+				"default": {
+					Value:      cty.StringVal("terraform.tfvars"),
+					SourceType: terraform.ValueFromAutoFile,
+				},
+			},
+			{
+				"auto1": {
+					Value:      cty.StringVal("auto1.auto.tfvars"),
+					SourceType: terraform.ValueFromAutoFile,
+				},
+			},
+			{
+				"auto2": {
+					Value:      cty.StringVal("auto2.auto.tfvars"),
+					SourceType: terraform.ValueFromAutoFile,
+				},
+			},
+			{
+				"cli1": {
+					Value:      cty.StringVal("cli1.tfvars"),
+					SourceType: terraform.ValueFromNamedFile,
+				},
+			},
+			{
+				"cli2": {
+					Value:      cty.StringVal("cli2.tfvars"),
+					SourceType: terraform.ValueFromNamedFile,
+				},
+			},
+		}
 
-	expected := []terraform.InputValues{
-		{
-			"default": {
-				Value:      cty.StringVal("terraform.tfvars"),
-				SourceType: terraform.ValueFromAutoFile,
-			},
-		},
-		{
-			"auto1": {
-				Value:      cty.StringVal("auto1.auto.tfvars"),
-				SourceType: terraform.ValueFromAutoFile,
-			},
-		},
-		{
-			"auto2": {
-				Value:      cty.StringVal("auto2.auto.tfvars"),
-				SourceType: terraform.ValueFromAutoFile,
-			},
-		},
-		{
-			"cli1": {
-				Value:      cty.StringVal("cli1.tfvars"),
-				SourceType: terraform.ValueFromNamedFile,
-			},
-		},
-		{
-			"cli2": {
-				Value:      cty.StringVal("cli2.tfvars"),
-				SourceType: terraform.ValueFromNamedFile,
-			},
-		},
-	}
-
-	if !reflect.DeepEqual(expected, ret) {
-		t.Fatalf("Unexpected input values are received: expected=%#v actual=%#v", expected, ret)
-	}
+		if !reflect.DeepEqual(expected, ret) {
+			t.Fatalf("Unexpected input values are received: expected=%#v actual=%#v", expected, ret)
+		}
+	})
 }
 
 func Test_LoadValuesFiles_invalidValuesFile(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
+	withinFixtureDir(t, "invalid_values_files", func() {
+		loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+		_, err = loader.LoadValuesFiles()
+		if err == nil {
+			t.Fatal("Expected error is not occurred")
+		}
 
-	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "invalid_values_files"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-	_, err = loader.LoadValuesFiles()
-	if err == nil {
-		t.Fatal("Expected error is not occurred")
-	}
-
-	expected := "terraform.tfvars:3,1-9: Unexpected \"resource\" block; Blocks are not allowed here."
-	if err.Error() != expected {
-		t.Fatalf("Expected error is `%s`, but get `%s`", expected, err.Error())
-	}
+		expected := "terraform.tfvars:3,1-9: Unexpected \"resource\" block; Blocks are not allowed here."
+		if err.Error() != expected {
+			t.Fatalf("Expected error is `%s`, but get `%s`", expected, err.Error())
+		}
+	})
 }

--- a/tflint/loader_test.go
+++ b/tflint/loader_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/hcl2/hcl/hclsyntax"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/spf13/afero"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -27,7 +28,7 @@ func Test_LoadConfig_v0_12_0(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader(moduleConfig())
+	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -105,7 +106,7 @@ func Test_LoadConfig_moduleNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader(moduleConfig())
+	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -132,7 +133,7 @@ func Test_LoadConfig_disableModules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader(EmptyConfig())
+	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -158,7 +159,7 @@ func Test_LoadConfig_invalidConfiguration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader(EmptyConfig())
+	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -184,7 +185,7 @@ func Test_LoadAnnotations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	loader, err := NewLoader(EmptyConfig())
+	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -242,7 +243,7 @@ func Test_LoadValuesFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	loader, err := NewLoader(EmptyConfig())
+	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -300,7 +301,7 @@ func Test_LoadValuesFiles_invalidValuesFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	loader, err := NewLoader(EmptyConfig())
+	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}

--- a/tflint/provider_test.go
+++ b/tflint/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/spf13/afero"
 	"github.com/wata727/tflint/client"
 )
 
@@ -21,7 +22,7 @@ func Test_Get(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader(EmptyConfig())
+	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -114,7 +115,7 @@ func Test_Get_withEmptyProvider(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader(EmptyConfig())
+	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}

--- a/tflint/provider_test.go
+++ b/tflint/provider_test.go
@@ -1,151 +1,103 @@
 package tflint
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
-	"github.com/hashicorp/terraform/terraform"
-	"github.com/spf13/afero"
 	"github.com/wata727/tflint/client"
 )
 
 func Test_Get(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
-
-	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "provider_config"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-	cfg, err := loader.LoadConfig(".")
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-
-	runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-	if err != nil {
-		t.Fatalf("Unexpected error occrred: %s", err)
-	}
-
-	providerConfig, err := NewProviderConfig(
-		runner.TFConfig.Module.ProviderConfigs["aws"],
-		runner,
-		client.AwsProviderBlockSchema,
-	)
-	if err != nil {
-		t.Fatalf("Unexpected error occrred: %s", err)
-	}
-
-	cases := []struct {
-		Key    string
-		Value  string
-		Exists bool
-		Err    error
-	}{
-		{
-			Key:    "access_key",
-			Value:  "AWS_ACCESS_KEY",
-			Exists: true,
-			Err:    nil,
-		},
-		{
-			Key:    "secret_key",
-			Value:  "",
-			Exists: true,
-			Err:    nil,
-		},
-		{
-			Key:    "region",
-			Value:  "us-east-1",
-			Exists: true,
-			Err:    nil,
-		},
-		{
-			Key:    "profile",
-			Value:  "",
-			Exists: true,
-			Err:    nil,
-		},
-		{
-			Key:    "shared_credentials_file",
-			Value:  "",
-			Exists: true,
-			Err:    nil,
-		},
-		{
-			Key:    "undefined",
-			Value:  "",
-			Exists: false,
-			Err:    nil,
-		},
-	}
-
-	for _, tc := range cases {
-		val, exists, err := providerConfig.Get(tc.Key)
-		if val != tc.Value {
-			t.Fatalf("Expected `%s` as the key value of `%s`, but got `%s`", tc.Value, tc.Key, val)
+	withinFixtureDir(t, "provider_config", func() {
+		runner := testRunnerWithOsFs(t, EmptyConfig())
+		providerConfig, err := NewProviderConfig(
+			runner.TFConfig.Module.ProviderConfigs["aws"],
+			runner,
+			client.AwsProviderBlockSchema,
+		)
+		if err != nil {
+			t.Fatalf("Unexpected error occrred: %s", err)
 		}
-		if exists != tc.Exists {
-			t.Fatalf("Expected `%t` as the exists, but got `%t`", tc.Exists, exists)
+
+		cases := []struct {
+			Key    string
+			Value  string
+			Exists bool
+			Err    error
+		}{
+			{
+				Key:    "access_key",
+				Value:  "AWS_ACCESS_KEY",
+				Exists: true,
+				Err:    nil,
+			},
+			{
+				Key:    "secret_key",
+				Value:  "",
+				Exists: true,
+				Err:    nil,
+			},
+			{
+				Key:    "region",
+				Value:  "us-east-1",
+				Exists: true,
+				Err:    nil,
+			},
+			{
+				Key:    "profile",
+				Value:  "",
+				Exists: true,
+				Err:    nil,
+			},
+			{
+				Key:    "shared_credentials_file",
+				Value:  "",
+				Exists: true,
+				Err:    nil,
+			},
+			{
+				Key:    "undefined",
+				Value:  "",
+				Exists: false,
+				Err:    nil,
+			},
 		}
-		if err != tc.Err {
-			t.Fatalf("Expected `%s` as the error, but got `%s`", tc.Err, err)
+
+		for _, tc := range cases {
+			val, exists, err := providerConfig.Get(tc.Key)
+			if val != tc.Value {
+				t.Fatalf("Expected `%s` as the key value of `%s`, but got `%s`", tc.Value, tc.Key, val)
+			}
+			if exists != tc.Exists {
+				t.Fatalf("Expected `%t` as the exists, but got `%t`", tc.Exists, exists)
+			}
+			if err != tc.Err {
+				t.Fatalf("Expected `%s` as the error, but got `%s`", tc.Err, err)
+			}
 		}
-	}
+	})
 }
 
 func Test_Get_withEmptyProvider(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
+	withinFixtureDir(t, "provider_config", func() {
+		runner := testRunnerWithOsFs(t, EmptyConfig())
+		providerConfig, err := NewProviderConfig(
+			nil,
+			runner,
+			client.AwsProviderBlockSchema,
+		)
+		if err != nil {
+			t.Fatalf("Unexpected error occrred: %s", err)
+		}
 
-	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "provider_config"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-	cfg, err := loader.LoadConfig(".")
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-
-	runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-	if err != nil {
-		t.Fatalf("Unexpected error occrred: %s", err)
-	}
-
-	providerConfig, err := NewProviderConfig(
-		nil,
-		runner,
-		client.AwsProviderBlockSchema,
-	)
-	if err != nil {
-		t.Fatalf("Unexpected error occrred: %s", err)
-	}
-
-	val, exists, err := providerConfig.Get("key")
-	if val != "" {
-		t.Fatalf("Expected empty string, but got `%s`", val)
-	}
-	if exists {
-		t.Fatal("Expected not exists, but exists")
-	}
-	if err != nil {
-		t.Fatalf("Expected to return nil, but got `%s`", err)
-	}
+		val, exists, err := providerConfig.Get("key")
+		if val != "" {
+			t.Fatalf("Expected empty string, but got `%s`", val)
+		}
+		if exists {
+			t.Fatal("Expected not exists, but exists")
+		}
+		if err != nil {
+			t.Fatalf("Expected to return nil, but got `%s`", err)
+		}
+	})
 }

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -3,7 +3,6 @@ package tflint
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,17 +13,10 @@ import (
 	"github.com/hashicorp/hcl2/hcl/hclsyntax"
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/spf13/afero"
 	"github.com/zclconf/go-cty/cty"
 )
 
 func Test_EvaluateExpr_string(t *testing.T) {
-	dir, err := ioutil.TempDir("", "string")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	cases := []struct {
 		Name     string
 		Content  string
@@ -156,7 +148,7 @@ resource "null_resource" "test" {
 resource "null_resource" "test" {
   key = path.root
 }`,
-			Expected: filepath.ToSlash(dir),
+			Expected: ".",
 		},
 		{
 			Name: "path.module",
@@ -164,86 +156,58 @@ resource "null_resource" "test" {
 resource "null_resource" "test" {
   key = path.module
 }`,
-			Expected: filepath.ToSlash(dir),
+			Expected: ".",
 		},
 	}
 
 	for _, tc := range cases {
-		err := ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := TestRunner(t, map[string]string{"main.tf": tc.Content})
 
-		cfg, err := loadConfigHelper(dir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		attribute, err := extractAttributeHelper("key", cfg)
-		if err != nil {
-			t.Fatal(err)
-		}
+		err := runner.WalkResourceAttributes("null_resource", "key", func(attribute *hcl.Attribute) error {
+			var ret string
+			if err := runner.EvaluateExpr(attribute.Expr, &ret); err != nil {
+				return err
+			}
 
-		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
-		}
+			if tc.Expected != ret {
+				t.Fatalf("Failed `%s` test: expected value is `%s`, but get `%s`", tc.Name, tc.Expected, ret)
+			}
+			return nil
+		})
 
-		var ret string
-		err = runner.EvaluateExpr(attribute.Expr, &ret)
 		if err != nil {
 			t.Fatalf("Failed `%s` test: `%s` occurred", tc.Name, err)
-		}
-
-		if tc.Expected != ret {
-			t.Fatalf("Failed `%s` test: expected value is `%s`, but get `%s`", tc.Name, tc.Expected, ret)
 		}
 	}
 }
 
 func Test_EvaluateExpr_pathCwd(t *testing.T) {
-	dir, err := ioutil.TempDir("", "string")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	content := `
-resource "null_resource" "test" {
-  key = path.cwd
-}`
 	cwd, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
 	}
 	expected := filepath.ToSlash(cwd)
 
-	err = ioutil.WriteFile(dir+"/resource.tf", []byte(content), os.ModePerm)
-	if err != nil {
-		t.Fatal(err)
-	}
+	content := `
+resource "null_resource" "test" {
+  key = path.cwd
+}`
+	runner := TestRunner(t, map[string]string{"main.tf": content})
 
-	cfg, err := loadConfigHelper(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	attribute, err := extractAttributeHelper("key", cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	err = runner.WalkResourceAttributes("null_resource", "key", func(attribute *hcl.Attribute) error {
+		var ret string
+		if err := runner.EvaluateExpr(attribute.Expr, &ret); err != nil {
+			return err
+		}
 
-	runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-	if err != nil {
-		t.Fatalf("Unexpected error: %s", err)
-	}
+		if expected != ret {
+			t.Fatalf("expected value is `%s`, but get `%s`", expected, ret)
+		}
+		return nil
+	})
 
-	var ret string
-	err = runner.EvaluateExpr(attribute.Expr, &ret)
 	if err != nil {
-		t.Fatalf("Unexpected error: `%s`", err)
-	}
-
-	if expected != ret {
-		t.Fatalf("expected value is `%s`, but get `%s`", expected, ret)
+		t.Fatalf("Failed: `%s` occurred", err)
 	}
 }
 
@@ -279,40 +243,23 @@ resource "null_resource" "test" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "integer")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	for _, tc := range cases {
-		err := ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := TestRunner(t, map[string]string{"main.tf": tc.Content})
 
-		cfg, err := loadConfigHelper(dir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		attribute, err := extractAttributeHelper("key", cfg)
-		if err != nil {
-			t.Fatal(err)
-		}
+		err := runner.WalkResourceAttributes("null_resource", "key", func(attribute *hcl.Attribute) error {
+			var ret int
+			if err := runner.EvaluateExpr(attribute.Expr, &ret); err != nil {
+				return err
+			}
 
-		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
-		}
+			if tc.Expected != ret {
+				t.Fatalf("Failed `%s` test: expected value is `%d`, but get `%d`", tc.Name, tc.Expected, ret)
+			}
+			return nil
+		})
 
-		var ret int
-		err = runner.EvaluateExpr(attribute.Expr, &ret)
 		if err != nil {
 			t.Fatalf("Failed `%s` test: `%s` occurred", tc.Name, err)
-		}
-
-		if tc.Expected != ret {
-			t.Fatalf("Failed `%s` test: expected value is %d, but get %d", tc.Name, tc.Expected, ret)
 		}
 	}
 }
@@ -333,40 +280,23 @@ resource "null_resource" "test" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "stringList")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	for _, tc := range cases {
-		err := ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := TestRunner(t, map[string]string{"main.tf": tc.Content})
 
-		cfg, err := loadConfigHelper(dir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		attribute, err := extractAttributeHelper("key", cfg)
-		if err != nil {
-			t.Fatal(err)
-		}
+		err := runner.WalkResourceAttributes("null_resource", "key", func(attribute *hcl.Attribute) error {
+			var ret []string
+			if err := runner.EvaluateExpr(attribute.Expr, &ret); err != nil {
+				return err
+			}
 
-		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
-		}
+			if !cmp.Equal(tc.Expected, ret) {
+				t.Fatalf("Failed `%s` test: diff: %s", tc.Name, cmp.Diff(tc.Expected, ret))
+			}
+			return nil
+		})
 
-		ret := []string{}
-		err = runner.EvaluateExpr(attribute.Expr, &ret)
 		if err != nil {
 			t.Fatalf("Failed `%s` test: `%s` occurred", tc.Name, err)
-		}
-
-		if !cmp.Equal(tc.Expected, ret) {
-			t.Fatalf("Failed `%s` test: diff: %s", tc.Name, cmp.Diff(tc.Expected, ret))
 		}
 	}
 }
@@ -387,40 +317,23 @@ resource "null_resource" "test" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "numberList")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	for _, tc := range cases {
-		err := ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := TestRunner(t, map[string]string{"main.tf": tc.Content})
 
-		cfg, err := loadConfigHelper(dir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		attribute, err := extractAttributeHelper("key", cfg)
-		if err != nil {
-			t.Fatal(err)
-		}
+		err := runner.WalkResourceAttributes("null_resource", "key", func(attribute *hcl.Attribute) error {
+			var ret []int
+			if err := runner.EvaluateExpr(attribute.Expr, &ret); err != nil {
+				return err
+			}
 
-		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
-		}
+			if !cmp.Equal(tc.Expected, ret) {
+				t.Fatalf("Failed `%s` test: diff: %s", tc.Name, cmp.Diff(tc.Expected, ret))
+			}
+			return nil
+		})
 
-		ret := []int{}
-		err = runner.EvaluateExpr(attribute.Expr, &ret)
 		if err != nil {
 			t.Fatalf("Failed `%s` test: `%s` occurred", tc.Name, err)
-		}
-
-		if !cmp.Equal(tc.Expected, ret) {
-			t.Fatalf("Failed `%s` test: diff: %s", tc.Name, cmp.Diff(tc.Expected, ret))
 		}
 	}
 }
@@ -444,40 +357,23 @@ resource "null_resource" "test" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "map")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	for _, tc := range cases {
-		err := ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := TestRunner(t, map[string]string{"main.tf": tc.Content})
 
-		cfg, err := loadConfigHelper(dir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		attribute, err := extractAttributeHelper("key", cfg)
-		if err != nil {
-			t.Fatal(err)
-		}
+		err := runner.WalkResourceAttributes("null_resource", "key", func(attribute *hcl.Attribute) error {
+			var ret map[string]string
+			if err := runner.EvaluateExpr(attribute.Expr, &ret); err != nil {
+				return err
+			}
 
-		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
-		}
+			if !cmp.Equal(tc.Expected, ret) {
+				t.Fatalf("Failed `%s` test: diff: %s", tc.Name, cmp.Diff(tc.Expected, ret))
+			}
+			return nil
+		})
 
-		ret := map[string]string{}
-		err = runner.EvaluateExpr(attribute.Expr, &ret)
 		if err != nil {
 			t.Fatalf("Failed `%s` test: `%s` occurred", tc.Name, err)
-		}
-
-		if !cmp.Equal(tc.Expected, ret) {
-			t.Fatalf("Failed `%s` test: diff: %s", tc.Name, cmp.Diff(tc.Expected, ret))
 		}
 	}
 }
@@ -501,51 +397,32 @@ resource "null_resource" "test" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "map")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	for _, tc := range cases {
-		err := ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := TestRunner(t, map[string]string{"main.tf": tc.Content})
 
-		cfg, err := loadConfigHelper(dir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		attribute, err := extractAttributeHelper("key", cfg)
-		if err != nil {
-			t.Fatal(err)
-		}
+		err := runner.WalkResourceAttributes("null_resource", "key", func(attribute *hcl.Attribute) error {
+			var ret map[string]int
+			if err := runner.EvaluateExpr(attribute.Expr, &ret); err != nil {
+				return err
+			}
 
-		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
-		}
+			if !cmp.Equal(tc.Expected, ret) {
+				t.Fatalf("Failed `%s` test: diff: %s", tc.Name, cmp.Diff(tc.Expected, ret))
+			}
+			return nil
+		})
 
-		ret := map[string]int{}
-		err = runner.EvaluateExpr(attribute.Expr, &ret)
 		if err != nil {
 			t.Fatalf("Failed `%s` test: `%s` occurred", tc.Name, err)
-		}
-
-		if !cmp.Equal(tc.Expected, ret) {
-			t.Fatalf("Failed `%s` test: diff: %s", tc.Name, cmp.Diff(tc.Expected, ret))
 		}
 	}
 }
 
 func Test_EvaluateExpr_interpolationError(t *testing.T) {
 	cases := []struct {
-		Name       string
-		Content    string
-		ErrorCode  int
-		ErrorLevel int
-		ErrorText  string
+		Name    string
+		Content string
+		Error   Error
 	}{
 		{
 			Name: "undefined variable",
@@ -553,9 +430,11 @@ func Test_EvaluateExpr_interpolationError(t *testing.T) {
 resource "null_resource" "test" {
   key = "${var.undefined_var}"
 }`,
-			ErrorCode:  EvaluationError,
-			ErrorLevel: ErrorLevel,
-			ErrorText:  "Failed to eval an expression in %s:3; Reference to undeclared input variable: An input variable with the name \"undefined_var\" has not been declared. This variable can be declared with a variable \"undefined_var\" {} block.",
+			Error: Error{
+				Code:    EvaluationError,
+				Level:   ErrorLevel,
+				Message: "Failed to eval an expression in main.tf:3; Reference to undeclared input variable: An input variable with the name \"undefined_var\" has not been declared. This variable can be declared with a variable \"undefined_var\" {} block.",
+			},
 		},
 		{
 			Name: "no default value",
@@ -565,9 +444,11 @@ variable "no_value_var" {}
 resource "null_resource" "test" {
   key = "${var.no_value_var}"
 }`,
-			ErrorCode:  UnknownValueError,
-			ErrorLevel: WarningLevel,
-			ErrorText:  "Unknown value found in %s:5; Please use environment variables or tfvars to set the value",
+			Error: Error{
+				Code:    UnknownValueError,
+				Level:   WarningLevel,
+				Message: "Unknown value found in main.tf:5; Please use environment variables or tfvars to set the value",
+			},
 		},
 		{
 			Name: "null value",
@@ -580,9 +461,11 @@ variable "null_var" {
 resource "null_resource" "test" {
   key = var.null_var
 }`,
-			ErrorCode:  NullValueError,
-			ErrorLevel: WarningLevel,
-			ErrorText:  "Null value found in %s:8",
+			Error: Error{
+				Code:    NullValueError,
+				Level:   WarningLevel,
+				Message: "Null value found in main.tf:8",
+			},
 		},
 		{
 			Name: "terraform env",
@@ -590,9 +473,11 @@ resource "null_resource" "test" {
 resource "null_resource" "test" {
   key = "${terraform.env}"
 }`,
-			ErrorCode:  EvaluationError,
-			ErrorLevel: ErrorLevel,
-			ErrorText:  "Failed to eval an expression in %s:3; Invalid \"terraform\" attribute: The terraform.env attribute was deprecated in v0.10 and removed in v0.12. The \"state environment\" concept was rename to \"workspace\" in v0.12, and so the workspace name can now be accessed using the terraform.workspace attribute.",
+			Error: Error{
+				Code:    EvaluationError,
+				Level:   ErrorLevel,
+				Message: "Failed to eval an expression in main.tf:3; Invalid \"terraform\" attribute: The terraform.env attribute was deprecated in v0.10 and removed in v0.12. The \"state environment\" concept was rename to \"workspace\" in v0.12, and so the workspace name can now be accessed using the terraform.workspace attribute.",
+			},
 		},
 		{
 			Name: "type mismatch",
@@ -600,9 +485,11 @@ resource "null_resource" "test" {
 resource "null_resource" "test" {
   key = ["one", "two", "three"]
 }`,
-			ErrorCode:  TypeConversionError,
-			ErrorLevel: ErrorLevel,
-			ErrorText:  "Invalid type expression in %s:3; string required",
+			Error: Error{
+				Code:    TypeConversionError,
+				Level:   ErrorLevel,
+				Message: "Invalid type expression in main.tf:3; string required",
+			},
 		},
 		{
 			Name: "unevalauble",
@@ -610,68 +497,36 @@ resource "null_resource" "test" {
 resource "null_resource" "test" {
   key = "${module.text}"
 }`,
-			ErrorCode:  UnevaluableError,
-			ErrorLevel: WarningLevel,
-			ErrorText:  "Unevaluable expression found in %s:3",
+			Error: Error{
+				Code:    UnevaluableError,
+				Level:   WarningLevel,
+				Message: "Unevaluable expression found in main.tf:3",
+			},
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "interpolationError")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	for _, tc := range cases {
-		err := ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := TestRunner(t, map[string]string{"main.tf": tc.Content})
 
-		cfg, err := loadConfigHelper(dir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		attribute, err := extractAttributeHelper("key", cfg)
-		if err != nil {
-			t.Fatal(err)
-		}
+		err := runner.WalkResourceAttributes("null_resource", "key", func(attribute *hcl.Attribute) error {
+			var ret string
+			err := runner.EvaluateExpr(attribute.Expr, &ret)
 
-		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+			assertAppError(t, tc.Error, err)
+			return nil
+		})
+
 		if err != nil {
-			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
-		}
-
-		expectedText := fmt.Sprintf(tc.ErrorText, filepath.Join(dir, "resource.tf"))
-
-		var ret string
-		err = runner.EvaluateExpr(attribute.Expr, &ret)
-		if appErr, ok := err.(*Error); ok {
-			if appErr == nil {
-				t.Fatalf("Failed `%s` test: expected err is `%s`, but nothing occurred", tc.Name, expectedText)
-			}
-			if appErr.Code != tc.ErrorCode {
-				t.Fatalf("Failed `%s` test: expected error code is `%d`, but get `%d`", tc.Name, tc.ErrorCode, appErr.Code)
-			}
-			if appErr.Level != tc.ErrorLevel {
-				t.Fatalf("Failed `%s` test: expected error level is `%d`, but get `%d`", tc.Name, tc.ErrorLevel, appErr.Level)
-			}
-			if appErr.Error() != expectedText {
-				t.Fatalf("Failed `%s` test: expected error is `%s`, but get `%s`", tc.Name, expectedText, appErr.Error())
-			}
-		} else {
-			t.Fatalf("Failed `%s` test: unexpected error occurred: %s", tc.Name, err)
+			t.Fatalf("Failed `%s` test: `%s` occurred", tc.Name, err)
 		}
 	}
 }
 
 func Test_EvaluateExpr_mapWithInterpolationError(t *testing.T) {
 	cases := []struct {
-		Name       string
-		Content    string
-		ErrorCode  int
-		ErrorLevel int
-		ErrorText  string
+		Name    string
+		Content string
+		Error   Error
 	}{
 		{
 			Name: "undefined variable",
@@ -681,9 +536,11 @@ resource "null_resource" "test" {
 		value = var.undefined_var
 	}
 }`,
-			ErrorCode:  EvaluationError,
-			ErrorLevel: ErrorLevel,
-			ErrorText:  "Failed to eval an expression in %s:3; Reference to undeclared input variable: An input variable with the name \"undefined_var\" has not been declared. This variable can be declared with a variable \"undefined_var\" {} block.",
+			Error: Error{
+				Code:    EvaluationError,
+				Level:   ErrorLevel,
+				Message: "Failed to eval an expression in main.tf:3; Reference to undeclared input variable: An input variable with the name \"undefined_var\" has not been declared. This variable can be declared with a variable \"undefined_var\" {} block.",
+			},
 		},
 		{
 			Name: "no default value",
@@ -695,9 +552,11 @@ resource "null_resource" "test" {
 		value = var.no_value_var
 	}
 }`,
-			ErrorCode:  UnknownValueError,
-			ErrorLevel: WarningLevel,
-			ErrorText:  "Unknown value found in %s:5; Please use environment variables or tfvars to set the value",
+			Error: Error{
+				Code:    UnknownValueError,
+				Level:   WarningLevel,
+				Message: "Unknown value found in main.tf:5; Please use environment variables or tfvars to set the value",
+			},
 		},
 		{
 			Name: "null value",
@@ -712,9 +571,11 @@ resource "null_resource" "test" {
 		value = var.null_var
 	}
 }`,
-			ErrorCode:  NullValueError,
-			ErrorLevel: WarningLevel,
-			ErrorText:  "Null value found in %s:8",
+			Error: Error{
+				Code:    NullValueError,
+				Level:   WarningLevel,
+				Message: "Null value found in main.tf:8",
+			},
 		},
 		{
 			Name: "unevalauble",
@@ -724,57 +585,27 @@ resource "null_resource" "test" {
 		value = module.text
 	}
 }`,
-			ErrorCode:  UnevaluableError,
-			ErrorLevel: WarningLevel,
-			ErrorText:  "Unevaluable expression found in %s:3",
+			Error: Error{
+				Code:    UnevaluableError,
+				Level:   WarningLevel,
+				Message: "Unevaluable expression found in main.tf:3",
+			},
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "mapWithInterpolationError")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	for _, tc := range cases {
-		err := ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := TestRunner(t, map[string]string{"main.tf": tc.Content})
 
-		cfg, err := loadConfigHelper(dir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		attribute, err := extractAttributeHelper("key", cfg)
-		if err != nil {
-			t.Fatal(err)
-		}
+		err := runner.WalkResourceAttributes("null_resource", "key", func(attribute *hcl.Attribute) error {
+			var ret map[string]string
+			err := runner.EvaluateExpr(attribute.Expr, &ret)
 
-		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+			assertAppError(t, tc.Error, err)
+			return nil
+		})
+
 		if err != nil {
-			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
-		}
-
-		expectedText := fmt.Sprintf(tc.ErrorText, filepath.Join(dir, "resource.tf"))
-
-		var ret map[string]string
-		err = runner.EvaluateExpr(attribute.Expr, &ret)
-		if appErr, ok := err.(*Error); ok {
-			if appErr == nil {
-				t.Fatalf("Failed `%s` test: expected err is `%s`, but nothing occurred", tc.Name, expectedText)
-			}
-			if appErr.Code != tc.ErrorCode {
-				t.Fatalf("Failed `%s` test: expected error code is `%d`, but get `%d`", tc.Name, tc.ErrorCode, appErr.Code)
-			}
-			if appErr.Level != tc.ErrorLevel {
-				t.Fatalf("Failed `%s` test: expected error level is `%d`, but get `%d`", tc.Name, tc.ErrorLevel, appErr.Level)
-			}
-			if appErr.Error() != expectedText {
-				t.Fatalf("Failed `%s` test: expected error is `%s`, but get `%s`", tc.Name, expectedText, appErr.Error())
-			}
-		} else {
-			t.Fatalf("Failed `%s` test: unexpected error occurred: %s", tc.Name, err)
+			t.Fatalf("Failed `%s` test: `%s` occurred", tc.Name, err)
 		}
 	}
 }
@@ -844,7 +675,6 @@ resource "null_resource" "test" {
 		{
 			Name: "list",
 			Content: `
-
 resource "null_resource" "test" {
   key = ["one", "two", "three"]
 }`,
@@ -906,30 +736,19 @@ resource "null_resource" "test" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "isEvaluable")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	for _, tc := range cases {
-		err := ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := TestRunner(t, map[string]string{"main.tf": tc.Content})
 
-		cfg, err := loadConfigHelper(dir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		attribute, err := extractAttributeHelper("key", cfg)
-		if err != nil {
-			t.Fatal(err)
-		}
+		err := runner.WalkResourceAttributes("null_resource", "key", func(attribute *hcl.Attribute) error {
+			ret := isEvaluable(attribute.Expr)
+			if ret != tc.Expected {
+				t.Fatalf("Failed `%s` test: expected value is %t, but get %t", tc.Name, tc.Expected, ret)
+			}
+			return nil
+		})
 
-		ret := isEvaluable(attribute.Expr)
-		if ret != tc.Expected {
-			t.Fatalf("Failed `%s` test: expected value is %t, but get %t", tc.Name, tc.Expected, ret)
+		if err != nil {
+			t.Fatalf("Failed `%s` test: `%s` occurred", tc.Name, err)
 		}
 	}
 }
@@ -1000,460 +819,279 @@ resource "null_resource" "test" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "overrideVariables")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	for _, tc := range cases {
-		for key, value := range tc.EnvVar {
-			err := os.Setenv(key, value)
+		withEnvVars(t, tc.EnvVar, func() {
+			runner := testRunnerWithInputVariables(t, map[string]string{"main.tf": tc.Content}, tc.InputValues...)
+
+			err := runner.WalkResourceAttributes("null_resource", "key", func(attribute *hcl.Attribute) error {
+				var ret string
+				err := runner.EvaluateExpr(attribute.Expr, &ret)
+				if err != nil {
+					return err
+				}
+
+				if tc.Expected != ret {
+					t.Fatalf("Failed `%s` test: expected value is %s, but get %s", tc.Name, tc.Expected, ret)
+				}
+				return nil
+			})
+
 			if err != nil {
-				t.Fatal(err)
+				t.Fatalf("Failed `%s` test: `%s` occurred", tc.Name, err)
 			}
-		}
-
-		err := ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		cfg, err := loadConfigHelper(dir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		attribute, err := extractAttributeHelper("key", cfg)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, tc.InputValues...)
-		if err != nil {
-			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
-		}
-
-		var ret string
-		err = runner.EvaluateExpr(attribute.Expr, &ret)
-		if err != nil {
-			t.Fatalf("Failed `%s` test: `%s` occurred", tc.Name, err)
-		}
-
-		if tc.Expected != ret {
-			t.Fatalf("Failed `%s` test: expected value is %s, but get %s", tc.Name, tc.Expected, ret)
-		}
-
-		for key := range tc.EnvVar {
-			err := os.Unsetenv(key)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
+		})
 	}
 }
 
 func Test_NewModuleRunners_noModules(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
+	withinFixtureDir(t, "no_modules", func() {
+		runner := testRunnerWithOsFs(t, moduleConfig())
 
-	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "no_modules"))
-	if err != nil {
-		t.Fatal(err)
-	}
+		runners, err := NewModuleRunners(runner)
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
 
-	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, moduleConfig())
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-	cfg, err := loader.LoadConfig(".")
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-
-	runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-	runners, err := NewModuleRunners(runner)
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-
-	if len(runners) > 0 {
-		t.Fatal("`NewModuleRunners` must not return runners when there is no module")
-	}
+		if len(runners) > 0 {
+			t.Fatal("`NewModuleRunners` must not return runners when there is no module")
+		}
+	})
 }
 
 func Test_NewModuleRunners_nestedModules(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
+	withinFixtureDir(t, "nested_modules", func() {
+		runner := testRunnerWithOsFs(t, moduleConfig())
 
-	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "nested_modules"))
-	if err != nil {
-		t.Fatal(err)
-	}
+		runners, err := NewModuleRunners(runner)
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
 
-	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, moduleConfig())
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-	cfg, err := loader.LoadConfig(".")
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
+		if len(runners) != 2 {
+			t.Fatal("This function must return 2 runners because the config has 2 modules")
+		}
 
-	runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-	runners, err := NewModuleRunners(runner)
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-
-	if len(runners) != 2 {
-		t.Fatal("This function must return 2 runners because the config has 2 modules")
-	}
-
-	child := runners[0].TFConfig
-	if child.Path.String() != "root" {
-		t.Fatalf("Expected child config path name is `root`, but get `%s`", child.Path.String())
-	}
-
-	expected := map[string]*configs.Variable{
-		"override": {
-			Name:        "override",
-			Default:     cty.StringVal("foo"),
-			Type:        cty.DynamicPseudoType,
-			ParsingMode: configs.VariableParseLiteral,
-			DeclRange: hcl.Range{
-				Filename: filepath.Join("module", "module.tf"),
-				Start:    hcl.Pos{Line: 1, Column: 1},
-				End:      hcl.Pos{Line: 1, Column: 20},
+		expectedVars := map[string]map[string]*configs.Variable{
+			"root": {
+				"override": {
+					Name:        "override",
+					Default:     cty.StringVal("foo"),
+					Type:        cty.DynamicPseudoType,
+					ParsingMode: configs.VariableParseLiteral,
+					DeclRange: hcl.Range{
+						Filename: filepath.Join("module", "module.tf"),
+						Start:    hcl.Pos{Line: 1, Column: 1},
+						End:      hcl.Pos{Line: 1, Column: 20},
+					},
+				},
+				"no_default": {
+					Name:        "no_default",
+					Default:     cty.StringVal("bar"),
+					Type:        cty.DynamicPseudoType,
+					ParsingMode: configs.VariableParseLiteral,
+					DeclRange: hcl.Range{
+						Filename: filepath.Join("module", "module.tf"),
+						Start:    hcl.Pos{Line: 4, Column: 1},
+						End:      hcl.Pos{Line: 4, Column: 22},
+					},
+				},
+				"unknown": {
+					Name:        "unknown",
+					Default:     cty.UnknownVal(cty.DynamicPseudoType),
+					Type:        cty.DynamicPseudoType,
+					ParsingMode: configs.VariableParseLiteral,
+					DeclRange: hcl.Range{
+						Filename: filepath.Join("module", "module.tf"),
+						Start:    hcl.Pos{Line: 5, Column: 1},
+						End:      hcl.Pos{Line: 5, Column: 19},
+					},
+				},
 			},
-		},
-		"no_default": {
-			Name:        "no_default",
-			Default:     cty.StringVal("bar"),
-			Type:        cty.DynamicPseudoType,
-			ParsingMode: configs.VariableParseLiteral,
-			DeclRange: hcl.Range{
-				Filename: filepath.Join("module", "module.tf"),
-				Start:    hcl.Pos{Line: 4, Column: 1},
-				End:      hcl.Pos{Line: 4, Column: 22},
+			"root.test": {
+				"override": {
+					Name:        "override",
+					Default:     cty.StringVal("foo"),
+					Type:        cty.DynamicPseudoType,
+					ParsingMode: configs.VariableParseLiteral,
+					DeclRange: hcl.Range{
+						Filename: filepath.Join("module", "module1", "resource.tf"),
+						Start:    hcl.Pos{Line: 1, Column: 1},
+						End:      hcl.Pos{Line: 1, Column: 20},
+					},
+				},
+				"no_default": {
+					Name:        "no_default",
+					Default:     cty.StringVal("bar"),
+					Type:        cty.DynamicPseudoType,
+					ParsingMode: configs.VariableParseLiteral,
+					DeclRange: hcl.Range{
+						Filename: filepath.Join("module", "module1", "resource.tf"),
+						Start:    hcl.Pos{Line: 4, Column: 1},
+						End:      hcl.Pos{Line: 4, Column: 22},
+					},
+				},
+				"unknown": {
+					Name:        "unknown",
+					Default:     cty.UnknownVal(cty.DynamicPseudoType),
+					Type:        cty.DynamicPseudoType,
+					ParsingMode: configs.VariableParseLiteral,
+					DeclRange: hcl.Range{
+						Filename: filepath.Join("module", "module1", "resource.tf"),
+						Start:    hcl.Pos{Line: 5, Column: 1},
+						End:      hcl.Pos{Line: 5, Column: 19},
+					},
+				},
 			},
-		},
-		"unknown": {
-			Name:        "unknown",
-			Default:     cty.UnknownVal(cty.DynamicPseudoType),
-			Type:        cty.DynamicPseudoType,
-			ParsingMode: configs.VariableParseLiteral,
-			DeclRange: hcl.Range{
-				Filename: filepath.Join("module", "module.tf"),
-				Start:    hcl.Pos{Line: 5, Column: 1},
-				End:      hcl.Pos{Line: 5, Column: 19},
-			},
-		},
-	}
-	opts := []cmp.Option{
-		cmpopts.IgnoreUnexported(cty.Type{}, cty.Value{}),
-		cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
-	}
-	if !cmp.Equal(expected, child.Module.Variables, opts...) {
-		t.Fatalf("`%s` module variables are unmatched: Diff=%s", child.Path.String(), cmp.Diff(expected, child.Module.Variables, opts...))
-	}
+		}
 
-	grandchild := runners[1].TFConfig
-	if grandchild.Path.String() != "root.test" {
-		t.Fatalf("Expected child config path name is `root.test`, but get `%s`", grandchild.Path.String())
-	}
+		for _, runner := range runners {
+			expected, exists := expectedVars[runner.TFConfig.Path.String()]
+			if !exists {
+				t.Fatalf("`%s` is not found in module runners", runner.TFConfig.Path)
+			}
 
-	expected = map[string]*configs.Variable{
-		"override": {
-			Name:        "override",
-			Default:     cty.StringVal("foo"),
-			Type:        cty.DynamicPseudoType,
-			ParsingMode: configs.VariableParseLiteral,
-			DeclRange: hcl.Range{
-				Filename: filepath.Join("module", "module1", "resource.tf"),
-				Start:    hcl.Pos{Line: 1, Column: 1},
-				End:      hcl.Pos{Line: 1, Column: 20},
-			},
-		},
-		"no_default": {
-			Name:        "no_default",
-			Default:     cty.StringVal("bar"),
-			Type:        cty.DynamicPseudoType,
-			ParsingMode: configs.VariableParseLiteral,
-			DeclRange: hcl.Range{
-				Filename: filepath.Join("module", "module1", "resource.tf"),
-				Start:    hcl.Pos{Line: 4, Column: 1},
-				End:      hcl.Pos{Line: 4, Column: 22},
-			},
-		},
-		"unknown": {
-			Name:        "unknown",
-			Default:     cty.UnknownVal(cty.DynamicPseudoType),
-			Type:        cty.DynamicPseudoType,
-			ParsingMode: configs.VariableParseLiteral,
-			DeclRange: hcl.Range{
-				Filename: filepath.Join("module", "module1", "resource.tf"),
-				Start:    hcl.Pos{Line: 5, Column: 1},
-				End:      hcl.Pos{Line: 5, Column: 19},
-			},
-		},
-	}
-	opts = []cmp.Option{
-		cmpopts.IgnoreUnexported(cty.Type{}, cty.Value{}),
-		cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
-	}
-	if !cmp.Equal(expected, grandchild.Module.Variables, opts...) {
-		t.Fatalf("`%s` module variables are unmatched: Diff=%s", grandchild.Path.String(), cmp.Diff(expected, grandchild.Module.Variables, opts...))
-	}
+			opts := []cmp.Option{
+				cmpopts.IgnoreUnexported(cty.Type{}, cty.Value{}),
+				cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
+			}
+			if !cmp.Equal(expected, runner.TFConfig.Module.Variables, opts...) {
+				t.Fatalf("`%s` module variables are unmatched: Diff=%s", runner.TFConfig.Path, cmp.Diff(expected, runner.TFConfig.Module.Variables, opts...))
+			}
+		}
+	})
 }
 
 func Test_NewModuleRunners_modVars(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
+	withinFixtureDir(t, "nested_module_vars", func() {
+		runner := testRunnerWithOsFs(t, moduleConfig())
 
-	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "nested_module_vars"))
-	if err != nil {
-		t.Fatal(err)
-	}
+		runners, err := NewModuleRunners(runner)
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
 
-	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, moduleConfig())
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-	cfg, err := loader.LoadConfig(".")
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
+		if len(runners) != 2 {
+			t.Fatal("This function must return 2 runners because the config has 2 modules")
+		}
 
-	runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-	runners, err := NewModuleRunners(runner)
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
+		child := runners[0]
+		if child.TFConfig.Path.String() != "module1" {
+			t.Fatalf("Expected child config path name is `module1`, but get `%s`", child.TFConfig.Path.String())
+		}
 
-	if len(runners) != 2 {
-		t.Fatal("This function must return 2 runners because the config has 2 modules")
-	}
-
-	child := runners[0]
-	if child.TFConfig.Path.String() != "module1" {
-		t.Fatalf("Expected child config path name is `module1`, but get `%s`", child.TFConfig.Path.String())
-	}
-
-	expected := map[string]*moduleVariable{
-		"foo": {
-			Root: true,
-			DeclRange: hcl.Range{
-				Filename: "main.tf",
-				Start:    hcl.Pos{Line: 4, Column: 9},
-				End:      hcl.Pos{Line: 4, Column: 14},
+		expected := map[string]*moduleVariable{
+			"foo": {
+				Root: true,
+				DeclRange: hcl.Range{
+					Filename: "main.tf",
+					Start:    hcl.Pos{Line: 4, Column: 9},
+					End:      hcl.Pos{Line: 4, Column: 14},
+				},
 			},
-		},
-		"bar": {
-			Root: true,
-			DeclRange: hcl.Range{
-				Filename: "main.tf",
-				Start:    hcl.Pos{Line: 5, Column: 9},
-				End:      hcl.Pos{Line: 5, Column: 14},
+			"bar": {
+				Root: true,
+				DeclRange: hcl.Range{
+					Filename: "main.tf",
+					Start:    hcl.Pos{Line: 5, Column: 9},
+					End:      hcl.Pos{Line: 5, Column: 14},
+				},
 			},
-		},
-	}
-	opts := []cmp.Option{cmpopts.IgnoreFields(hcl.Pos{}, "Byte")}
-	if !cmp.Equal(expected, child.modVars, opts...) {
-		t.Fatalf("`%s` module variables are unmatched: Diff=%s", child.TFConfig.Path.String(), cmp.Diff(expected, child.modVars, opts...))
-	}
+		}
+		opts := []cmp.Option{cmpopts.IgnoreFields(hcl.Pos{}, "Byte")}
+		if !cmp.Equal(expected, child.modVars, opts...) {
+			t.Fatalf("`%s` module variables are unmatched: Diff=%s", child.TFConfig.Path.String(), cmp.Diff(expected, child.modVars, opts...))
+		}
 
-	grandchild := runners[1]
-	if grandchild.TFConfig.Path.String() != "module1.module2" {
-		t.Fatalf("Expected child config path name is `module1.module2`, but get `%s`", grandchild.TFConfig.Path.String())
-	}
+		grandchild := runners[1]
+		if grandchild.TFConfig.Path.String() != "module1.module2" {
+			t.Fatalf("Expected child config path name is `module1.module2`, but get `%s`", grandchild.TFConfig.Path.String())
+		}
 
-	expected = map[string]*moduleVariable{
-		"red": {
-			Root:    false,
-			Parents: []*moduleVariable{expected["foo"], expected["bar"]},
-			DeclRange: hcl.Range{
-				Filename: filepath.Join("module", "main.tf"),
-				Start:    hcl.Pos{Line: 8, Column: 11},
-				End:      hcl.Pos{Line: 8, Column: 34},
+		expected = map[string]*moduleVariable{
+			"red": {
+				Root:    false,
+				Parents: []*moduleVariable{expected["foo"], expected["bar"]},
+				DeclRange: hcl.Range{
+					Filename: filepath.Join("module", "main.tf"),
+					Start:    hcl.Pos{Line: 8, Column: 11},
+					End:      hcl.Pos{Line: 8, Column: 34},
+				},
 			},
-		},
-		"blue": {
-			Root:    false,
-			Parents: []*moduleVariable{},
-			DeclRange: hcl.Range{
-				Filename: filepath.Join("module", "main.tf"),
-				Start:    hcl.Pos{Line: 9, Column: 11},
-				End:      hcl.Pos{Line: 9, Column: 17},
+			"blue": {
+				Root:    false,
+				Parents: []*moduleVariable{},
+				DeclRange: hcl.Range{
+					Filename: filepath.Join("module", "main.tf"),
+					Start:    hcl.Pos{Line: 9, Column: 11},
+					End:      hcl.Pos{Line: 9, Column: 17},
+				},
 			},
-		},
-		"green": {
-			Root:    false,
-			Parents: []*moduleVariable{expected["foo"]},
-			DeclRange: hcl.Range{
-				Filename: filepath.Join("module", "main.tf"),
-				Start:    hcl.Pos{Line: 10, Column: 11},
-				End:      hcl.Pos{Line: 10, Column: 49},
+			"green": {
+				Root:    false,
+				Parents: []*moduleVariable{expected["foo"]},
+				DeclRange: hcl.Range{
+					Filename: filepath.Join("module", "main.tf"),
+					Start:    hcl.Pos{Line: 10, Column: 11},
+					End:      hcl.Pos{Line: 10, Column: 49},
+				},
 			},
-		},
-	}
-	opts = []cmp.Option{cmpopts.IgnoreFields(hcl.Pos{}, "Byte")}
-	if !cmp.Equal(expected, grandchild.modVars, opts...) {
-		t.Fatalf("`%s` module variables are unmatched: Diff=%s", grandchild.TFConfig.Path.String(), cmp.Diff(expected, grandchild.modVars, opts...))
-	}
+		}
+		opts = []cmp.Option{cmpopts.IgnoreFields(hcl.Pos{}, "Byte")}
+		if !cmp.Equal(expected, grandchild.modVars, opts...) {
+			t.Fatalf("`%s` module variables are unmatched: Diff=%s", grandchild.TFConfig.Path.String(), cmp.Diff(expected, grandchild.modVars, opts...))
+		}
+	})
 }
 
 func Test_NewModuleRunners_ignoreModules(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
+	withinFixtureDir(t, "nested_modules", func() {
+		config := moduleConfig()
+		config.IgnoreModule["./module"] = true
+		runner := testRunnerWithOsFs(t, config)
 
-	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "nested_modules"))
-	if err != nil {
-		t.Fatal(err)
-	}
+		runners, err := NewModuleRunners(runner)
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
 
-	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, moduleConfig())
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-	cfg, err := loader.LoadConfig(".")
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-
-	conf := EmptyConfig()
-	conf.IgnoreModule["./module"] = true
-
-	runner, err := NewRunner(conf, map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-	runners, err := NewModuleRunners(runner)
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-
-	if len(runners) != 0 {
-		t.Fatalf("This function must not return runners because `ignore_module` is set. Got `%d` runner(s)", len(runners))
-	}
+		if len(runners) != 0 {
+			t.Fatalf("This function must not return runners because `ignore_module` is set. Got `%d` runner(s)", len(runners))
+		}
+	})
 }
 
 func Test_NewModuleRunners_withInvalidExpression(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
+	withinFixtureDir(t, "invalid_module_attribute", func() {
+		runner := testRunnerWithOsFs(t, moduleConfig())
 
-	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "invalid_module_attribute"))
-	if err != nil {
-		t.Fatal(err)
-	}
+		_, err := NewModuleRunners(runner)
 
-	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, moduleConfig())
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-	cfg, err := loader.LoadConfig(".")
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-
-	runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-	if err != nil {
-		t.Fatalf("Unexpected error: %s", err)
-	}
-
-	_, err = NewModuleRunners(runner)
-
-	errText := "Failed to eval an expression in module.tf:4; Invalid \"terraform\" attribute: The terraform.env attribute was deprecated in v0.10 and removed in v0.12. The \"state environment\" concept was rename to \"workspace\" in v0.12, and so the workspace name can now be accessed using the terraform.workspace attribute."
-	errCode := EvaluationError
-	errLevel := ErrorLevel
-
-	if appErr, ok := err.(*Error); ok {
-		if appErr == nil {
-			t.Fatalf("Expected err is `%s`, but nothing occurred", errText)
+		expected := Error{
+			Code:    EvaluationError,
+			Level:   ErrorLevel,
+			Message: "Failed to eval an expression in module.tf:4; Invalid \"terraform\" attribute: The terraform.env attribute was deprecated in v0.10 and removed in v0.12. The \"state environment\" concept was rename to \"workspace\" in v0.12, and so the workspace name can now be accessed using the terraform.workspace attribute.",
 		}
-		if appErr.Code != errCode {
-			t.Fatalf("Expected error code is `%d`, but get `%d`", errCode, appErr.Code)
-		}
-		if appErr.Level != errLevel {
-			t.Fatalf("Expected error level is `%d`, but get `%d`", errLevel, appErr.Level)
-		}
-		if appErr.Error() != errText {
-			t.Fatalf("Expected error is `%s`, but get `%s`", errText, appErr.Error())
-		}
-	} else {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
+		assertAppError(t, expected, err)
+	})
 }
 
 func Test_NewModuleRunners_withNotAllowedAttributes(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(currentDir)
+	withinFixtureDir(t, "not_allowed_module_attribute", func() {
+		runner := testRunnerWithOsFs(t, moduleConfig())
 
-	err = os.Chdir(filepath.Join(currentDir, "test-fixtures", "not_allowed_module_attribute"))
-	if err != nil {
-		t.Fatal(err)
-	}
+		_, err := NewModuleRunners(runner)
 
-	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, moduleConfig())
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-	cfg, err := loader.LoadConfig(".")
-	if err != nil {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
-
-	runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-	if err != nil {
-		t.Fatalf("Unexpected error: %s", err)
-	}
-
-	_, err = NewModuleRunners(runner)
-
-	errText := "Attribute of module not allowed was found in module.tf:1; module.tf:4,3-10: Unexpected \"invalid\" block; Blocks are not allowed here."
-	errCode := UnexpectedAttributeError
-	errLevel := ErrorLevel
-
-	if appErr, ok := err.(*Error); ok {
-		if appErr == nil {
-			t.Fatalf("Expected err is `%s`, but nothing occurred", errText)
+		expected := Error{
+			Code:    UnexpectedAttributeError,
+			Level:   ErrorLevel,
+			Message: "Attribute of module not allowed was found in module.tf:1; module.tf:4,3-10: Unexpected \"invalid\" block; Blocks are not allowed here.",
 		}
-		if appErr.Code != errCode {
-			t.Fatalf("Expected error code is `%d`, but get `%d`", errCode, appErr.Code)
-		}
-		if appErr.Level != errLevel {
-			t.Fatalf("Expected error level is `%d`, but get `%d`", errLevel, appErr.Level)
-		}
-		if appErr.Error() != errText {
-			t.Fatalf("Expected error is `%s`, but get `%s`", errText, appErr.Error())
-		}
-	} else {
-		t.Fatalf("Unexpected error occurred: %s", err)
-	}
+		assertAppError(t, expected, err)
+	})
 }
 
 func Test_LookupResourcesByType(t *testing.T) {
-	dir, err := ioutil.TempDir("", "lookupResourcesByType")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	err = ioutil.WriteFile(dir+"/resource.tf", []byte(`
+	content := `
 resource "aws_instance" "web" {
   ami           = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.micro"
@@ -1472,22 +1110,9 @@ resource "aws_route" "r" {
   destination_cidr_block    = "10.0.1.0/22"
   vpc_peering_connection_id = "pcx-45ff3dc1"
   depends_on                = ["aws_route_table.testing"]
-}
-`), os.ModePerm)
-	if err != nil {
-		t.Fatal(err)
-	}
+}`
 
-	cfg, err := loadConfigHelper(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-	if err != nil {
-		t.Fatalf("Unexpected error: %s", err)
-	}
-
+	runner := TestRunner(t, map[string]string{"resource.tf": content})
 	resources := runner.LookupResourcesByType("aws_instance")
 
 	if len(resources) != 1 {
@@ -1499,11 +1124,7 @@ resource "aws_route" "r" {
 }
 
 func Test_LookupIssues(t *testing.T) {
-	runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, configs.NewEmptyConfig(), map[string]*terraform.InputValue{})
-	if err != nil {
-		t.Fatalf("Unexpected error: %s", err)
-	}
-
+	runner := TestRunner(t, map[string]string{})
 	runner.Issues = Issues{
 		{
 			Rule:    &testRule{},
@@ -1579,28 +1200,10 @@ resource "aws_instance" "test" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "WalkResourceAttributes")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	for _, tc := range cases {
-		err := ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := TestRunner(t, map[string]string{"main.tf": tc.Content})
 
-		cfg, err := loadConfigHelper(dir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
-		}
-
-		err = runner.WalkResourceAttributes("aws_instance", "instance_type", func(attribute *hcl.Attribute) error {
+		err := runner.WalkResourceAttributes("aws_instance", "instance_type", func(attribute *hcl.Attribute) error {
 			return fmt.Errorf("Walk %s", attribute.Name)
 		})
 		if err == nil {
@@ -1683,28 +1286,10 @@ resource "aws_instance" "test" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "WalkResourceBlocks")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	for _, tc := range cases {
-		err := ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := TestRunner(t, map[string]string{"main.tf": tc.Content})
 
-		cfg, err := loadConfigHelper(dir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
-		}
-
-		err = runner.WalkResourceBlocks("aws_instance", "instance_type", func(block *hcl.Block) error {
+		err := runner.WalkResourceBlocks("aws_instance", "instance_type", func(block *hcl.Block) error {
 			return fmt.Errorf("Walk %s", block.Type)
 		})
 		if err == nil {
@@ -1752,19 +1337,10 @@ func Test_EnsureNoError(t *testing.T) {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "EnsureNoError")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	for _, tc := range cases {
-		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, configs.NewEmptyConfig(), map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
-		}
+		runner := TestRunner(t, map[string]string{})
 
-		err = runner.EnsureNoError(tc.Error, func() error {
+		err := runner.EnsureNoError(tc.Error, func() error {
 			return errors.New("function called")
 		})
 		if err == nil {
@@ -1851,35 +1427,20 @@ resource "null_resource" "test" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "IsNullExpr")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	for _, tc := range cases {
-		err := ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
+		runner := TestRunner(t, map[string]string{"main.tf": tc.Content})
 
-		cfg, err := loadConfigHelper(dir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		attribute, err := extractAttributeHelper("key", cfg)
-		if err != nil {
-			t.Fatal(err)
-		}
+		err := runner.WalkResourceAttributes("null_resource", "test", func(attribute *hcl.Attribute) error {
+			ret := runner.IsNullExpr(attribute.Expr)
 
-		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
-		}
-		ret := runner.IsNullExpr(attribute.Expr)
+			if tc.Expected != ret {
+				t.Fatalf("Failed `%s` test: expected value is %t, but get %t", tc.Name, tc.Expected, ret)
+			}
+			return nil
+		})
 
-		if tc.Expected != ret {
-			t.Fatalf("Failed `%s` test: expected value is %t, but get %t", tc.Name, tc.Expected, ret)
+		if err != nil {
+			t.Fatalf("Failed `%s` test: `%s` occurred", tc.Name, err)
 		}
 	}
 }
@@ -1938,30 +1499,12 @@ resource "null_resource" "test" {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "EachStringSliceExprs")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	for _, tc := range cases {
-		err := ioutil.WriteFile(dir+"/resource.tf", []byte(tc.Content), os.ModePerm)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		cfg, err := loadConfigHelper(dir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		runner, err := NewRunner(EmptyConfig(), map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
-		}
+		runner := TestRunner(t, map[string]string{"main.tf": tc.Content})
 
 		vals := []string{}
 		lines := []int{}
-		err = runner.WalkResourceAttributes("null_resource", "value", func(attribute *hcl.Attribute) error {
+		err := runner.WalkResourceAttributes("null_resource", "value", func(attribute *hcl.Attribute) error {
 			return runner.EachStringSliceExprs(attribute.Expr, func(val string, expr hcl.Expression) {
 				vals = append(vals, val)
 				lines = append(lines, expr.Range().Start.Line)
@@ -2047,17 +1590,8 @@ func Test_EmitIssue(t *testing.T) {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "EmitIssue")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	for _, tc := range cases {
-		runner, err := NewRunner(EmptyConfig(), tc.Annotations, configs.NewEmptyConfig(), map[string]*terraform.InputValue{})
-		if err != nil {
-			t.Fatalf("Failed %s test: Unexpected error: %s", tc.Name, err)
-		}
+		runner := testRunnerWithAnnotations(t, map[string]string{}, tc.Annotations)
 
 		runner.EmitIssue(tc.Rule, tc.Message, tc.Location)
 

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/hcl2/hcl/hclsyntax"
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/spf13/afero"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -1063,7 +1064,7 @@ func Test_NewModuleRunners_noModules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader(moduleConfig())
+	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -1095,7 +1096,7 @@ func Test_NewModuleRunners_nestedModules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader(moduleConfig())
+	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -1223,7 +1224,7 @@ func Test_NewModuleRunners_modVars(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader(moduleConfig())
+	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -1322,7 +1323,7 @@ func Test_NewModuleRunners_ignoreModules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader(moduleConfig())
+	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -1357,7 +1358,7 @@ func Test_NewModuleRunners_withInvalidExpression(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader(moduleConfig())
+	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}
@@ -1407,7 +1408,7 @@ func Test_NewModuleRunners_withNotAllowedAttributes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loader, err := NewLoader(moduleConfig())
+	loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, moduleConfig())
 	if err != nil {
 		t.Fatalf("Unexpected error occurred: %s", err)
 	}

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -512,7 +512,7 @@ resource "null_resource" "test" {
 			var ret string
 			err := runner.EvaluateExpr(attribute.Expr, &ret)
 
-			assertAppError(t, tc.Error, err)
+			AssertAppError(t, tc.Error, err)
 			return nil
 		})
 
@@ -600,7 +600,7 @@ resource "null_resource" "test" {
 			var ret map[string]string
 			err := runner.EvaluateExpr(attribute.Expr, &ret)
 
-			assertAppError(t, tc.Error, err)
+			AssertAppError(t, tc.Error, err)
 			return nil
 		})
 
@@ -1071,7 +1071,7 @@ func Test_NewModuleRunners_withInvalidExpression(t *testing.T) {
 			Level:   ErrorLevel,
 			Message: "Failed to eval an expression in module.tf:4; Invalid \"terraform\" attribute: The terraform.env attribute was deprecated in v0.10 and removed in v0.12. The \"state environment\" concept was rename to \"workspace\" in v0.12, and so the workspace name can now be accessed using the terraform.workspace attribute.",
 		}
-		assertAppError(t, expected, err)
+		AssertAppError(t, expected, err)
 	})
 }
 
@@ -1086,7 +1086,7 @@ func Test_NewModuleRunners_withNotAllowedAttributes(t *testing.T) {
 			Level:   ErrorLevel,
 			Message: "Attribute of module not allowed was found in module.tf:1; module.tf:4,3-10: Unexpected \"invalid\" block; Blocks are not allowed here.",
 		}
-		assertAppError(t, expected, err)
+		AssertAppError(t, expected, err)
 	})
 }
 

--- a/tflint/testing.go
+++ b/tflint/testing.go
@@ -1,0 +1,51 @@
+package tflint
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/hcl2/hcl"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/spf13/afero"
+)
+
+// TestRunner returns a runner for testing.
+// Note that this runner ignores a config, annotations, and input variables.
+func TestRunner(t *testing.T, files map[string]string) *Runner {
+	config := EmptyConfig()
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	for name, src := range files {
+		err := fs.WriteFile(name, []byte(src), os.ModePerm)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	loader, err := NewLoader(fs, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := loader.LoadConfig(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runner, err := NewRunner(config, map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return runner
+}
+
+// AssertIssues is an assertion helper for comparing issues
+func AssertIssues(t *testing.T, expected Issues, actual Issues) {
+	// Byte field will be ignored because it's not important in tests such as positions
+	opts := []cmp.Option{cmpopts.IgnoreFields(hcl.Pos{}, "Byte")}
+	if !cmp.Equal(expected, actual, opts...) {
+		t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(expected, actual, opts...))
+	}
+}

--- a/tflint/testing.go
+++ b/tflint/testing.go
@@ -43,9 +43,43 @@ func TestRunner(t *testing.T, files map[string]string) *Runner {
 
 // AssertIssues is an assertion helper for comparing issues
 func AssertIssues(t *testing.T, expected Issues, actual Issues) {
-	// Byte field will be ignored because it's not important in tests such as positions
-	opts := []cmp.Option{cmpopts.IgnoreFields(hcl.Pos{}, "Byte")}
+	opts := []cmp.Option{
+		// Byte field will be ignored because it's not important in tests such as positions
+		cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
+		cmpopts.IgnoreFields(Issue{}, "Rule"),
+	}
 	if !cmp.Equal(expected, actual, opts...) {
 		t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(expected, actual, opts...))
+	}
+}
+
+// AssertIssuesWithoutRange is an assertion helper for comparing issues
+func AssertIssuesWithoutRange(t *testing.T, expected Issues, actual Issues) {
+	opts := []cmp.Option{
+		cmpopts.IgnoreFields(Issue{}, "Range"),
+		cmpopts.IgnoreFields(Issue{}, "Rule"),
+	}
+	if !cmp.Equal(expected, actual, opts...) {
+		t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(expected, actual, opts...))
+	}
+}
+
+// AssertAppError is an assertion helper for comparing tflint.Error
+func AssertAppError(t *testing.T, expected Error, got error) {
+	if appErr, ok := got.(*Error); ok {
+		if appErr == nil {
+			t.Fatalf("expected err is `%s`, but nothing occurred", expected.Error())
+		}
+		if appErr.Code != expected.Code {
+			t.Fatalf("expected error code is `%d`, but get `%d`", expected.Code, appErr.Code)
+		}
+		if appErr.Level != expected.Level {
+			t.Fatalf("expected error level is `%d`, but get `%d`", expected.Level, appErr.Level)
+		}
+		if appErr.Error() != expected.Error() {
+			t.Fatalf("expected error is `%s`, but get `%s`", expected.Error(), appErr.Error())
+		}
+	} else {
+		t.Fatalf("unexpected error occurred: %s", got)
 	}
 }

--- a/tflint/tflint_test.go
+++ b/tflint/tflint_test.go
@@ -17,25 +17,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func assertAppError(t *testing.T, expected Error, got error) {
-	if appErr, ok := got.(*Error); ok {
-		if appErr == nil {
-			t.Fatalf("expected err is `%s`, but nothing occurred", expected.Error())
-		}
-		if appErr.Code != expected.Code {
-			t.Fatalf("expected error code is `%d`, but get `%d`", expected.Code, appErr.Code)
-		}
-		if appErr.Level != expected.Level {
-			t.Fatalf("expected error level is `%d`, but get `%d`", expected.Level, appErr.Level)
-		}
-		if appErr.Error() != expected.Error() {
-			t.Fatalf("expected error is `%s`, but get `%s`", expected.Error(), appErr.Error())
-		}
-	} else {
-		t.Fatalf("unexpected error occurred: %s", got)
-	}
-}
-
 func testRunnerWithInputVariables(t *testing.T, files map[string]string, variables ...terraform.InputValues) *Runner {
 	config := EmptyConfig()
 	fs := afero.Afero{Fs: afero.NewMemMapFs()}


### PR DESCRIPTION
Introduced several helper functions and removed redundant setups for tests.

In addition, it is now possible to set up test files without writing to the actual file system by loading files from `afero.Afero`.