### PR TITLE
Fix typo in dash rule

### DIFF
--- a/docs/rules/terraform_dash_in_resource_name.md
+++ b/docs/rules/terraform_dash_in_resource_name.md
@@ -1,6 +1,6 @@
 # terraform_dash_in_resource_name
 
-Disallow dashes (-) in `resource` names without.
+Disallow dashes (-) in `resource` names.
 
 ## Example
 

--- a/rules/terraformrules/terraform_dash_in_resource_name.go
+++ b/rules/terraformrules/terraform_dash_in_resource_name.go
@@ -9,7 +9,7 @@ import (
 	"github.com/wata727/tflint/tflint"
 )
 
-// TerraformDashInResourceNameRule checks whether outputs have descriptions
+// TerraformDashInResourceNameRule checks whether resources have any dashes in the name
 type TerraformDashInResourceNameRule struct{}
 
 // NewTerraformDashInResourceNameRule returns a new rule


### PR DESCRIPTION
This fixes unclear wording.

On a side note, the rationale to avoid dashes in names is because they make expressions `${var.instance-count-1}` unclear - it it hard to say if is subtraction `${var.instance-count - 1}` or just a reference to `instance-count-1` variable.

https://www.terraform.io/docs/configuration-0-11/interpolation.html#math