### PR TITLE
Add `--enable-rule` and `--disable-rule` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Application Options:
   -f, --format=[default|json|checkstyle]    Output format (default: default)
   -c, --config=FILE                         Config file name (default: .tflint.hcl)
       --ignore-module=SOURCE1,SOURCE2...    Ignore module sources
+      --enable-rule=RULE_NAME               Enable rules from the command line
+      --disable-rule=RULE_NAME              Disable rules from the command line
       --var-file=FILE1,FILE2...             Terraform variable file names
       --var='foo=bar'                       Set a Terraform variable
       --module                              Inspect modules

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -65,7 +65,7 @@ func (cli *CLI) Run(args []string) int {
 			return []string{}, errors.New("`quiet` option was removed in v0.11.0. The behavior is now default")
 		}
 		if option == "ignore-rule" {
-			return []string{}, errors.New("`ignore-rule` option was removed in v0.12.0")
+			return []string{}, errors.New("`ignore-rule` option was removed in v0.12.0. Please use `--disable-rule` instead")
 		}
 		return []string{}, fmt.Errorf("`%s` is unknown option. Please run `tflint --help`", option)
 	}

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -93,7 +93,7 @@ func TestCLIRun__noIssuesFound(t *testing.T) {
 			Name:    "removed `--ignore-rule` option",
 			Command: "./tflint --ignore-rule aws_instance_invalid_type",
 			Status:  ExitCodeError,
-			Stderr:  "`ignore-rule` option was removed in v0.12.0",
+			Stderr:  "`ignore-rule` option was removed in v0.12.0. Please use `--disable-rule` instead",
 		},
 		{
 			Name:    "invalid options",

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -15,6 +15,8 @@ type Options struct {
 	Format       string   `short:"f" long:"format" description:"Output format" choice:"default" choice:"json" choice:"checkstyle" default:"default"`
 	Config       string   `short:"c" long:"config" description:"Config file name" value-name:"FILE" default:".tflint.hcl"`
 	IgnoreModule string   `long:"ignore-module" description:"Ignore module sources" value-name:"SOURCE1,SOURCE2..."`
+	EnableRules  []string `long:"enable-rule" description:"Enable rules from the command line" value-name:"RULE_NAME"`
+	DisableRules []string `long:"disable-rule" description:"Disable rules from the command line" value-name:"RULE_NAME"`
 	Varfile      string   `long:"var-file" description:"Terraform variable file names" value-name:"FILE1,FILE2..."`
 	Variables    []string `long:"var" description:"Set a Terraform variable" value-name:"'foo=bar'"`
 	Module       bool     `long:"module" description:"Inspect modules"`
@@ -49,8 +51,24 @@ func (opts *Options) toConfig() *tflint.Config {
 	log.Printf("[DEBUG]   DeepCheck: %t", opts.Deep)
 	log.Printf("[DEBUG]   Force: %t", opts.Force)
 	log.Printf("[DEBUG]   IgnoreModule: %#v", ignoreModule)
+	log.Printf("[DEBUG]   EnableRules: %#v", opts.EnableRules)
+	log.Printf("[DEBUG]   DisableRules: %#v", opts.DisableRules)
 	log.Printf("[DEBUG]   Varfile: %#v", varfile)
 	log.Printf("[DEBUG]   Variables: %#v", opts.Variables)
+
+	rules := map[string]*tflint.RuleConfig{}
+	for _, rule := range opts.EnableRules {
+		rules[rule] = &tflint.RuleConfig{
+			Name:    rule,
+			Enabled: true,
+		}
+	}
+	for _, rule := range opts.DisableRules {
+		rules[rule] = &tflint.RuleConfig{
+			Name:    rule,
+			Enabled: false,
+		}
+	}
 
 	return &tflint.Config{
 		Module:    opts.Module,
@@ -66,6 +84,6 @@ func (opts *Options) toConfig() *tflint.Config {
 		IgnoreModule: ignoreModule,
 		Varfile:      varfile,
 		Variables:    opts.Variables,
-		Rules:        map[string]*tflint.RuleConfig{},
+		Rules:        rules,
 	}
 }

--- a/cmd/option_test.go
+++ b/cmd/option_test.go
@@ -158,6 +158,52 @@ func Test_toConfig(t *testing.T) {
 				Rules:          map[string]*tflint.RuleConfig{},
 			},
 		},
+		{
+			Name:    "--enable-rule",
+			Command: "./tflint --enable-rule aws_instance_invalid_type --enable-rule aws_instance_previous_type",
+			Expected: &tflint.Config{
+				Module:         false,
+				DeepCheck:      false,
+				Force:          false,
+				AwsCredentials: client.AwsCredentials{},
+				IgnoreModule:   map[string]bool{},
+				Varfile:        []string{},
+				Variables:      []string{},
+				Rules: map[string]*tflint.RuleConfig{
+					"aws_instance_invalid_type": {
+						Name:    "aws_instance_invalid_type",
+						Enabled: true,
+					},
+					"aws_instance_previous_type": {
+						Name:    "aws_instance_previous_type",
+						Enabled: true,
+					},
+				},
+			},
+		},
+				{
+			Name:    "--disable-rule",
+			Command: "./tflint --disable-rule aws_instance_invalid_type --disable-rule aws_instance_previous_type",
+			Expected: &tflint.Config{
+				Module:         false,
+				DeepCheck:      false,
+				Force:          false,
+				AwsCredentials: client.AwsCredentials{},
+				IgnoreModule:   map[string]bool{},
+				Varfile:        []string{},
+				Variables:      []string{},
+				Rules: map[string]*tflint.RuleConfig{
+					"aws_instance_invalid_type": {
+						Name:    "aws_instance_invalid_type",
+						Enabled: false,
+					},
+					"aws_instance_previous_type": {
+						Name:    "aws_instance_previous_type",
+						Enabled: false,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/docs/guides/config.md
+++ b/docs/guides/config.md
@@ -87,6 +87,8 @@ Set a Terraform variable from a passed value. This flag can be set multiple time
 
 ## `rule` blocks
 
+CLI flag: `--enable-rule`, `--disable-rule`
+
 You can make settings for each rule in the `rule` block. Currently, it can set only `enabled` option. If you set `enabled = false`, TFLint doesn't inspect configuration files by this rule.
 
 ```hcl


### PR DESCRIPTION
Fixes #438 

Note that `--disable-rule` behaves differently than `--ignore-rule`. Since `--ignore-rule` is deprecated, it was overridden by the value defined in `rule` blocks, but `--disable-rule` always takes precedence.