### PR TITLE
Check invalid rule names in command line options (fixes #470)

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -158,6 +158,16 @@ func (cli *CLI) Run(args []string) int {
 	}
 	runners = append(runners, runner)
 
+	var ruleNames []string
+	for name := range cfg.Rules {
+		ruleNames = append(ruleNames, name)
+	}
+	err = rules.CheckRuleNames(ruleNames)
+	if err != nil {
+		formatter.Print(tflint.Issues{}, tflint.NewContextError("Failed to check rule config", err), cli.loader.Sources())
+		return ExitCodeError
+	}
+
 	for _, rule := range rules.NewRules(cfg) {
 		for _, runner := range runners {
 			err := rule.Check(runner)

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -106,6 +106,12 @@ func TestCLIRun__noIssuesFound(t *testing.T) {
 			Status:  ExitCodeError,
 			Stderr:  "Invalid value `awesome' for option",
 		},
+		{
+			Name:    "invalid rule name",
+			Command: "./tflint --enable-rule nosuchrule",
+			Status:  ExitCodeError,
+			Stderr:  "Rule not found: nosuchrule",
+		},
 	}
 
 	ctrl := gomock.NewController(t)

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -25,6 +25,15 @@ func NewHandler(configPath string, cliConfig *tflint.Config) (jsonrpc2.Handler, 
 	}
 	cfg = cfg.Merge(cliConfig)
 
+	var ruleNames []string
+	for name := range cfg.Rules {
+		ruleNames = append(ruleNames, name)
+	}
+	err = rules.CheckRuleNames(ruleNames)
+	if err != nil {
+		return nil, err
+	}
+
 	return jsonrpc2.HandlerWithError((&handler{
 		configPath: configPath,
 		cliConfig:  cliConfig,

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/wata727/tflint/rules/awsrules"
@@ -43,6 +44,30 @@ var manualDeepCheckRules = []Rule{
 	awsrules.NewAwsLaunchConfigurationInvalidImageIDRule(),
 }
 
+// CheckRuleNames returns map of rules indexed by name
+func CheckRuleNames(ruleNames []string) error {
+	log.Print("[INFO] Checking rules")
+
+	rulesMap := map[string]Rule{}
+	for _, rule := range append(DefaultRules, deepCheckRules...) {
+		rulesMap[rule.Name()] = rule
+	}
+
+	totalEnabled := 0
+	for _, rule := range rulesMap {
+		if rule.Enabled() {
+			totalEnabled++
+		}
+	}
+	log.Printf("[INFO]   %d (%d) rules total", len(rulesMap), totalEnabled)
+	for _, rule := range ruleNames {
+		if _, ok := rulesMap[rule]; !ok {
+			return fmt.Errorf("Rule not found: %s", rule)
+		}
+	}
+	return nil
+}
+
 // NewRules returns rules according to configuration
 func NewRules(c *tflint.Config) []Rule {
 	log.Print("[INFO] Prepare rules")
@@ -72,6 +97,6 @@ func NewRules(c *tflint.Config) []Rule {
 			ret = append(ret, rule)
 		}
 	}
-
+	log.Printf("[INFO]   %d rules enabled", len(ret))
 	return ret
 }

--- a/rules/provider_test.go
+++ b/rules/provider_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
@@ -8,6 +9,44 @@ import (
 	"github.com/wata727/tflint/rules/terraformrules"
 	"github.com/wata727/tflint/tflint"
 )
+
+func Test_CheckRuleNames(t *testing.T) {
+	// Mock rules in test
+	DefaultRules = []Rule{
+		awsrules.NewAwsRouteNotSpecifiedTargetRule(),
+		terraformrules.NewTerraformDashInResourceNameRule(),
+	}
+	deepCheckRules = []Rule{
+		awsrules.NewAwsInstanceInvalidAMIRule(),
+	}
+
+	cases := []struct {
+		Name     string
+		Rules    []string
+		Expected error
+	}{
+		{
+			Name:     "no error",
+			Rules:    []string{"aws_route_not_specified_target"},
+			Expected: nil,
+		},
+		{
+			Name: "invalid rule name",
+			Rules: []string{
+				"aws_route_not_specified_target",
+				"invalid_not_exist",
+			},
+			Expected: errors.New("Rule not found: invalid_not_exist"),
+		},
+	}
+
+	for _, tc := range cases {
+		err := CheckRuleNames(tc.Rules)
+		if !reflect.DeepEqual(tc.Expected, err) {
+			t.Fatalf("Failed `%s` test: expected `%#v`, but got `%#v`", tc.Name, tc.Expected, err)
+		}
+	}
+}
 
 func Test_NewRules(t *testing.T) {
 	// Mock rules in test
@@ -71,7 +110,7 @@ func Test_NewRules(t *testing.T) {
 	for _, tc := range cases {
 		ret := NewRules(tc.Config)
 		if !reflect.DeepEqual(tc.Expected, ret) {
-			t.Fatalf("Failed `%s` test: expected rules are `%#v`, but get `%#v`", tc.Name, tc.Expected, ret)
+			t.Fatalf("Failed `%s` test: expected rules are `%#v`, but got `%#v`", tc.Name, tc.Expected, ret)
 		}
 	}
 }


### PR DESCRIPTION
Exit with an error when --enable-rule name is not found.

Also adds INFO level stats about total amount of rules and enabled rules.