### PR TITLE
Fix panic when the expression includes invalid references

### DIFF
--- a/rules/awsrules/aws_route_not_specified_target.go
+++ b/rules/awsrules/aws_route_not_specified_target.go
@@ -77,7 +77,12 @@ func (r *AwsRouteNotSpecifiedTargetRule) Check(runner *tflint.Runner) error {
 
 		var nullAttributes int
 		for _, attribute := range body.Attributes {
-			if runner.IsNullExpr(attribute.Expr) {
+			isNull, err := runner.IsNullExpr(attribute.Expr)
+			if err != nil {
+				return err
+			}
+
+			if isNull {
 				nullAttributes = nullAttributes + 1
 			}
 		}

--- a/rules/awsrules/aws_route_specified_multiple_targets.go
+++ b/rules/awsrules/aws_route_specified_multiple_targets.go
@@ -77,7 +77,12 @@ func (r *AwsRouteSpecifiedMultipleTargetsRule) Check(runner *tflint.Runner) erro
 
 		var nullAttributes int
 		for _, attribute := range body.Attributes {
-			if runner.IsNullExpr(attribute.Expr) {
+			isNull, err := runner.IsNullExpr(attribute.Expr)
+			if err != nil {
+				return err
+			}
+
+			if isNull {
 				nullAttributes = nullAttributes + 1
 			}
 		}


### PR DESCRIPTION
If an expression includes invalid references, panic and exit instead of returning an error. The following configuration is an example:

```hcl
resource "aws_s3_bucket" "example" {
  bucket = "example"
  acl    = "private"
  region = invalid // invalid reference
}
```

**Before**

```
Panic: Invalid reference: A reference to a resource type must be followed by at least one attribute access, specifying the resource name.
 -> 0: main.main.func1: /main.go(30)
 -> 1: runtime.gopanic: /panic.go(679)
 -> 2: github.com/wata727/tflint/tflint.isEvaluableExpr: /runner.go(677)
 -> 3: github.com/wata727/tflint/tflint.(*Runner).EvaluateExpr: /runner.go(207)
 -> 4: github.com/wata727/tflint/rules/awsrules.(*AwsS3BucketInvalidRegionRule).Check.func1: /aws_s3_bucket_invalid_region.go(75)
 -> 5: github.com/wata727/tflint/tflint.(*Runner).WalkResourceAttributes: /runner.go(471)
 -> 6: github.com/wata727/tflint/rules/awsrules.(*AwsS3BucketInvalidRegionRule).Check: /aws_s3_bucket_invalid_region.go(73)
 -> 7: github.com/wata727/tflint/cmd.(*CLI).Run: /cli.go(152)
 -> 8: main.main: /main.go(43)
 -> 9: runtime.main: /proc.go(203)
 -> 10: runtime.goexit: /asm_amd64.s(1357)

TFLint crashed... :(
Please attach an output log, describe the situation and version that occurred and post an issue to https://github.com/wata727/tflint/issues
```

**After**

```
Failed to check `aws_s3_bucket_invalid_region` rule. An error occurred:

Error: Failed to parse an expression in s3.tf:4; Invalid reference: A reference to a resource type must be followed by at least one attribute access, specifying the reso
urce name.
```