### PR TITLE
Bump terraform-provider-aws from v2.25.0 to v2.27.0

### DIFF
--- a/client/aws_ec2_mock.go
+++ b/client/aws_ec2_mock.go
@@ -7865,6 +7865,56 @@ func (mr *MockEC2APIMockRecorder) DescribeElasticGpusRequest(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeElasticGpusRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeElasticGpusRequest), arg0)
 }
 
+// DescribeExportImageTasks mocks base method
+func (m *MockEC2API) DescribeExportImageTasks(arg0 *ec2.DescribeExportImageTasksInput) (*ec2.DescribeExportImageTasksOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeExportImageTasks", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeExportImageTasksOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeExportImageTasks indicates an expected call of DescribeExportImageTasks
+func (mr *MockEC2APIMockRecorder) DescribeExportImageTasks(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeExportImageTasks", reflect.TypeOf((*MockEC2API)(nil).DescribeExportImageTasks), arg0)
+}
+
+// DescribeExportImageTasksWithContext mocks base method
+func (m *MockEC2API) DescribeExportImageTasksWithContext(arg0 aws.Context, arg1 *ec2.DescribeExportImageTasksInput, arg2 ...request.Option) (*ec2.DescribeExportImageTasksOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeExportImageTasksWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeExportImageTasksOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeExportImageTasksWithContext indicates an expected call of DescribeExportImageTasksWithContext
+func (mr *MockEC2APIMockRecorder) DescribeExportImageTasksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeExportImageTasksWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeExportImageTasksWithContext), varargs...)
+}
+
+// DescribeExportImageTasksRequest mocks base method
+func (m *MockEC2API) DescribeExportImageTasksRequest(arg0 *ec2.DescribeExportImageTasksInput) (*request.Request, *ec2.DescribeExportImageTasksOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeExportImageTasksRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeExportImageTasksOutput)
+	return ret0, ret1
+}
+
+// DescribeExportImageTasksRequest indicates an expected call of DescribeExportImageTasksRequest
+func (mr *MockEC2APIMockRecorder) DescribeExportImageTasksRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeExportImageTasksRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeExportImageTasksRequest), arg0)
+}
+
 // DescribeExportTasks mocks base method
 func (m *MockEC2API) DescribeExportTasks(arg0 *ec2.DescribeExportTasksInput) (*ec2.DescribeExportTasksOutput, error) {
 	m.ctrl.T.Helper()
@@ -14897,6 +14947,56 @@ func (mr *MockEC2APIMockRecorder) ExportClientVpnClientConfigurationRequest(arg0
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportClientVpnClientConfigurationRequest", reflect.TypeOf((*MockEC2API)(nil).ExportClientVpnClientConfigurationRequest), arg0)
 }
 
+// ExportImage mocks base method
+func (m *MockEC2API) ExportImage(arg0 *ec2.ExportImageInput) (*ec2.ExportImageOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExportImage", arg0)
+	ret0, _ := ret[0].(*ec2.ExportImageOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExportImage indicates an expected call of ExportImage
+func (mr *MockEC2APIMockRecorder) ExportImage(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportImage", reflect.TypeOf((*MockEC2API)(nil).ExportImage), arg0)
+}
+
+// ExportImageWithContext mocks base method
+func (m *MockEC2API) ExportImageWithContext(arg0 aws.Context, arg1 *ec2.ExportImageInput, arg2 ...request.Option) (*ec2.ExportImageOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ExportImageWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.ExportImageOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExportImageWithContext indicates an expected call of ExportImageWithContext
+func (mr *MockEC2APIMockRecorder) ExportImageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportImageWithContext", reflect.TypeOf((*MockEC2API)(nil).ExportImageWithContext), varargs...)
+}
+
+// ExportImageRequest mocks base method
+func (m *MockEC2API) ExportImageRequest(arg0 *ec2.ExportImageInput) (*request.Request, *ec2.ExportImageOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExportImageRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ExportImageOutput)
+	return ret0, ret1
+}
+
+// ExportImageRequest indicates an expected call of ExportImageRequest
+func (mr *MockEC2APIMockRecorder) ExportImageRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportImageRequest", reflect.TypeOf((*MockEC2API)(nil).ExportImageRequest), arg0)
+}
+
 // ExportTransitGatewayRoutes mocks base method
 func (m *MockEC2API) ExportTransitGatewayRoutes(arg0 *ec2.ExportTransitGatewayRoutesInput) (*ec2.ExportTransitGatewayRoutesOutput, error) {
 	m.ctrl.T.Helper()
@@ -17646,6 +17746,56 @@ func (mr *MockEC2APIMockRecorder) ModifyVpnConnectionRequest(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpnConnectionRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyVpnConnectionRequest), arg0)
 }
 
