### PR TITLE
Detect invalid rule name in command line option

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -158,7 +158,12 @@ func (cli *CLI) Run(args []string) int {
 	}
 	runners = append(runners, runner)
 
-	for _, rule := range rules.NewRules(cfg) {
+	lintRules, err := rules.NewRules(cfg)
+	if err != nil {
+		formatter.Print(tflint.Issues{}, tflint.NewContextError("Failed to prepare rules", err), cli.loader.Sources())
+		return ExitCodeError
+	}
+	for _, rule := range lintRules {
 		for _, runner := range runners {
 			err := rule.Check(runner)
 			if err != nil {

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -25,12 +25,16 @@ func NewHandler(configPath string, cliConfig *tflint.Config) (jsonrpc2.Handler, 
 	}
 	cfg = cfg.Merge(cliConfig)
 
+	lintRules, err := rules.NewRules(cfg)
+	if err != nil {
+		return nil, err
+	}
 	return jsonrpc2.HandlerWithError((&handler{
 		configPath: configPath,
 		cliConfig:  cliConfig,
 		config:     cfg,
 		fs:         afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs()),
-		rules:      rules.NewRules(cfg),
+		rules:      lintRules,
 		diagsPaths: []string{},
 	}).handle), nil
 }

--- a/langserver/workspace_did_change_watched_files.go
+++ b/langserver/workspace_did_change_watched_files.go
@@ -22,7 +22,10 @@ func (h *handler) workspaceDidChangeWatchedFiles(ctx context.Context, conn *json
 		return nil, err
 	}
 	h.config = newConfig.Merge(h.cliConfig)
-	h.rules = rules.NewRules(h.config)
+	h.rules, err = rules.NewRules(h.config)
+	if err != nil {
+		return nil, err
+	}
 
 	h.fs = afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs())
 

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -43,7 +43,7 @@ var manualDeepCheckRules = []Rule{
 	awsrules.NewAwsLaunchConfigurationInvalidImageIDRule(),
 }
 
-// AllRules returns map of rules indexed by name
+// AllRulesMap returns map of rules indexed by name
 func AllRulesMap() map[string]Rule {
 	ret := map[string]Rule{}
 	for _, rule := range append(DefaultRules, deepCheckRules...) {
@@ -60,11 +60,11 @@ func NewRules(c *tflint.Config) []Rule {
 	totalEnabled := 0
 	for _, rule := range rulesMap {
 		if rule.Enabled() {
-			totalEnabled += 1
+			totalEnabled++
 		}
 	}
 	log.Printf("[INFO]   %d (%d) rules total", len(rulesMap), totalEnabled)
-	for rulename, _ := range c.Rules {
+	for rulename := range c.Rules {
 		if _, ok := rulesMap[rulename]; !ok {
 			log.Printf("[ERROR] Invalid rule:  %s", rulename)
 		}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/wata727/tflint/rules/awsrules"
@@ -53,8 +54,10 @@ func AllRulesMap() map[string]Rule {
 }
 
 // NewRules returns rules according to configuration
-func NewRules(c *tflint.Config) []Rule {
+func NewRules(c *tflint.Config) ([]Rule, error) {
 	log.Print("[INFO] Prepare rules")
+
+	ret := []Rule{}
 
 	rulesMap := AllRulesMap()
 	totalEnabled := 0
@@ -66,11 +69,10 @@ func NewRules(c *tflint.Config) []Rule {
 	log.Printf("[INFO]   %d (%d) rules total", len(rulesMap), totalEnabled)
 	for rulename := range c.Rules {
 		if _, ok := rulesMap[rulename]; !ok {
-			log.Printf("[ERROR] Invalid rule:  %s", rulename)
+			return ret, fmt.Errorf("Rule not found: %s", rulename)
 		}
 	}
 
-	ret := []Rule{}
 	allRules := []Rule{}
 
 	if c.DeepCheck {
@@ -96,5 +98,5 @@ func NewRules(c *tflint.Config) []Rule {
 		}
 	}
 	log.Printf("[INFO]   %d rules enabled", len(ret))
-	return ret
+	return ret, nil
 }

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -15,8 +15,8 @@ type Rule interface {
 	Check(runner *tflint.Runner) error
 }
 
-// defaultRules is rules by default
-var defaultRules = append(manualDefaultRules, modelRules...)
+// DefaultRules is rules by default
+var DefaultRules = append(manualDefaultRules, modelRules...)
 var deepCheckRules = append(manualDeepCheckRules, apiRules...)
 
 var manualDefaultRules = []Rule{
@@ -46,7 +46,7 @@ var manualDeepCheckRules = []Rule{
 // AllRules returns map of rules indexed by name
 func AllRulesMap() map[string]Rule {
 	ret := map[string]Rule{}
-	for _, rule := range append(defaultRules, deepCheckRules...) {
+	for _, rule := range append(DefaultRules, deepCheckRules...) {
 		ret[rule.Name()] = rule
 	}
 	return ret
@@ -75,9 +75,9 @@ func NewRules(c *tflint.Config) []Rule {
 
 	if c.DeepCheck {
 		log.Printf("[DEBUG] Deep check mode is enabled. Add deep check rules")
-		allRules = append(defaultRules, deepCheckRules...)
+		allRules = append(DefaultRules, deepCheckRules...)
 	} else {
-		allRules = defaultRules
+		allRules = DefaultRules
 	}
 
 	for _, rule := range allRules {

--- a/rules/provider_test.go
+++ b/rules/provider_test.go
@@ -69,7 +69,7 @@ func Test_NewRules(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		ret := NewRules(tc.Config)
+		ret, _ := NewRules(tc.Config)
 		if !reflect.DeepEqual(tc.Expected, ret) {
 			t.Fatalf("Failed `%s` test: expected rules are `%#v`, but get `%#v`", tc.Name, tc.Expected, ret)
 		}


### PR DESCRIPTION
This adds INFO level stats about total amount of rules and enabled
rules, makes `defaultRules` private, because they are not accessed
from anywhere. It also shows ERROR level message for invalid name
specified for --enable-rule or --disable-rule options.

The missing thing is to stop processing and with the error at this
point.

Fixes #470.