### PR TITLE
Disable CGO in GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,7 @@
 # This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
 env:
+  - CGO_ENABLED=0
   - GO111MODULE=on
 builds:
   - goos:


### PR DESCRIPTION
To produce statically linked binaries even when not cross-compiling.

Related to https://github.com/wata727/tflint/issues/430.