+// ModifyVpnTunnelCertificate mocks base method
+func (m *MockEC2API) ModifyVpnTunnelCertificate(arg0 *ec2.ModifyVpnTunnelCertificateInput) (*ec2.ModifyVpnTunnelCertificateOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModifyVpnTunnelCertificate", arg0)
+	ret0, _ := ret[0].(*ec2.ModifyVpnTunnelCertificateOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyVpnTunnelCertificate indicates an expected call of ModifyVpnTunnelCertificate
+func (mr *MockEC2APIMockRecorder) ModifyVpnTunnelCertificate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpnTunnelCertificate", reflect.TypeOf((*MockEC2API)(nil).ModifyVpnTunnelCertificate), arg0)
+}
+
+// ModifyVpnTunnelCertificateWithContext mocks base method
+func (m *MockEC2API) ModifyVpnTunnelCertificateWithContext(arg0 aws.Context, arg1 *ec2.ModifyVpnTunnelCertificateInput, arg2 ...request.Option) (*ec2.ModifyVpnTunnelCertificateOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ModifyVpnTunnelCertificateWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.ModifyVpnTunnelCertificateOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ModifyVpnTunnelCertificateWithContext indicates an expected call of ModifyVpnTunnelCertificateWithContext
+func (mr *MockEC2APIMockRecorder) ModifyVpnTunnelCertificateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpnTunnelCertificateWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyVpnTunnelCertificateWithContext), varargs...)
+}
+
+// ModifyVpnTunnelCertificateRequest mocks base method
+func (m *MockEC2API) ModifyVpnTunnelCertificateRequest(arg0 *ec2.ModifyVpnTunnelCertificateInput) (*request.Request, *ec2.ModifyVpnTunnelCertificateOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ModifyVpnTunnelCertificateRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.ModifyVpnTunnelCertificateOutput)
+	return ret0, ret1
+}
+
+// ModifyVpnTunnelCertificateRequest indicates an expected call of ModifyVpnTunnelCertificateRequest
+func (mr *MockEC2APIMockRecorder) ModifyVpnTunnelCertificateRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpnTunnelCertificateRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyVpnTunnelCertificateRequest), arg0)
+}
+
 // MonitorInstances mocks base method
 func (m *MockEC2API) MonitorInstances(arg0 *ec2.MonitorInstancesInput) (*ec2.MonitorInstancesOutput, error) {
 	m.ctrl.T.Helper()
@@ -19394,6 +19544,56 @@ func (m *MockEC2API) SearchTransitGatewayRoutesRequest(arg0 *ec2.SearchTransitGa
 func (mr *MockEC2APIMockRecorder) SearchTransitGatewayRoutesRequest(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchTransitGatewayRoutesRequest", reflect.TypeOf((*MockEC2API)(nil).SearchTransitGatewayRoutesRequest), arg0)
+}
+
+// SendDiagnosticInterrupt mocks base method
+func (m *MockEC2API) SendDiagnosticInterrupt(arg0 *ec2.SendDiagnosticInterruptInput) (*ec2.SendDiagnosticInterruptOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendDiagnosticInterrupt", arg0)
+	ret0, _ := ret[0].(*ec2.SendDiagnosticInterruptOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SendDiagnosticInterrupt indicates an expected call of SendDiagnosticInterrupt
+func (mr *MockEC2APIMockRecorder) SendDiagnosticInterrupt(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendDiagnosticInterrupt", reflect.TypeOf((*MockEC2API)(nil).SendDiagnosticInterrupt), arg0)
+}
+
+// SendDiagnosticInterruptWithContext mocks base method
+func (m *MockEC2API) SendDiagnosticInterruptWithContext(arg0 aws.Context, arg1 *ec2.SendDiagnosticInterruptInput, arg2 ...request.Option) (*ec2.SendDiagnosticInterruptOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SendDiagnosticInterruptWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.SendDiagnosticInterruptOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SendDiagnosticInterruptWithContext indicates an expected call of SendDiagnosticInterruptWithContext
+func (mr *MockEC2APIMockRecorder) SendDiagnosticInterruptWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendDiagnosticInterruptWithContext", reflect.TypeOf((*MockEC2API)(nil).SendDiagnosticInterruptWithContext), varargs...)
+}
+
+// SendDiagnosticInterruptRequest mocks base method
+func (m *MockEC2API) SendDiagnosticInterruptRequest(arg0 *ec2.SendDiagnosticInterruptInput) (*request.Request, *ec2.SendDiagnosticInterruptOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendDiagnosticInterruptRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.SendDiagnosticInterruptOutput)
+	return ret0, ret1
+}
+
+// SendDiagnosticInterruptRequest indicates an expected call of SendDiagnosticInterruptRequest
+func (mr *MockEC2APIMockRecorder) SendDiagnosticInterruptRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendDiagnosticInterruptRequest", reflect.TypeOf((*MockEC2API)(nil).SendDiagnosticInterruptRequest), arg0)
 }
 
 // StartInstances mocks base method

--- a/client/aws_ecs_mock.go
+++ b/client/aws_ecs_mock.go
@@ -2183,6 +2183,56 @@ func (mr *MockECSAPIMockRecorder) UntagResourceRequest(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResourceRequest", reflect.TypeOf((*MockECSAPI)(nil).UntagResourceRequest), arg0)
 }
 
+// UpdateClusterSettings mocks base method
+func (m *MockECSAPI) UpdateClusterSettings(arg0 *ecs.UpdateClusterSettingsInput) (*ecs.UpdateClusterSettingsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateClusterSettings", arg0)
+	ret0, _ := ret[0].(*ecs.UpdateClusterSettingsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateClusterSettings indicates an expected call of UpdateClusterSettings
+func (mr *MockECSAPIMockRecorder) UpdateClusterSettings(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterSettings", reflect.TypeOf((*MockECSAPI)(nil).UpdateClusterSettings), arg0)
+}
+
+// UpdateClusterSettingsWithContext mocks base method
+func (m *MockECSAPI) UpdateClusterSettingsWithContext(arg0 aws.Context, arg1 *ecs.UpdateClusterSettingsInput, arg2 ...request.Option) (*ecs.UpdateClusterSettingsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateClusterSettingsWithContext", varargs...)
+	ret0, _ := ret[0].(*ecs.UpdateClusterSettingsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateClusterSettingsWithContext indicates an expected call of UpdateClusterSettingsWithContext
+func (mr *MockECSAPIMockRecorder) UpdateClusterSettingsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterSettingsWithContext", reflect.TypeOf((*MockECSAPI)(nil).UpdateClusterSettingsWithContext), varargs...)
+}
+
+// UpdateClusterSettingsRequest mocks base method
+func (m *MockECSAPI) UpdateClusterSettingsRequest(arg0 *ecs.UpdateClusterSettingsInput) (*request.Request, *ecs.UpdateClusterSettingsOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateClusterSettingsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ecs.UpdateClusterSettingsOutput)
+	return ret0, ret1
+}
+
+// UpdateClusterSettingsRequest indicates an expected call of UpdateClusterSettingsRequest
+func (mr *MockECSAPIMockRecorder) UpdateClusterSettingsRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterSettingsRequest", reflect.TypeOf((*MockECSAPI)(nil).UpdateClusterSettingsRequest), arg0)
+}
+
 // UpdateContainerAgent mocks base method
 func (m *MockECSAPI) UpdateContainerAgent(arg0 *ecs.UpdateContainerAgentInput) (*ecs.UpdateContainerAgentOutput, error) {
 	m.ctrl.T.Helper()

--- a/docs/guides/compatibility.md
+++ b/docs/guides/compatibility.md
@@ -3,7 +3,7 @@
 Some inspections implicitly assume the behavior of a specific version of provider plugins or Terraform. This always assumes the latest version and is as follows:
 
 - Terraform v0.12.7
-- AWS Provider v2.25.0
+- AWS Provider v2.27.0
 
 Of course, TFLint may work correctly if you run it on other versions. But, false positives/negatives can occur based on this assumption.
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/wata727/tflint
 go 1.12
 
 require (
-	github.com/aws/aws-sdk-go v1.23.0
+	github.com/aws/aws-sdk-go v1.23.15
 	github.com/fatih/color v1.7.0
 	github.com/golang/mock v1.3.1
 	github.com/google/go-cmp v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
 github.com/aws/aws-sdk-go v1.16.36/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.22.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.23.0 h1:ilfJN/vJtFo1XDFxB2YMBYGeOvGZl6Qow17oyD4+Z9A=
-github.com/aws/aws-sdk-go v1.23.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.23.15 h1:ut2ZzO0A34Ds18NXvvkWWKyO4aZqQ9uZquslWzCQvGU=
+github.com/aws/aws-sdk-go v1.23.15/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=

--- a/rules/awsrules/models/aws_cur_report_definition_invalid_s3_region.go
+++ b/rules/awsrules/models/aws_cur_report_definition_invalid_s3_region.go
@@ -32,6 +32,7 @@ func NewAwsCurReportDefinitionInvalidS3RegionRule() *AwsCurReportDefinitionInval
 			"ap-northeast-1",
 			"eu-north-1",
 			"ap-northeast-3",
+			"ap-east-1",
 		},
 	}
 }

--- a/rules/awsrules/models/aws_instance_invalid_type.go
+++ b/rules/awsrules/models/aws_instance_invalid_type.go
@@ -133,6 +133,7 @@ func NewAwsInstanceInvalidTypeRule() *AwsInstanceInvalidTypeRule {
 			"i3en.6xlarge",
 			"i3en.12xlarge",
 			"i3en.24xlarge",
+			"i3en.metal",
 			"hi1.4xlarge",
 			"hs1.8xlarge",
 			"c1.medium",

--- a/rules/awsrules/models/aws_launch_configuration_invalid_type.go
+++ b/rules/awsrules/models/aws_launch_configuration_invalid_type.go
@@ -133,6 +133,7 @@ func NewAwsLaunchConfigurationInvalidTypeRule() *AwsLaunchConfigurationInvalidTy
 			"i3en.6xlarge",
 			"i3en.12xlarge",
 			"i3en.24xlarge",
+			"i3en.metal",
 			"hi1.4xlarge",
 			"hs1.8xlarge",
 			"c1.medium",

--- a/rules/awsrules/models/aws_launch_template_invalid_instance_type.go
+++ b/rules/awsrules/models/aws_launch_template_invalid_instance_type.go
@@ -133,6 +133,7 @@ func NewAwsLaunchTemplateInvalidInstanceTypeRule() *AwsLaunchTemplateInvalidInst
 			"i3en.6xlarge",
 			"i3en.12xlarge",
 			"i3en.24xlarge",
+			"i3en.metal",
 			"hi1.4xlarge",
 			"hs1.8xlarge",
 			"c1.medium",

--- a/rules/awsrules/models/aws_ssm_parameter_invalid_tier.go
+++ b/rules/awsrules/models/aws_ssm_parameter_invalid_tier.go
@@ -24,6 +24,7 @@ func NewAwsSsmParameterInvalidTierRule() *AwsSsmParameterInvalidTierRule {
 		enum: []string{
 			"Standard",
 			"Advanced",
+			"Intelligent-Tiering",
 		},
 	}
 }

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/hashicorp/hcl2 v0.0.0-20190821123243-0c888d1241f6
-	github.com/hashicorp/terraform v0.12.7
+	github.com/hashicorp/terraform v0.12.8
 	github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516
-	github.com/terraform-providers/terraform-provider-aws v2.25.0+incompatible
+	github.com/terraform-providers/terraform-provider-aws v2.27.0+incompatible
 )

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -61,8 +61,8 @@ github.com/aws/aws-sdk-go v1.19.18/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/aws/aws-sdk-go v1.21.7 h1:ml+k7szyVaq4YD+3LhqOGl9tgMTqgMbpnuUSkB6UJvQ=
 github.com/aws/aws-sdk-go v1.21.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.22.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.23.0 h1:ilfJN/vJtFo1XDFxB2YMBYGeOvGZl6Qow17oyD4+Z9A=
-github.com/aws/aws-sdk-go v1.23.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.23.15 h1:ut2ZzO0A34Ds18NXvvkWWKyO4aZqQ9uZquslWzCQvGU=
+github.com/aws/aws-sdk-go v1.23.15/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
@@ -74,6 +74,8 @@ github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/bmatcuk/doublestar v1.1.5 h1:2bNwBOmhyFEFcoB3tGvTD5xanq+4kyOZlB8wFYbMjkk=
+github.com/bmatcuk/doublestar v1.1.5/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -83,6 +85,7 @@ github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXH
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20161106042343-c914be64f07d h1:aG5FcWiZTOhPQzYIxwxSR1zEOxzL32fwr1CsaCfhO6w=
 github.com/chzyer/readline v0.0.0-20161106042343-c914be64f07d/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.0/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -289,6 +292,8 @@ github.com/hashicorp/terraform v0.12.6 h1:mWItQdLZQ7f3kBYBu2Kgdg+E5iZb1KtCq73V10
 github.com/hashicorp/terraform v0.12.6/go.mod h1:udmq5rU8CO9pEIh/A/Xrs3zb3yYU/W9ce1pp8K1ysHA=
 github.com/hashicorp/terraform v0.12.7 h1:4pD+XguGRMGBnERUO3Wbtmv23R26ovWpGSQ2yqIL73Q=
 github.com/hashicorp/terraform v0.12.7/go.mod h1:dpIRVHTSvPpGZPDKBLEw3U7nNQaJCybZoZkeJSYxg/w=
+github.com/hashicorp/terraform v0.12.8 h1:51Z5K8oj42KZi0IiTf99wMTujDpvsTd3eaF1k5z1URk=
+github.com/hashicorp/terraform v0.12.8/go.mod h1:8rXMj8q+hRsR/28WWWyiHu1GEDSjWaHPoV14E66X5VU=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20190327195015-8022a2663a70 h1:oZm5nE11yhzsTRz/YrUyDMSvixePqjoZihwn8ipuOYI=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20190327195015-8022a2663a70/go.mod h1:ItvqtvbC3K23FFET62ZwnkwtpbKZm8t8eMcWjmVVjD8=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20190821133035-82a99dc22ef4 h1:fTkL0YwjohGyN7AqsDhz6bwcGBpT+xBqi3Qhpw58Juw=
@@ -511,8 +516,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d h1:Z4EH+5EffvBEhh37F0C0DnpklTMh00JOkjW5zK3ofBI=
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BSTlc8jOjh0niykqEGVXOLXdi9o0r0kR8tCYiMvjFgw=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/terraform-providers/terraform-provider-aws v2.25.0+incompatible h1:/ImYAqN3vkmo2byaAezwTt5dW+9jKaFk8183ad7lcG8=
-github.com/terraform-providers/terraform-provider-aws v2.25.0+incompatible/go.mod h1:Yc+SQyXHUSQkxM3hi7lzaOnD5uu21v0xNyVMcOGsj9Y=
+github.com/terraform-providers/terraform-provider-aws v2.27.0+incompatible h1:C5mRLt6ggZdzxcnvSwbKg3t+3nHJy0wwZlEIwINtYO4=
+github.com/terraform-providers/terraform-provider-aws v2.27.0+incompatible/go.mod h1:ywfllIO2LPlzOyLYBUE8N1vr1AMiK1CiEP1bA4I8zVc=
 github.com/terraform-providers/terraform-provider-openstack v1.15.0 h1:adpjqej+F8BAX9dHmuPF47sUIkgifeqBu6p7iCsyj0Y=
 github.com/terraform-providers/terraform-provider-openstack v1.15.0/go.mod h1:2aQ6n/BtChAl1y2S60vebhyJyZXBsuAI5G4+lHrT1Ew=
 github.com/terraform-providers/terraform-provider-template v2.1.2+incompatible h1:imLvtj+kEr7z3xsHlHed+CAw4Z/mnlLYXfynKLv12SI=
@@ -626,6 +631,8 @@ golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82 h1:vsphBvatvfbhlb4PO1BYSr9dzugGxJ/SQHoNufZJq1w=
 golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa h1:KIDDMLT1O0Nr7TSxp8xM5tJcdn8tgyAONntO829og1M=
+golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Changed rules:

- `aws_cur_report_definition_invalid_s3_region` rule now allows `ap-east-1` as a valid value.
- `aws_instance_invalid_type`, `aws_launch_configuration_invalid_type` and `aws_launch_template_invalid_instance_type` rules now allow `i3en.metal` as a valid value.
- `aws_ssm_parameter_invalid_tier` rule now allows `Intelligent-Tiering` as a valid value.