### PR TITLE
Add aws-exec-read ACL as a valid value

### DIFF
--- a/rules/awsrules/aws_s3_bucket_invalid_acl.go
+++ b/rules/awsrules/aws_s3_bucket_invalid_acl.go
@@ -23,6 +23,7 @@ func NewAwsS3BucketInvalidACLRule() *AwsS3BucketInvalidACLRule {
 			"private",
 			"public-read",
 			"public-read-write",
+			"aws-exec-read",
 			"authenticated-read",
 			"log-delivery-write",
 		},


### PR DESCRIPTION
Add `aws-exec-read` ACL as a valid value to `aws_s3_bucket_invalid_acl` rule.